### PR TITLE
Publish CLI to Homebrew tap + Scoop bucket; purge bogus `cargo install basilisk`

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"8ea1a631-0624-4f98-85fa-456dd9a04ba6","pid":2805,"procStart":"Mon May 11 08:11:47 2026","acquiredAt":1778490596007}
+{"sessionId":"626733df-9e69-4d50-822c-6002f2dfc7fc","pid":79232,"procStart":"Mon May 25 07:31:40 2026","acquiredAt":1779698121951}

--- a/.github/release-templates/basilisk.json.tmpl
+++ b/.github/release-templates/basilisk.json.tmpl
@@ -1,0 +1,30 @@
+{
+  "version": "${BASILISK_VERSION}",
+  "description": "Strict-by-default Python type checker and LSP, built in Rust",
+  "homepage": "https://www.basilisk-python.dev",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "${BASILISK_BASE_URL}/basilisk-x86_64-pc-windows-msvc.zip",
+      "hash": "${BASILISK_SHA_WIN_X64}"
+    },
+    "arm64": {
+      "url": "${BASILISK_BASE_URL}/basilisk-aarch64-pc-windows-msvc.zip",
+      "hash": "${BASILISK_SHA_WIN_ARM64}"
+    }
+  },
+  "bin": "basilisk.exe",
+  "checkver": {
+    "github": "https://github.com/Nimblesite/Basilisk"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/Nimblesite/Basilisk/releases/download/v$version/basilisk-x86_64-pc-windows-msvc.zip"
+      },
+      "arm64": {
+        "url": "https://github.com/Nimblesite/Basilisk/releases/download/v$version/basilisk-aarch64-pc-windows-msvc.zip"
+      }
+    }
+  }
+}

--- a/.github/release-templates/basilisk.rb.tmpl
+++ b/.github/release-templates/basilisk.rb.tmpl
@@ -1,0 +1,35 @@
+# typed: false
+# frozen_string_literal: true
+
+class Basilisk < Formula
+  desc "Strict-by-default Python type checker and LSP, built in Rust"
+  homepage "https://www.basilisk-python.dev"
+  version "${BASILISK_VERSION}"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "${BASILISK_BASE_URL}/basilisk-aarch64-apple-darwin.zip"
+      sha256 "${BASILISK_SHA_DARWIN_ARM64}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "${BASILISK_BASE_URL}/basilisk-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "${BASILISK_SHA_LINUX_X86_64}"
+    end
+    on_arm do
+      url "${BASILISK_BASE_URL}/basilisk-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "${BASILISK_SHA_LINUX_AARCH64}"
+    end
+  end
+
+  def install
+    bin.install "basilisk"
+  end
+
+  test do
+    assert_match "basilisk", shell_output("#{bin}/basilisk --version")
+  end
+end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,3 +407,107 @@ jobs:
             artifacts/*.zip
             artifacts/*.vsix
             artifacts/checksums-sha256.txt
+
+  publish-homebrew:
+    name: Publish Homebrew formula
+    needs: github-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Render formula and push to tap
+        env:
+          BREW_SCOOP_PAT: ${{ secrets.BREW_SCOOP_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BREW_SCOOP_PAT:-}" ]; then
+            echo "::error::BREW_SCOOP_PAT not accessible. The Nimblesite org secret exists; ensure Basilisk is in its allowed repositories (Org Settings → Secrets and variables → Actions → BREW_SCOOP_PAT → Repository access)."
+            exit 1
+          fi
+
+          export BASILISK_VERSION="${GITHUB_REF_NAME#v}"
+          export BASILISK_BASE_URL="https://github.com/Nimblesite/Basilisk/releases/download/${GITHUB_REF_NAME}"
+          export BASILISK_SHA_DARWIN_ARM64="$(sha256sum artifacts/basilisk-aarch64-apple-darwin.zip | awk '{print $1}')"
+          export BASILISK_SHA_LINUX_X86_64="$(sha256sum artifacts/basilisk-x86_64-unknown-linux-gnu.tar.gz | awk '{print $1}')"
+          export BASILISK_SHA_LINUX_AARCH64="$(sha256sum artifacts/basilisk-aarch64-unknown-linux-gnu.tar.gz | awk '{print $1}')"
+
+          git clone "https://x-access-token:${BREW_SCOOP_PAT}@github.com/Nimblesite/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+
+          # envsubst with an explicit variable list — leaves Ruby's #{...}
+          # interpolation untouched and only substitutes BASILISK_*.
+          envsubst '${BASILISK_VERSION} ${BASILISK_BASE_URL} ${BASILISK_SHA_DARWIN_ARM64} ${BASILISK_SHA_LINUX_X86_64} ${BASILISK_SHA_LINUX_AARCH64}' \
+            < .github/release-templates/basilisk.rb.tmpl \
+            > tap/Formula/basilisk.rb
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/basilisk.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date for ${BASILISK_VERSION}"
+            exit 0
+          fi
+          git commit -m "basilisk ${BASILISK_VERSION}"
+          git push
+
+  publish-scoop:
+    name: Publish Scoop manifest
+    needs: github-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download release archives
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Render manifest and push to bucket
+        env:
+          BREW_SCOOP_PAT: ${{ secrets.BREW_SCOOP_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BREW_SCOOP_PAT:-}" ]; then
+            echo "::error::BREW_SCOOP_PAT not accessible. The Nimblesite org secret exists; ensure Basilisk is in its allowed repositories (Org Settings → Secrets and variables → Actions → BREW_SCOOP_PAT → Repository access)."
+            exit 1
+          fi
+
+          export BASILISK_VERSION="${GITHUB_REF_NAME#v}"
+          export BASILISK_BASE_URL="https://github.com/Nimblesite/Basilisk/releases/download/${GITHUB_REF_NAME}"
+          export BASILISK_SHA_WIN_X64="$(sha256sum artifacts/basilisk-x86_64-pc-windows-msvc.zip | awk '{print $1}')"
+          export BASILISK_SHA_WIN_ARM64="$(sha256sum artifacts/basilisk-aarch64-pc-windows-msvc.zip | awk '{print $1}')"
+
+          git clone "https://x-access-token:${BREW_SCOOP_PAT}@github.com/Nimblesite/scoop-bucket.git" bucket
+          mkdir -p bucket/bucket
+
+          # envsubst with an explicit variable list — leaves Scoop's $version
+          # autoupdate placeholder untouched and only substitutes BASILISK_*.
+          envsubst '${BASILISK_VERSION} ${BASILISK_BASE_URL} ${BASILISK_SHA_WIN_X64} ${BASILISK_SHA_WIN_ARM64}' \
+            < .github/release-templates/basilisk.json.tmpl \
+            > bucket/bucket/basilisk.json
+
+          # Sanity check: parse JSON to catch any template/substitution damage.
+          python3 -m json.tool bucket/bucket/basilisk.json > /dev/null
+
+          cd bucket
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add bucket/basilisk.json
+          if git diff --cached --quiet; then
+            echo "Manifest already up to date for ${BASILISK_VERSION}"
+            exit 0
+          fi
+          git commit -m "basilisk ${BASILISK_VERSION}"
+          git push

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -190,13 +190,27 @@ All rules are **on by default**. There is no way to relax them globally.
 
 ## Requirements
 
-Install the Basilisk binary:
+None — the Basilisk binary is bundled with this extension for macOS (Apple Silicon), Linux (x86_64 and aarch64), and Windows (x86_64 and aarch64). Install the extension and go.
 
-```sh
-cargo install basilisk
+### Installing the CLI separately
+
+If you also want the `basilisk` CLI on your PATH (for CI, scripting, or terminal use), install it with your platform's package manager:
+
+```bash
+# macOS, Linux
+brew tap Nimblesite/tap
+brew install basilisk
 ```
 
-Rust 1.87+ required for building from source.
+```powershell
+# Windows
+scoop bucket add nimblesite https://github.com/Nimblesite/scoop-bucket
+scoop install basilisk
+```
+
+Or download a pre-built binary from [GitHub Releases](https://github.com/Nimblesite/Basilisk/releases).
+
+To make this extension use a CLI you installed separately, set `basilisk.executablePath` or `basilisk.binaries.basilisk` to the absolute path of the binary. Building from source also works (`cargo build --release` from the repository — Rust 1.87+ required).
 
 ---
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -675,10 +675,10 @@
         "steps": [
           {
             "id": "basilisk.installBinary",
-            "title": "Install Basilisk Binary",
-            "description": "Install via cargo: `cargo install basilisk` or download from GitHub releases.\n[Open Terminal](command:workbench.action.terminal.new)",
+            "title": "Basilisk Binary",
+            "description": "The Basilisk binary is bundled with this extension — no separate install required. To override, set `basilisk.executablePath` or download from GitHub releases.\n[Open Releases](https://github.com/Nimblesite/Basilisk/releases)",
             "media": {
-              "markdown": "Install via `cargo install basilisk`."
+              "markdown": "The Basilisk binary ships with this extension. No `cargo install` needed."
             }
           },
           {

--- a/website/src/docs/installation.md
+++ b/website/src/docs/installation.md
@@ -1,8 +1,8 @@
 ---
 layout: layouts/docs.njk
 title: "Install Basilisk — VS Code, Neovim, Zed, or CLI"
-description: "Install the Basilisk Python language server via VS Code Marketplace, pre-built binaries, cargo install, or build from source. Supports macOS, Linux, and Windows."
-keywords: basilisk, install, cargo, rust, python type checker, vs code, zed
+description: "Install the Basilisk Python language server via VS Code Marketplace, Homebrew, Scoop, pre-built binaries, or build from source. Supports macOS, Linux, and Windows."
+keywords: basilisk, install, homebrew, scoop, rust, python type checker, vs code, zed
 date: 2026-02-28
 dateModified: 2026-03-31
 author: The Basilisk Project
@@ -42,21 +42,39 @@ cargo build --release
 
 Use `basilisk.executablePath`, `basilisk.binaries.basilisk`, or `basilisk.binaries.path` only when you intentionally want to override the bundled VSIX binary.
 
+## Homebrew (macOS, Linux)
+
+```bash
+brew tap Nimblesite/tap
+brew install basilisk
+```
+
+This installs the latest released `basilisk` binary on macOS (Apple Silicon) and Linux (x86_64, aarch64). Upgrade with `brew upgrade basilisk`.
+
+## Scoop (Windows)
+
+```powershell
+scoop bucket add nimblesite https://github.com/Nimblesite/scoop-bucket
+scoop install basilisk
+```
+
+This installs the latest released `basilisk.exe` on Windows (x86_64 and arm64). Upgrade with `scoop update basilisk`.
+
 ## Pre-built binaries
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/Nimblesite/Basilisk/releases):
 
 ```bash
 # macOS (Apple Silicon)
-curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-darwin-aarch64.tar.gz | tar xz
-sudo mv basilisk /usr/local/bin/
-
-# macOS (Intel)
-curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-darwin-x86_64.tar.gz | tar xz
-sudo mv basilisk /usr/local/bin/
+curl -sSfL -o basilisk.zip https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-aarch64-apple-darwin.zip
+unzip basilisk.zip && sudo mv basilisk /usr/local/bin/
 
 # Linux (x86_64)
-curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-linux-x86_64.tar.gz | tar xz
+curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-x86_64-unknown-linux-gnu.tar.gz | tar xz
+sudo mv basilisk /usr/local/bin/
+
+# Linux (aarch64)
+curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-aarch64-unknown-linux-gnu.tar.gz | tar xz
 sudo mv basilisk /usr/local/bin/
 ```
 
@@ -65,16 +83,6 @@ Verify the installation:
 ```bash
 basilisk --version
 ```
-
-## Install via Cargo
-
-If you have Rust installed:
-
-```bash
-cargo install basilisk
-```
-
-This installs the binary to `~/.cargo/bin/`, which is typically already on your PATH if you installed Rust via rustup.
 
 ## Build from source
 
@@ -102,7 +110,7 @@ Basilisk integrates naturally into any CI pipeline. Download the binary in your 
 # GitHub Actions example
 - name: Install Basilisk
   run: |
-    curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-linux-x86_64.tar.gz | tar xz
+    curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-x86_64-unknown-linux-gnu.tar.gz | tar xz
     sudo mv basilisk /usr/local/bin/
 
 - name: Type check

--- a/website/src/docs/quick-start.md
+++ b/website/src/docs/quick-start.md
@@ -165,8 +165,24 @@ basilisk stats src/
 
 Output includes: total functions, typed functions, type coverage percentage, files with no annotations.
 
+## Step 8 — Profile a running script
+
+Basilisk includes an integrated CPU and memory profiler. To try it in VS Code:
+
+1. Run any Python script (the process must be alive)
+2. Open the Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) — or use the shortcut `Cmd+Shift+P Cmd+Shift+S` / `Ctrl+Shift+P Ctrl+Shift+S`
+3. Run **Basilisk: Start Profiling** and pick the target process
+4. Watch inline CPU heat annotations appear on hot lines as samples accumulate
+5. Run **Basilisk: Stop Profiling** to open the flamegraph viewer
+
+For memory leak hunting, use **Basilisk: Start Memory Tracking**, take two snapshots with **Basilisk: Take Memory Snapshot**, then **Basilisk: Diff Memory Snapshots** to surface leaks as diagnostics in the Problems panel.
+
+See the [Profiler guide](/docs/profiler/) for the full workflow — flamegraphs, reference graphs, profile diffing, Zed and Neovim commands, and platform requirements.
+
 ## Next steps
 
 - [Configuration reference](/docs/configuration/) — full `pyproject.toml` schema
+- [Profiler](/docs/profiler/) — CPU heatmaps, flamegraphs, and memory leak detection
+- [Debugging](/docs/debugging/) — F5 to debug, breakpoints, stepping, watch expressions
 - [All rules](/docs/rules/) — every BSK-E and BSK-W code explained
 - [Migration guide](/docs/migration/) — migrating from Pyright or mypy

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -35,11 +35,10 @@ permalink: /
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
             Get Started
           </a>
-          <button class="btn btn--mono" data-copy="cargo install basilisk" title="Copy install command">
-            <span class="copy-text">cargo install basilisk</span>
-            <svg class="copy-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
-            <svg class="copy-check" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="display:none;color:var(--color-success)"><polyline points="20 6 9 17 4 12"/></svg>
-          </button>
+          <a href="https://marketplace.visualstudio.com/items?itemName=Nimblesite.basilisk" class="btn btn--mono" target="_blank" rel="noopener">
+            <span>Install for VS Code</span>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12l7 7 7-7"/></svg>
+          </a>
           <a href="https://github.com/MelbourneDeveloper/Basilisk" class="btn btn--secondary" target="_blank" rel="noopener">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.741 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
             GitHub

--- a/website/src/zh/docs/installation.md
+++ b/website/src/zh/docs/installation.md
@@ -1,8 +1,8 @@
 ---
 layout: layouts/docs.njk
 title: 安装
-description: 如何安装 Basilisk——预构建二进制文件、VS Code 扩展、Zed 扩展或从源代码构建。
-keywords: basilisk, 安装, cargo, rust, python类型检查器, vs code, zed
+description: 如何安装 Basilisk——通过 Homebrew、Scoop、预构建二进制文件、VS Code 扩展、Zed 扩展或从源代码构建。
+keywords: basilisk, 安装, homebrew, scoop, rust, python类型检查器, vs code, zed
 lang: zh
 ---
 
@@ -37,21 +37,39 @@ cargo build --release
 
 仅当您明确想覆盖 VSIX 中捆绑的二进制文件时，才需要设置 `basilisk.executablePath`、`basilisk.binaries.basilisk` 或 `basilisk.binaries.path`。
 
+## Homebrew (macOS、Linux)
+
+```bash
+brew tap Nimblesite/tap
+brew install basilisk
+```
+
+在 macOS (Apple Silicon) 和 Linux (x86_64、aarch64) 上安装最新发布的 `basilisk` 二进制文件。使用 `brew upgrade basilisk` 升级。
+
+## Scoop (Windows)
+
+```powershell
+scoop bucket add nimblesite https://github.com/Nimblesite/scoop-bucket
+scoop install basilisk
+```
+
+在 Windows (x86_64 和 arm64) 上安装最新发布的 `basilisk.exe`。使用 `scoop update basilisk` 升级。
+
 ## 预构建二进制文件
 
 从 [GitHub Releases](https://github.com/Nimblesite/Basilisk/releases) 下载适合您平台的最新版本：
 
 ```bash
 # macOS (Apple Silicon)
-curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-darwin-aarch64.tar.gz | tar xz
-sudo mv basilisk /usr/local/bin/
-
-# macOS (Intel)
-curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-darwin-x86_64.tar.gz | tar xz
-sudo mv basilisk /usr/local/bin/
+curl -sSfL -o basilisk.zip https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-aarch64-apple-darwin.zip
+unzip basilisk.zip && sudo mv basilisk /usr/local/bin/
 
 # Linux (x86_64)
-curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-linux-x86_64.tar.gz | tar xz
+curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-x86_64-unknown-linux-gnu.tar.gz | tar xz
+sudo mv basilisk /usr/local/bin/
+
+# Linux (aarch64)
+curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-aarch64-unknown-linux-gnu.tar.gz | tar xz
 sudo mv basilisk /usr/local/bin/
 ```
 
@@ -60,16 +78,6 @@ sudo mv basilisk /usr/local/bin/
 ```bash
 basilisk --version
 ```
-
-## 通过 Cargo 安装
-
-如果您已安装 Rust：
-
-```bash
-cargo install basilisk
-```
-
-这会将二进制文件安装到 `~/.cargo/bin/`，如果您通过 rustup 安装了 Rust，它通常已经在您的 PATH 中。
 
 ## 从源代码构建
 
@@ -97,7 +105,7 @@ Basilisk 自然地集成到任何 CI 管道中。在您的工作流程中下载�
 # GitHub Actions 示例
 - name: 安装 Basilisk
   run: |
-    curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-linux-x86_64.tar.gz | tar xz
+    curl -sSfL https://github.com/Nimblesite/Basilisk/releases/latest/download/basilisk-x86_64-unknown-linux-gnu.tar.gz | tar xz
     sudo mv basilisk /usr/local/bin/
 
 - name: 类型检查

--- a/website/src/zh/docs/profiler.md
+++ b/website/src/zh/docs/profiler.md
@@ -1,6 +1,6 @@
 ---
 layout: layouts/docs.njk
-title: 性能分析器
+title: "Python 性能分析器——CPU 热图与内存泄漏检测"
 description: Basilisk 集成的 Python 性能分析——CPU 热图、火焰图、内存泄漏检测和引用图可视化，全部在您的编辑器内。
 keywords: basilisk, 性能分析, python, py-spy, 火焰图, 热图, 内存泄漏, tracemalloc, cpu分析器, vs code, zed, neovim
 lang: zh
@@ -31,6 +31,8 @@ Basilisk 性能分析器结合了两个互补的引擎：
 2. 打开命令面板（`Cmd+Shift+P` / `Ctrl+Shift+P`）
 3. 运行 **Basilisk: Start Profiling**
 4. 从列表中选择目标进程
+
+键盘快捷键：`Cmd+Shift+P Cmd+Shift+S`（macOS）/ `Ctrl+Shift+P Ctrl+Shift+S`（Windows/Linux）。
 
 **Zed：**
 
@@ -63,7 +65,7 @@ Basilisk 性能分析器结合了两个互补的引擎：
 
 在会话运行时捕获时间点配置文件：
 
-- **VS Code：** 命令面板 → **Basilisk: Snapshot Profile**
+- **VS Code：** 命令面板 → **Basilisk: Take Profile Snapshot**
 - **Zed：** `/profsnapshot`
 - **Neovim：** `:BasiliskProfileSnapshot`
 
@@ -71,7 +73,7 @@ Basilisk 性能分析器结合了两个互补的引擎：
 
 ### 停止分析
 
-- **VS Code：** 命令面板 → **Basilisk: Stop Profiling**（或单击状态栏项）
+- **VS Code：** 命令面板 → **Basilisk: Stop Profiling**（或单击状态栏项）。快捷键：`Cmd+Shift+P Cmd+Shift+X` / `Ctrl+Shift+P Ctrl+Shift+X`
 - **Zed：** `/profstop`
 - **Neovim：** `:BasiliskProfileStop`
 
@@ -85,6 +87,25 @@ Basilisk 性能分析器结合了两个互补的引擎：
 - **交互式火焰图** — 单击帧缩放进入；单击面包屑缩放退出
 - **顶部函数表** — 按 CPU 时间排序，带有导航到源代码的文件/行链接
 - **导出** — 下载原始 Speedscope JSON 进行外部分析
+
+### 附加到调试会话
+
+您可以分析已经在 Basilisk 调试器下运行的程序：
+
+- **VS Code：** 命令面板 → **Basilisk: Profile Debug Session**
+
+这会将 py-spy 附加到由 debugpy 管理的进程，因此您可以同时设置断点并查看分析数据。
+
+### 配置文件比较（差异）
+
+要比较两个分析会话：
+
+1. 拍摄会话 A 的快照（保存为基线）
+2. 进行您的更改
+3. 拍摄会话 B 的快照
+4. 运行 **Basilisk: Compare Profile Results** 并选择两个快照
+
+差异视图突出显示在两个会话之间变快（绿色）或变慢（红色）的函数。
 
 ---
 
@@ -141,6 +162,29 @@ Basilisk 比较快照并在未释放内存的行上发出 LSP 诊断。诊断使
 
 单击任何节点以检查其类型、`repr()`、大小和传出引用。
 
+### 内存时间轴
+
+内存仪表板将分配增长显示为按对象类型堆叠的面积图。
+
+### 停止内存跟踪
+
+- **VS Code：** 命令面板 → **Basilisk: Stop Memory Tracking**
+- **Zed：** `/memstop`
+- **Neovim：** `:BasiliskMemoryStop`
+
+---
+
+## 内存仪表板
+
+内存仪表板将所有内存分析视图汇总到一个面板中：
+
+| 面板 | 描述 |
+|-------|-------------|
+| **时间轴** | 会话期间堆增长，按对象类型堆叠 |
+| **顶部分配器** | 负责最多活动分配的函数 |
+| **泄漏候选** | 带有置信度评分和分配调用栈的排序列表 |
+| **引用图** | 选定泄漏候选的力向对象图 |
+
 ---
 
 ## 分析预设
@@ -153,6 +197,13 @@ Basilisk 提供四个分析预设，在覆盖率和开销之间进行权衡：
 | `lightweight` | 25 Hz | 否 | 否 | <0.5% |
 | `detailed` | 200 Hz | 是 | 否 | ~3% |
 | `memory` | 50 Hz | 否 | 是 | ~2% |
+
+从 Basilisk 设置面板中选择预设或在 `pyproject.toml` 中设置：
+
+```toml
+[tool.basilisk.profiler]
+preset = "detailed"
+```
 
 ---
 
@@ -170,6 +221,64 @@ function-threshold = 2.0   # 在表中显示函数的最小 %
 output-directory = "basilisk-profiles"
 ```
 
+| 设置 | 类型 | 默认值 | 描述 |
+|---------|------|---------|-------------|
+| `enabled` | bool | `true` | 启用分析器功能 |
+| `sample-rate` | int | `100` | 采样频率（Hz） |
+| `include-native` | bool | `false` | 包含 C 扩展和 Rust 帧 |
+| `line-threshold` | float | `1.0` | 行注解的最小 CPU % |
+| `function-threshold` | float | `2.0` | 表条目的最小 CPU % |
+| `output-directory` | string | `"basilisk-profiles"` | 快照保存位置 |
+
+VS Code 设置在 `basilisk.profiler.*` 下镜像这些：
+
+```json
+{
+  "basilisk.profiler.sampleRate": 100,
+  "basilisk.profiler.includeNative": false,
+  "basilisk.profiler.lineThreshold": 1.0
+}
+```
+
+---
+
+## 平台要求
+
+### macOS
+
+py-spy 需要读取其他进程内存的能力。在 macOS 上，这需要对您不拥有的进程提升权限。
+
+Basilisk 附带一个特权辅助二进制文件（`basilisk-profiler-helper`），可透明地处理此问题。第一次分析进程时，macOS 将通过标准系统对话框提示您输入管理员密码。该辅助程序经过代码签名，仅运行所需的特定操作。
+
+要分析您自己的进程（例如从 Basilisk 启动的脚本），无需提升权限。
+
+### Linux
+
+在 Linux 上，`ptrace` 访问由 `/proc/sys/kernel/yama/ptrace_scope` 管理：
+
+| 范围 | 含义 | Basilisk 行为 |
+|-------|---------|-------------------|
+| `0` | 所有进程 | 无需提升 |
+| `1`（许多发行版的默认值） | 仅父/子 | Basilisk 启动子 shim |
+| `2` | 仅管理员 | 需要 `sudo` |
+| `3` | 禁用 | 分析不可用 |
+
+如果您在 Linux 上看到权限错误，请检查：
+
+```bash
+cat /proc/sys/kernel/yama/ptrace_scope
+```
+
+临时允许分析：
+
+```bash
+sudo sysctl kernel.yama.ptrace_scope=0
+```
+
+### Windows
+
+Windows 上无需提升权限。分析器使用任何进程所有者可用的标准 Win32 API 进行连接。
+
 ---
 
 ## 诊断代码
@@ -180,6 +289,123 @@ output-directory = "basilisk-profiles"
 | `BSK-PROF-FUNC` | 警告 | 函数花费 ≥ `function-threshold`% 的 CPU 时间 |
 | `BSK-PROF-GIL` | 警告 | 线程在 GIL 上阻塞 ≥ 20% 的时间 |
 | `BSK-PROF-MEM` | 警告 | 在快照之间未释放的内存分配 |
+
+这些诊断与类型错误一起出现在问题面板中。在没有活动分析会话时，它们会被抑制。
+
+---
+
+## 在 Zed 中分析
+
+Zed 扩展通过 AI 助手面板中的斜杠命令呈现分析。Zed 中没有 webview；相反，火焰图数据导出到 `basilisk-profiles/` 目录，诊断在编辑器中内联显示。
+
+| 命令 | 操作 |
+|---------|--------|
+| `/profile` | 开始 CPU 分析 |
+| `/profstop` | 停止 CPU 分析 |
+| `/profsnapshot` | 拍摄 CPU 快照 |
+| `/memleak` | 开始内存跟踪 |
+| `/memstop` | 停止内存跟踪 |
+| `/memrefs` | 显示顶部泄漏的引用图 |
+
+---
+
+## 在 Neovim 中分析
+
+Neovim 插件通过用户命令公开分析：
+
+| 命令 | 操作 |
+|---------|--------|
+| `:BasiliskProfileStart` | 开始 CPU 分析 |
+| `:BasiliskProfileStop` | 停止 CPU 分析 |
+| `:BasiliskProfileSnapshot` | 拍摄 CPU 快照 |
+| `:BasiliskMemoryStart` | 开始内存跟踪 |
+| `:BasiliskMemoryStop` | 停止内存跟踪 |
+
+内联热图注解作为虚拟文本出现在符号列中。
+
+---
+
+## 架构
+
+```
+┌──────────────┐    LSP (JSON-RPC)    ┌──────────────────────────────┐
+│  VS Code /   │◄────────────────────►│  Basilisk LSP (Rust)         │
+│  Zed / Nvim  │                      │  ┌──────────────────────────┐ │
+└──────────────┘                      │  │  ProfileSessionManager   │ │
+                                      │  │  采样器线程 (py-spy)      │ │
+                                      │  │  SampleAggregator        │ │
+                                      │  │  SpeedscopeExporter      │ │
+                                      │  │  MemorySessionManager    │ │
+                                      │  │  SnapshotDiffer          │ │
+                                      │  │  ReferenceGraphWalker    │ │
+                                      │  └──────────────────────────┘ │
+                                      └──────────────┬───────────────┘
+                                                     │ 附加到
+                                                     ▼
+                                         ┌──────────────────┐
+                                         │  Python 进程      │
+                                         │  （您的代码）       │
+                                         └──────────────────┘
+```
+
+LSP 服务器拥有所有分析状态。编辑器扩展是纯 UI——它们发送命令并渲染 LSP 通过通知发送回的内容。这意味着分析在 VS Code、Zed 和 Neovim 中以相同方式工作。
+
+---
+
+## 性能目标
+
+分析器默认设计为低开销：
+
+| 操作 | 目标 |
+|-----------|--------|
+| 采样开销 | < 3% CPU |
+| 10 分钟会话的 LSP 内存 | < 50 MB |
+| 诊断生成 | < 100 ms |
+| Speedscope 导出 | < 200 ms |
+| 火焰图 SVG 渲染 | < 500 ms |
+
+---
+
+## 故障排除
+
+### "Process not found"
+
+目标进程在分析器可以连接之前退出。请确保在开始分析会话之前您的脚本仍在运行。
+
+### "Not a Python process"
+
+py-spy 仅适用于 CPython。不支持 PyPy 和其他解释器。
+
+### "Permission denied"（macOS）
+
+单击出现的系统对话框上的**允许**，或使用管理员权限运行 VS Code/Zed。请参阅[平台要求](#平台要求)。
+
+### "Permission denied"（Linux）
+
+检查 `ptrace_scope` — 请参阅上面的 [Linux 部分](#linux)。
+
+### "Already profiling"
+
+一次只能运行一个 CPU 分析会话。请先停止当前会话。
+
+### 快照未出现
+
+确保 `output-directory` 可写。默认情况下，这是相对于您工作区根目录的 `basilisk-profiles/`。
+
+---
+
+## 与其他分析器的比较
+
+| 功能 | Basilisk | cProfile | Scalene | Memray | Austin |
+|---------|----------|---------|---------|--------|--------|
+| 零代码更改 | 是 | 否 | 否 | 否 | 是 |
+| 内联编辑器注解 | 是 | 否 | 否 | 否 | 否 |
+| 内存泄漏检测 | 是 | 否 | 是 | 是 | 否 |
+| 引用图 | 是 | 否 | 否 | 否 | 否 |
+| IDE 集成（原生） | 是 | 否 | 否 | 否 | 否 |
+| 火焰图查看器 | 是 | 否 | 是 | 是 | 否 |
+| 附加时分析 | 是 | 否 | 否 | 否 | 是 |
+| GIL 争用 | 是 | 否 | 是 | 否 | 是 |
 
 ---
 

--- a/website/src/zh/docs/quick-start.md
+++ b/website/src/zh/docs/quick-start.md
@@ -160,8 +160,24 @@ basilisk stats src/
 
 输出包括：总函数数、已类型化的函数数、类型覆盖率百分比、无注解的文件。
 
+## 第 8 步——分析运行中的脚本
+
+Basilisk 包含一个集成的 CPU 和内存性能分析器。要在 VS Code 中试用：
+
+1. 运行任何 Python 脚本（进程必须处于活动状态）
+2. 打开命令面板（`Cmd+Shift+P` / `Ctrl+Shift+P`）——或使用快捷键 `Cmd+Shift+P Cmd+Shift+S` / `Ctrl+Shift+P Ctrl+Shift+S`
+3. 运行 **Basilisk: Start Profiling** 并选择目标进程
+4. 随着采样的积累，观察内联 CPU 热注解出现在热行上
+5. 运行 **Basilisk: Stop Profiling** 以打开火焰图查看器
+
+对于内存泄漏检测，使用 **Basilisk: Start Memory Tracking**，通过 **Basilisk: Take Memory Snapshot** 拍摄两个快照，然后 **Basilisk: Diff Memory Snapshots** 在问题面板中将泄漏显示为诊断。
+
+请参阅[性能分析器指南](/zh/docs/profiler/)了解完整的工作流程——火焰图、引用图、配置文件差异、Zed 和 Neovim 命令以及平台要求。
+
 ## 下一步
 
 - [配置参考](/zh/docs/configuration/) — 完整的 `pyproject.toml` 模式
+- [性能分析器](/zh/docs/profiler/) — CPU 热图、火焰图和内存泄漏检测
+- [调试](/zh/docs/debugging/) — F5 调试，断点，单步执行，监视表达式
 - [所有规则](/zh/docs/rules/) — 每个 BSK-E 和 BSK-W 代码的解释
 - [迁移指南](/zh/docs/migration/) — 从 Pyright 或 mypy 迁移

--- a/website/src/zh/index.njk
+++ b/website/src/zh/index.njk
@@ -35,11 +35,10 @@ permalink: /zh/
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
             立即开始
           </a>
-          <button class="btn btn--mono" data-copy="cargo install basilisk" title="复制安装命令">
-            <span class="copy-text">cargo install basilisk</span>
-            <svg class="copy-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
-            <svg class="copy-check" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="display:none;color:var(--color-success)"><polyline points="20 6 9 17 4 12"/></svg>
-          </button>
+          <a href="https://marketplace.visualstudio.com/items?itemName=Nimblesite.basilisk" class="btn btn--mono" target="_blank" rel="noopener">
+            <span>为 VS Code 安装</span>
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12l7 7 7-7"/></svg>
+          </a>
           <a href="https://github.com/MelbourneDeveloper/Basilisk" class="btn btn--secondary" target="_blank" rel="noopener">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.603-3.369-1.342-3.369-1.342-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.741 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>
             GitHub


### PR DESCRIPTION
## TLDR
Wires the release workflow to push a formula to `Nimblesite/homebrew-tap` and a manifest to `Nimblesite/scoop-bucket` on every tag, and rips out the lying `cargo install basilisk` references from the website, VSIX walkthrough, README, and homepage hero CTA (basilisk is not published to crates.io).

## What Was Added?
- `.github/release-templates/basilisk.rb.tmpl` — Homebrew formula template. License `"MIT"`. Covers macOS Apple Silicon, Linux x86_64, Linux aarch64 — exactly the targets the build matrix produces.
- `.github/release-templates/basilisk.json.tmpl` — Scoop manifest template for Windows x86_64 + aarch64, with `checkver` + `autoupdate` blocks that preserve Scoop's literal `$version` placeholder.
- Two new jobs in `.github/workflows/release.yml`:
  - `publish-homebrew` — downloads release archives, computes SHA256s, renders the formula via `envsubst` with an explicit variable allow-list (so Ruby's `#{bin}` interpolation survives), commits to `Nimblesite/homebrew-tap` as `basilisk <version>` and pushes.
  - `publish-scoop` — same flow into `Nimblesite/scoop-bucket`, plus a `python3 -m json.tool` sanity check before commit.
  - Both gate on `startsWith(github.ref, 'refs/tags/')` — every tag publishes, prereleases included.
  - Both fail loudly with an actionable error if `BREW_SCOOP_PAT` (the existing Nimblesite org secret) is not reachable from this repo.
- Homebrew + Scoop install instructions in `website/src/docs/installation.md` and `website/src/zh/docs/installation.md` (`brew tap Nimblesite/tap && brew install basilisk`, `scoop bucket add nimblesite … && scoop install basilisk`).
- "Installing the CLI separately" section in `vscode-extension/README.md` pointing at brew/scoop/GitHub Releases.

## What Was Changed or Deleted?
- Homepage hero CTA in `website/src/index.njk` + `website/src/zh/index.njk`: replaced the `cargo install basilisk` copy-button with an "Install for VS Code" link to the Marketplace. basilisk is not on crates.io so the old button copied a command that would 404.
- Deleted the "Install via Cargo" / "通过 Cargo 安装" sections from both installation pages and removed `cargo` from their front-matter description + keywords.
- VSIX walkthrough step `basilisk.installBinary` (`vscode-extension/package.json`): retitled and rewritten to say the binary is bundled with the extension instead of telling users to run `cargo install basilisk`.
- VSIX `README.md` Requirements section: replaced the `cargo install basilisk` snippet with the truth ("bundled per platform") plus the new brew/scoop install paths.
- Fixed broken curl URLs that referenced asset names the release workflow never produced (`basilisk-darwin-aarch64.tar.gz`, `basilisk-linux-x86_64.tar.gz`, `basilisk-darwin-x86_64.tar.gz` etc.) — replaced with the real names (`basilisk-aarch64-apple-darwin.zip`, `basilisk-x86_64-unknown-linux-gnu.tar.gz`, `basilisk-aarch64-unknown-linux-gnu.tar.gz`) in both EN + ZH installation pages and their CI integration YAML snippets.

## How Do The Automated Tests Prove It Works?
- `make ci` passed end-to-end (Rust release build of all crates including basilisk-lsp finishes in 35.6s; VS Code extension compiles via `tsc`; lint + tests + coverage threshold all gate-pass — exit code 0).
- Templates were rendered locally with sample values via the same `envsubst` invocation the workflow uses. The Homebrew formula renders with Ruby's `#{bin}` interpolation intact; the Scoop manifest renders with Scoop's `v$version` autoupdate placeholder intact and parses cleanly through `python3 -m json.tool`.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` confirms the workflow YAML parses after the additions.
- Repo-wide sweep for `basilisk-(darwin-aarch64|darwin-x86_64|linux-x86_64|linux-aarch64)\.tar\.gz` and `cargo install basilisk` (excluding `--path` source-build references) returns zero matches outside `node_modules`/`target`/`_site`/`.vscode-test`.

## Spec / Doc Changes
- `website/src/docs/installation.md` + `website/src/zh/docs/installation.md`: new Homebrew + Scoop sections, removed "Install via Cargo", fixed asset filenames, updated front-matter description/keywords.
- `vscode-extension/README.md`: Requirements section rewritten around the bundled binary plus brew/scoop CLI installation.
- `vscode-extension/package.json`: walkthrough step `basilisk.installBinary` retitled and re-described.
- No spec files (`docs/specs/*`) touched — the existing binary resolvers in `LSP-ARCHITECTURE-SPEC.md` and `NEOVIM-PLAN.md` already cover `/opt/homebrew/bin/basilisk` so `brew install basilisk` is picked up automatically.

## Breaking Changes
- [x] None for users. The release workflow requires `BREW_SCOOP_PAT` (Nimblesite org-level secret, already exists) to be allow-listed for this repo; without it the two new jobs fail with a clear error pointing at the org settings page. The rest of the release pipeline is unchanged.