### PR TITLE
Fix tuple/dict E0014 false positives; configurable strict missing-stubs error (E0152); CLI config; Shipwright 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2492,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "shipwright"
-version = "0.2.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d9c8e37e50fe32929d360cacd8dad21744b069d01ab6239f6497266c0c3cb6"
+checksum = "700e837054c52994c6d0b16918d3694467b42ebeaa332690bff21cd7fcb2d42e"
 dependencies = [
  "serde_json",
  "shipwright-manifest",
@@ -2503,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "shipwright-manifest"
-version = "0.2.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da47084e0d15717a38feb0beb071fd581a3805e23592748b9fdfab635d48707"
+checksum = "234b38e4c69f14d67f3703084b740e54fc2de797db00d2b6804660bb5978788b"
 dependencies = [
  "serde",
  "serde_json",

--- a/conformance/conformance_status.csv
+++ b/conformance/conformance_status.csv
@@ -127,8 +127,8 @@ BSK-E0062|BSK-E0070,specialtypes_never.py,specialtypes,PASS,3,0,0
 BSK-E0012|BSK-E0014,specialtypes_none.py,specialtypes,PASS,3,0,1
 BSK-E0065,specialtypes_promotions.py,specialtypes,PASS,1,0,0
 BSK-E0014|BSK-E0015|BSK-E0092|BSK-E0145,specialtypes_type.py,specialtypes,PASS,9,0,2
-BSK-E0014|BSK-E0045|BSK-E0147,tuples_type_compat.py,tuples,PASS,16,0,16
-BSK-E0013|BSK-E0014|BSK-E0049|BSK-E0090,tuples_type_form.py,tuples,PASS,11,0,4
+BSK-E0014|BSK-E0045|BSK-E0147,tuples_type_compat.py,tuples,PASS,16,0,14
+BSK-E0013|BSK-E0014|BSK-E0049|BSK-E0090,tuples_type_form.py,tuples,PASS,11,0,3
 BSK-E0049|BSK-E0053,tuples_unpacked.py,tuples,PASS,4,0,3
 BSK-E0037,typeddicts_alt_syntax.py,typeddicts,PASS,4,0,0
 BSK-E0029|BSK-E0032,typeddicts_class_syntax.py,typeddicts,PASS,3,0,0

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -41,7 +41,7 @@
     }
   },
   "conformance": {
-    "_doc": "Minimum PEP conformance pass percentage (files passing / total files). Ratchet UP only. Current: 134/146 = 91.78% (pinned to python/typing@268d0c4e). Regression from 135/146: generics_defaults_specialization.py now fails (upstream added new assertions for type-alias default substitution); fixing BSK-E0092 is tracked separately.",
-    "threshold": 91
+    "_doc": "Minimum PEP conformance pass percentage (files passing / total files). Ratchet UP only. Current: 135/146 = 92.46% (pinned to python/typing@268d0c4e). 11 files still fail (missed required diagnostics): constructors_callable, dataclasses_transform_converter, generics_defaults_specialization, generics_paramspec_components, generics_paramspec_semantics, generics_paramspec_specialization, generics_typevartuple_args, generics_typevartuple_basic, protocols_definition, typeddicts_extra_items, typeddicts_readonly_inheritance.",
+    "threshold": 92
   }
 }

--- a/crates/basilisk-checker/src/lib.rs
+++ b/crates/basilisk-checker/src/lib.rs
@@ -82,7 +82,7 @@ pub fn check_with_config(
             let code = diag.code.code;
 
             // 0. Config gating for uv diagnostics.
-            if code == "BSK-W0010" && !config.uv_stub_suggestions {
+            if code == "BSK-E0152" && !config.uv_stub_suggestions {
                 return None;
             }
             if matches!(code, "BSK-W0011" | "BSK-W0012" | "BSK-W0013")
@@ -124,7 +124,7 @@ pub fn check_with_config(
                     basilisk_config::RuleSeverity::Disabled => return None,
                     basilisk_config::RuleSeverity::Warning => diag.severity = Severity::Warning,
                     basilisk_config::RuleSeverity::Info => diag.severity = Severity::Info,
-                    basilisk_config::RuleSeverity::Error => {} // keep default
+                    basilisk_config::RuleSeverity::Error => diag.severity = Severity::Error,
                 }
             }
 
@@ -136,7 +136,7 @@ pub fn check_with_config(
                     basilisk_config::RuleSeverity::Disabled => return None,
                     basilisk_config::RuleSeverity::Warning => diag.severity = Severity::Warning,
                     basilisk_config::RuleSeverity::Info => diag.severity = Severity::Info,
-                    basilisk_config::RuleSeverity::Error => {}
+                    basilisk_config::RuleSeverity::Error => diag.severity = Severity::Error,
                 }
             }
 
@@ -321,7 +321,7 @@ mod tests {
         // Should NOT have any downstream errors referencing `get`.
         let downstream = diagnostics
             .iter()
-            .filter(|d| d.code.code != "BSK-E0010" && d.code.code != "BSK-W0010")
+            .filter(|d| d.code.code != "BSK-E0010" && d.code.code != "BSK-E0152")
             .filter(|d| d.message.contains("get"))
             .count();
         assert_eq!(

--- a/crates/basilisk-checker/src/rules/e0010.rs
+++ b/crates/basilisk-checker/src/rules/e0010.rs
@@ -103,7 +103,7 @@ fn format_reason(import: &ImportInfo, root_module: &str) -> (String, String) {
             ),
             "Check the `requires-python` setting in pyproject.toml".to_owned(),
         ),
-        // NoStubs is handled by W0010 — fall through to generic message.
+        // NoStubs is handled by E0152 — fall through to generic message.
         Some(UnresolvedReason::NoStubs | UnresolvedReason::Unknown) | None => (
             format!(
                 "Cannot resolve import `{}` \u{2014} no type information available",

--- a/crates/basilisk-checker/src/rules/e0152.rs
+++ b/crates/basilisk-checker/src/rules/e0152.rs
@@ -1,12 +1,15 @@
-//! Implements [BSK-W0010] from [CHKARCH-DIAG-TYPESAFETY]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#chkarch-diag-typesafety
-//! BSK-W0010: Missing type stubs for installed package.
+//! Implements [BSK-E0152] from [CHKARCH-DIAG]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#chkarch-diag
+//! BSK-E0152: Missing type stubs for installed package.
 //!
 //! Fires when a package is imported and resolves to a `.py` source file (not
 //! `.pyi`) without a `py.typed` marker. This means the package is installed
-//! but lacks type information, reducing type safety.
+//! but lacks type information, reducing type safety. Strict-by-default: an
+//! untyped third-party import is a hard error. Projects can opt out per import
+//! (`# type: warning[BSK-E0152]`) or globally (`"BSK-E0152" = "warning"`) to
+//! import non-type-safe libraries at their own risk.
 //!
 //! ```python
-//! import flask  # W0010: Package 'flask' is installed but has no type stubs
+//! import flask  # E0152: Package 'flask' is installed but has no type stubs
 //! ```
 
 use basilisk_resolver::{ImportInfo, ImportResolution, ResolvedModule};
@@ -17,11 +20,11 @@ use crate::diagnostic::{Diagnostic, ErrorCode, Severity};
 use super::Rule;
 
 const CODE: ErrorCode = ErrorCode {
-    code: "BSK-W0010",
-    docs_url: "https://www.basilisk-python.dev/warnings/BSK-W0010",
+    code: "BSK-E0152",
+    docs_url: "https://www.basilisk-python.dev/errors/BSK-E0152",
 };
 
-/// Emits BSK-W0010 when an imported package resolves to a `.py` source file
+/// Emits BSK-E0152 when an imported package resolves to a `.py` source file
 /// without a `py.typed` marker, indicating missing type stubs.
 pub(crate) struct MissingTypeStubs;
 
@@ -68,13 +71,13 @@ fn has_py_typed_marker(import: &ImportInfo) -> bool {
         .is_some_and(|resolved| basilisk_stubs::has_py_typed_marker(resolved))
 }
 
-/// Build the diagnostic for a missing type stubs warning.
+/// Build the diagnostic for a missing type stubs error.
 fn make_diagnostic(import: &ImportInfo, path: &str) -> Diagnostic {
     let root_module = import.module.split('.').next().unwrap_or(&import.module);
 
     Diagnostic {
         code: CODE.clone(),
-        severity: Severity::Warning,
+        severity: Severity::Error,
         message: format!("Package `{root_module}` is installed but has no type stubs available"),
         span: import.span,
         path: path.to_owned(),
@@ -163,7 +166,27 @@ mod tests {
         );
         let diagnostics = run_check(import);
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code.code, "BSK-W0010");
+        assert_eq!(diagnostics[0].code.code, "BSK-E0152");
+    }
+
+    /// Strict-by-default: an untyped third-party import is a hard ERROR, not a
+    /// warning. Users opt down (`"BSK-E0152" = "warning"`) to import at their
+    /// own risk; this asserts the default severity stays an error.
+    #[test]
+    fn defaults_to_error_severity() {
+        let import = make_import(
+            "flask",
+            12,
+            ImportResolution::SourcePy,
+            Some("/venv/lib/python3.12/site-packages/flask/__init__.py"),
+        );
+        let diagnostics = run_check(import);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].severity,
+            Severity::Error,
+            "missing type stubs must default to a hard error"
+        );
     }
 
     /// Regression for issue #46: the help text must name the *real* typeshed
@@ -277,7 +300,7 @@ mod tests {
 
         assert!(
             diagnostics.is_empty(),
-            "PEP 561 inline-typed packages must not emit BSK-W0010"
+            "PEP 561 inline-typed packages must not emit BSK-E0152"
         );
         Ok(())
     }
@@ -335,7 +358,7 @@ mod tests {
     /// subpackage `__init__.py`). The resolved file's parent is *already* the
     /// top-level package directory, so climbing `depth` (one dot) levels
     /// over-climbs into `site-packages` and misses the marker, producing a
-    /// false-positive W0010. The marker check must locate the top-level package
+    /// false-positive E0152. The marker check must locate the top-level package
     /// regardless of whether the submodule is a flat file or a subpackage.
     #[test]
     fn skips_flat_file_submodule_when_root_package_has_py_typed(

--- a/crates/basilisk-checker/src/rules/mod.rs
+++ b/crates/basilisk-checker/src/rules/mod.rs
@@ -157,9 +157,9 @@ pub(crate) mod e0148;
 pub(crate) mod e0149;
 pub(crate) mod e0150;
 pub(crate) mod e0151;
+pub(crate) mod e0152;
 pub(crate) mod guards;
 pub(crate) mod shared;
-pub(crate) mod w0010;
 pub(crate) mod w0011;
 pub(crate) mod w0012;
 pub(crate) mod w0013;
@@ -327,7 +327,7 @@ fn all_rules() -> &'static [&'static dyn Rule] {
         &e0149::Pep695TypeParamScopingViolation,
         &e0150::DeadBranchVariable,
         &e0151::TypeAliasTypeViolation,
-        &w0010::MissingTypeStubs,
+        &e0152::MissingTypeStubs,
         &w0011::UndeclaredDependencyImport,
         &w0012::UnusedDependency,
         &w0013::StaleLockFile,

--- a/crates/basilisk-checker/src/rules/w0010.rs
+++ b/crates/basilisk-checker/src/rules/w0010.rs
@@ -62,22 +62,10 @@ fn is_site_packages_import(import: &ImportInfo) -> bool {
 /// in the dotted module name) honors flat-file and subpackage submodules
 /// uniformly and never over-climbs past the package into `site-packages`.
 fn has_py_typed_marker(import: &ImportInfo) -> bool {
-    let Some(resolved) = import.resolved_path.as_ref() else {
-        return false;
-    };
-    let mut dir = resolved.parent();
-    while let Some(current) = dir {
-        // Stop at the `site-packages` boundary: installed packages are its
-        // direct children, so the marker never lives at or above this level.
-        if current.file_name() == Some(std::ffi::OsStr::new("site-packages")) {
-            return false;
-        }
-        if current.join("py.typed").is_file() {
-            return true;
-        }
-        dir = current.parent();
-    }
-    false
+    import
+        .resolved_path
+        .as_ref()
+        .is_some_and(|resolved| basilisk_stubs::has_py_typed_marker(resolved))
 }
 
 /// Build the diagnostic for a missing type stubs warning.

--- a/crates/basilisk-checker/src/types.rs
+++ b/crates/basilisk-checker/src/types.rs
@@ -247,10 +247,23 @@ impl InferredType {
                 a_key.is_assignable_to(b_key) && a_val.is_assignable_to(b_val)
             }
             (InferredType::Tuple(a), InferredType::Tuple(b)) => {
-                a.len() == b.len()
-                    && a.iter()
-                        .zip(b.iter())
-                        .all(|(a_elem, b_elem)| a_elem.is_assignable_to(b_elem))
+                match (homogeneous_tuple_elem(a), homogeneous_tuple_elem(b)) {
+                    // Target `tuple[X, ...]` (PEP 484 homogeneous variable-length):
+                    // a source `tuple[Y, ...]` matches when `Y` is assignable to `X`.
+                    (Some(a_elem), Some(b_elem)) => a_elem.is_assignable_to(b_elem),
+                    // Target `tuple[X, ...]`: every element of a fixed-length source
+                    // tuple must be assignable to `X` (empty tuple is vacuously valid).
+                    (None, Some(b_elem)) => a.iter().all(|elem| elem.is_assignable_to(b_elem)),
+                    // Target is fixed-length: a variable-length source cannot satisfy it.
+                    (Some(_), None) => false,
+                    // Both fixed-length: require equal arity and positional assignability.
+                    (None, None) => {
+                        a.len() == b.len()
+                            && a.iter()
+                                .zip(b.iter())
+                                .all(|(a_elem, b_elem)| a_elem.is_assignable_to(b_elem))
+                    }
+                }
             }
             // Callable type assignability
             (InferredType::Callable(a), InferredType::Callable(b)) => {
@@ -317,5 +330,19 @@ impl InferredType {
             // structural checking, so we don't treat it as universally compatible.
             _ => false,
         }
+    }
+}
+
+/// Returns the element type `X` when `elems` is the homogeneous variable-length
+/// tuple form `tuple[X, ...]`.
+///
+/// Implements [TYPEINF-OVERVIEW]. The annotation parser ([`super::types_parsing`])
+/// represents the `...` terminator as `Named("...")`, so `tuple[str, ...]` becomes
+/// `Tuple([Str, Named("...")])`. Distinguishing this from a fixed-length tuple is
+/// what lets a literal `(a, b, c)` widen to `tuple[X, ...]` (PEP 484).
+fn homogeneous_tuple_elem(elems: &[InferredType]) -> Option<&InferredType> {
+    match elems {
+        [elem, InferredType::Named(terminator)] if terminator == "..." => Some(elem),
+        _ => None,
     }
 }

--- a/crates/basilisk-checker/src/types_parsing.rs
+++ b/crates/basilisk-checker/src/types_parsing.rs
@@ -75,7 +75,9 @@ fn parse_container_annotation(annotation: &str) -> InferredType {
     }
     if annotation.starts_with("dict[") && annotation.ends_with(']') {
         let inner = &annotation[5..annotation.len() - 1];
-        let parts: Vec<&str> = inner.split(',').collect();
+        // Bracket-aware split so a nested key type (e.g. `tuple[str, str]`) is
+        // not severed at its inner comma — same splitter `tuple[`/`union[` use.
+        let parts = split_type_params(inner);
         if parts.len() == 2 {
             let key_type = InferredType::from_annotation(parts.first().map_or("", |s| s.trim()));
             let value_type = InferredType::from_annotation(parts.get(1).map_or("", |s| s.trim()));

--- a/crates/basilisk-checker/tests/checker/e0014_tests.rs
+++ b/crates/basilisk-checker/tests/checker/e0014_tests.rs
@@ -231,6 +231,28 @@ _MODEL_SETTING_KEYS: tuple[str, ...] = ("max_tokens", "temperature", "top_p", "t
 }
 
 #[test]
+fn e0014_no_false_positive_on_dict_with_tuple_key_annotation(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Regression for issue #51: `dict[tuple[str, str], str]` has a tuple KEY
+    // type whose inner comma must not be split by the dict arg parser. A dict
+    // literal matching the annotation exactly must NOT fire E0014.
+    let source = r#"
+_LLM_DISPLAY_NAMES: dict[tuple[str, str], str] = {
+    ("anthropic", "claude-opus-4-7"): "Claude Opus 4.7",
+    ("anthropic", "claude-sonnet-4-6"): "Claude Sonnet 4.6",
+}
+"#;
+    let diags = run(source)?;
+
+    let msgs = messages_for(&diags, "BSK-E0014");
+    assert!(
+        msgs.is_empty(),
+        "dict[tuple[str, str], str] = {{matching literal}} should NOT fire E0014, got: {msgs:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn e0014_tuple_reassignment() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
 x: int = 1

--- a/crates/basilisk-checker/tests/checker/e0014_tests.rs
+++ b/crates/basilisk-checker/tests/checker/e0014_tests.rs
@@ -212,6 +212,25 @@ r1_2: RecursiveTypeAlias1[int] = [1, [1, 2, 3]]
 }
 
 #[test]
+fn e0014_no_false_positive_on_homogeneous_tuple_str_annotation(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Regression for issue #45: `tuple[str, ...]` is PEP 484's homogeneous
+    // variable-length tuple. A literal tuple of all-string elements widens to
+    // it and must NOT fire E0014.
+    let source = r#"
+_MODEL_SETTING_KEYS: tuple[str, ...] = ("max_tokens", "temperature", "top_p", "timeout", "seed")
+"#;
+    let diags = run(source)?;
+
+    let msgs = messages_for(&diags, "BSK-E0014");
+    assert!(
+        msgs.is_empty(),
+        "tuple[str, ...] = (..all strings..) should NOT fire E0014, got: {msgs:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn e0014_tuple_reassignment() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
 x: int = 1

--- a/crates/basilisk-checker/tests/config_override_tests.rs
+++ b/crates/basilisk-checker/tests/config_override_tests.rs
@@ -94,6 +94,47 @@ fn global_rule_severity_override_demotes_to_info() {
 }
 
 #[test]
+fn global_rule_severity_override_promotes_warning_to_error() {
+    // A warning-level rule (BSK-W0050 redundant annotation) must be promotable
+    // to a hard ERROR via `rules."BSK-W0050" = "error"`. This lets a project
+    // dial strictness UP — e.g. make "no type stubs" a red error — not just
+    // down. Today the `Error` override is a silent no-op, so this fails.
+    let source = "x: int = 42\n";
+    let default_diags = check_default(source, "test.py");
+    let w0050_default: Vec<_> = default_diags
+        .iter()
+        .filter(|d| d.code.code == "BSK-W0050")
+        .collect();
+    assert!(!w0050_default.is_empty(), "W0050 should fire by default");
+    assert_eq!(
+        w0050_default[0].severity,
+        basilisk_checker::Severity::Warning,
+        "W0050 defaults to warning"
+    );
+
+    let config = BasiliskConfig {
+        rules: HashMap::from([("BSK-W0050".to_owned(), RuleSeverity::Error)]),
+        ..Default::default()
+    };
+    let diags = check_with(source, "test.py", &config);
+    let promoted: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code.code == "BSK-W0050")
+        .collect();
+    assert!(
+        !promoted.is_empty(),
+        "W0050 should still fire when promoted to error"
+    );
+    for diag in &promoted {
+        assert_eq!(
+            diag.severity,
+            basilisk_checker::Severity::Error,
+            "W0050 should be promoted to a hard error via config"
+        );
+    }
+}
+
+#[test]
 fn per_path_override_disables_rule() {
     let source = "def foo(x):\n    return x\n";
 

--- a/crates/basilisk-cli/Cargo.toml
+++ b/crates/basilisk-cli/Cargo.toml
@@ -20,8 +20,8 @@ basilisk-uv.workspace       = true
 basilisk-stubs.workspace    = true
 clap.workspace              = true
 # Shipwright `--version` / `--version --json` contract emitter.
-shipwright                  = "0.5"
-shipwright-manifest         = "0.5"
+shipwright                  = "0.5.3"
+shipwright-manifest         = "0.5.3"
 colored.workspace           = true
 tower-lsp                   = "0.20"
 walkdir.workspace           = true

--- a/crates/basilisk-cli/Cargo.toml
+++ b/crates/basilisk-cli/Cargo.toml
@@ -20,8 +20,8 @@ basilisk-uv.workspace       = true
 basilisk-stubs.workspace    = true
 clap.workspace              = true
 # Shipwright `--version` / `--version --json` contract emitter.
-shipwright                  = "0.2"
-shipwright-manifest         = "0.2"
+shipwright                  = "0.5"
+shipwright-manifest         = "0.5"
 colored.workspace           = true
 tower-lsp                   = "0.20"
 walkdir.workspace           = true

--- a/crates/basilisk-cli/src/main.rs
+++ b/crates/basilisk-cli/src/main.rs
@@ -506,7 +506,7 @@ fn collect_and_check(
     let mut sources = Vec::new();
 
     for path in python_files {
-        match process_file(&path, &search_paths) {
+        match process_file(&path, &search_paths, &config) {
             Ok((diags, source)) => {
                 all_diagnostics.extend(diags);
                 sources.push(FileSource { path, text: source });
@@ -564,6 +564,7 @@ fn build_uv_registry(
 fn process_file(
     path: &str,
     search_paths: &basilisk_lsp::import_resolver::ImportSearchPaths,
+    config: &basilisk_config::BasiliskConfig,
 ) -> Result<(Vec<basilisk_checker::Diagnostic>, String), String> {
     let parsed = basilisk_parser::parse_file(path).map_err(|e| e.to_string())?;
     let source = parsed.source.clone();
@@ -574,7 +575,10 @@ fn process_file(
     // package-dependency metadata (W0011 transitive-import warnings, etc.).
     basilisk_lsp::import_resolver::resolve_module_imports(&mut resolved, search_paths);
 
-    let diags = basilisk_checker::check(&resolved);
+    // Apply the project's `[tool.basilisk.rules]` / per-path overrides so the
+    // CLI and editor agree on severity (e.g. a project can promote "no type
+    // stubs" to a hard error). Using `check` here would silently drop config.
+    let diags = basilisk_checker::check_with_config(&resolved, config);
     Ok((diags, source))
 }
 
@@ -768,6 +772,55 @@ mod tests {
         assert!(
             !diags.is_empty(),
             "unannotated function must produce diagnostics"
+        );
+        Ok(())
+    }
+
+    // ── collect_and_check: project config severity overrides are applied ──────
+
+    /// Unique temp dir for tests that need an isolated project root.
+    fn unique_project_dir(prefix: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static CTR: AtomicU64 = AtomicU64::new(0);
+        let n = CTR.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("{prefix}_{}_{n}", std::process::id()))
+    }
+
+    /// Regression: the `basilisk check` CLI must honor `[tool.basilisk.rules]`
+    /// severity overrides from `pyproject.toml`. A project that escalates a
+    /// warning-default rule (BSK-W0050) to "error" must see it surface as a
+    /// hard error through the real CLI pipeline — otherwise strictness config
+    /// is silently ignored in CI. Previously `process_file` called
+    /// `basilisk_checker::check` (default config), dropping all overrides.
+    #[test]
+    fn collect_and_check_applies_project_rule_severity_override(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let dir = unique_project_dir("basilisk_cli_cfg_promote");
+        std::fs::create_dir_all(&dir)?;
+        std::fs::write(
+            dir.join("pyproject.toml"),
+            b"[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n\
+              [tool.basilisk.rules]\n\"BSK-W0050\" = \"error\"\n",
+        )?;
+        let py = dir.join("m.py");
+        std::fs::write(&py, b"x: int = 42\n")?;
+
+        let path = py.to_string_lossy().into_owned();
+        let (diags, _) = collect_and_check(&[path])?;
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let w0050: Vec<_> = diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-W0050")
+            .collect();
+        assert!(!w0050.is_empty(), "BSK-W0050 must still fire");
+        assert!(
+            w0050
+                .iter()
+                .all(|d| d.severity == basilisk_checker::Severity::Error),
+            "project config `BSK-W0050 = \"error\"` must promote W0050 to error \
+             through the CLI; got {:?}",
+            w0050.iter().map(|d| d.severity).collect::<Vec<_>>()
         );
         Ok(())
     }

--- a/crates/basilisk-cli/tests/e2e_stub_resolution.rs
+++ b/crates/basilisk-cli/tests/e2e_stub_resolution.rs
@@ -144,6 +144,52 @@ fn stub_package_resolved_before_inline_typed() {
     let _ = fs::remove_dir_all(&sp);
 }
 
+/// Reproduces issue: "I can't get it to pick up stubs and the auto-fix doesn't
+/// fix anything." The BSK-W0010 quick-fix runs `uv add --dev types-<pkg>`, which
+/// drops a `<pkg>-stubs/` package into site-packages. W0010 fires only while the
+/// import resolves to `SourcePy`; after the stub package is installed the import
+/// MUST resolve to `StubPyi` so the warning clears. This exercises that exact
+/// before/after transition deterministically (no network / no uv).
+#[test]
+fn autofix_stub_install_flips_source_resolution_to_stub() {
+    let sp = unique_tmp("e2e_stub_autofix_flip");
+
+    // BEFORE the auto-fix: `requests` is installed without inline types and
+    // without a stub package → resolves to plain source (W0010 fires here).
+    let pkg = sp.join("requests");
+    fs::create_dir_all(&pkg).unwrap();
+    fs::write(pkg.join("__init__.py"), "def get(url): pass\n").unwrap();
+
+    let paths = search_paths(vec![], vec![], Some(sp.clone()));
+    let before = resolve_module("requests", &paths).expect("should resolve requests");
+    assert_eq!(
+        before.resolution,
+        ImportResolution::SourcePy,
+        "precondition: plain site-packages package resolves to SourcePy (W0010 fires)"
+    );
+
+    // AFTER the auto-fix: `uv add --dev types-requests` installs `requests-stubs/`.
+    let stubs_dir = sp.join("requests-stubs");
+    fs::create_dir_all(&stubs_dir).unwrap();
+    fs::write(
+        stubs_dir.join("__init__.pyi"),
+        "def get(url: str) -> bytes: ...\n",
+    )
+    .unwrap();
+
+    let after = resolve_module("requests", &paths).expect("should resolve requests");
+    assert_eq!(
+        after.resolution,
+        ImportResolution::StubPyi,
+        "after `uv add --dev types-requests` the import must resolve to the stub \
+         package so BSK-W0010 clears, got: {:?} at {:?}",
+        after.resolution,
+        after.path
+    );
+
+    let _ = fs::remove_dir_all(&sp);
+}
+
 #[test]
 fn stub_package_submodule_resolution() {
     let sp = unique_tmp("e2e_stub_pep561_sub");

--- a/crates/basilisk-cli/tests/e2e_stub_resolution.rs
+++ b/crates/basilisk-cli/tests/e2e_stub_resolution.rs
@@ -145,8 +145,8 @@ fn stub_package_resolved_before_inline_typed() {
 }
 
 /// Reproduces issue: "I can't get it to pick up stubs and the auto-fix doesn't
-/// fix anything." The BSK-W0010 quick-fix runs `uv add --dev types-<pkg>`, which
-/// drops a `<pkg>-stubs/` package into site-packages. W0010 fires only while the
+/// fix anything." The BSK-E0152 quick-fix runs `uv add --dev types-<pkg>`, which
+/// drops a `<pkg>-stubs/` package into site-packages. E0152 fires only while the
 /// import resolves to `SourcePy`; after the stub package is installed the import
 /// MUST resolve to `StubPyi` so the warning clears. This exercises that exact
 /// before/after transition deterministically (no network / no uv).
@@ -155,7 +155,7 @@ fn autofix_stub_install_flips_source_resolution_to_stub() {
     let sp = unique_tmp("e2e_stub_autofix_flip");
 
     // BEFORE the auto-fix: `requests` is installed without inline types and
-    // without a stub package → resolves to plain source (W0010 fires here).
+    // without a stub package → resolves to plain source (E0152 fires here).
     let pkg = sp.join("requests");
     fs::create_dir_all(&pkg).unwrap();
     fs::write(pkg.join("__init__.py"), "def get(url): pass\n").unwrap();
@@ -165,7 +165,7 @@ fn autofix_stub_install_flips_source_resolution_to_stub() {
     assert_eq!(
         before.resolution,
         ImportResolution::SourcePy,
-        "precondition: plain site-packages package resolves to SourcePy (W0010 fires)"
+        "precondition: plain site-packages package resolves to SourcePy (E0152 fires)"
     );
 
     // AFTER the auto-fix: `uv add --dev types-requests` installs `requests-stubs/`.
@@ -182,7 +182,7 @@ fn autofix_stub_install_flips_source_resolution_to_stub() {
         after.resolution,
         ImportResolution::StubPyi,
         "after `uv add --dev types-requests` the import must resolve to the stub \
-         package so BSK-W0010 clears, got: {:?} at {:?}",
+         package so BSK-E0152 clears, got: {:?} at {:?}",
         after.resolution,
         after.path
     );

--- a/crates/basilisk-config/src/parse.rs
+++ b/crates/basilisk-config/src/parse.rs
@@ -42,9 +42,9 @@ pub struct BasiliskConfig {
     /// (e.g. `"vendor/**"` matches `vendor/lib/foo.py`).
     pub per_path_overrides: HashMap<String, PathOverride>,
 
-    /// Whether to emit BSK-W0010 (missing type stubs) warnings.
+    /// Whether to emit BSK-E0152 (missing type stubs) diagnostics.
     ///
-    /// When `true` (default), warns about installed packages lacking type stubs.
+    /// When `true` (default), flags installed packages lacking type stubs.
     /// Maps to `basilisk.uv.stubSuggestions` in the LSP config.
     pub uv_stub_suggestions: bool,
 

--- a/crates/basilisk-lsp/src/code_actions/mod.rs
+++ b/crates/basilisk-lsp/src/code_actions/mod.rs
@@ -85,7 +85,7 @@ pub fn code_actions(
                 )));
             }
         }
-        if code == "BSK-W0010" {
+        if code == "BSK-E0152" {
             if let Some(action) = extract_module_from_diagnostic(&diag.message)
                 .and_then(|module| make_uv_add_stubs_action(diag, &module))
             {
@@ -486,10 +486,10 @@ mod tests {
     /// not `<module>-stubs`. For `requests` the real package is
     /// `types-requests`; offering `requests-stubs` fails to resolve on `PyPI`.
     #[test]
-    fn test_bsk_w0010_code_action_includes_uv_add_dev() {
+    fn test_bsk_e0152_code_action_includes_uv_add_dev() {
         let diag = make_diagnostic(
-            DiagnosticSeverity::WARNING,
-            "BSK-W0010",
+            DiagnosticSeverity::ERROR,
+            "BSK-E0152",
             "Package `requests` is installed but has no type stubs available",
             range_at((0, 0), (0, 8)),
         );
@@ -511,10 +511,10 @@ mod tests {
     /// ships inline `py.typed` and has no typeshed stub — suggesting
     /// `pydantic_ai-stubs` (or any name) leads to a broken `uv add` that 404s.
     #[test]
-    fn test_bsk_w0010_action_suppressed_for_unknown_stub() {
+    fn test_bsk_e0152_action_suppressed_for_unknown_stub() {
         let diag = make_diagnostic(
-            DiagnosticSeverity::WARNING,
-            "BSK-W0010",
+            DiagnosticSeverity::ERROR,
+            "BSK-E0152",
             "Package `pydantic_ai` is installed but has no type stubs available",
             range_at((0, 0), (0, 12)),
         );

--- a/crates/basilisk-lsp/src/cross_module.rs
+++ b/crates/basilisk-lsp/src/cross_module.rs
@@ -508,7 +508,7 @@ mod tests {
 
     /// A site-packages `.py` package WITHOUT a `py.typed` marker must NOT have its
     /// annotations consumed (PEP 561: inline types are opt-in). This keeps
-    /// untyped third-party packages untyped so BSK-W0010 still applies.
+    /// untyped third-party packages untyped so BSK-E0152 still applies.
     #[test]
     fn cross_module_skips_non_py_typed_package() {
         let sp = std::env::temp_dir().join(format!("bsk_xmod_untyped_{}", std::process::id()));

--- a/crates/basilisk-lsp/src/cross_module.rs
+++ b/crates/basilisk-lsp/src/cross_module.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use basilisk_resolver::scope::{ExternalSymbol, ExternalSymbolKind};
+use basilisk_resolver::Span;
+use basilisk_stubs::types::{StubFunction, StubSource, StubTier};
 use basilisk_stubs::TypeProvenance;
 
 use crate::workspace::WorkspaceIndex;
@@ -86,6 +88,122 @@ fn extract_exports(
     exports
 }
 
+/// Extract exported symbols from a `.pyi` stub file.
+///
+/// Parses the stub and converts its functions, classes, and variables into
+/// `ExternalSymbol` entries with stub provenance, so imports that resolve to a
+/// stub (typeshed, `*-stubs` packages, or user stubs) carry real type
+/// information instead of nothing. Returns an empty vec if the stub cannot be
+/// parsed. Implements [ANALYSIS-CROSSLSP].
+fn extract_stub_exports(
+    stub_path: &std::path::Path,
+    module_name: &str,
+) -> Vec<(String, ExternalSymbol)> {
+    // `.pyi` stubs (typeshed, `*-stubs`, user stubs) are hand-written, verified
+    // types — Tier1. Source/tier only affect provenance via the Tier mapping.
+    let Ok(stub) = basilisk_stubs::parse_pyi_file(
+        stub_path,
+        module_name,
+        StubSource::StubPackage,
+        StubTier::Tier1,
+    ) else {
+        return Vec::new();
+    };
+
+    let provenance = Some(TypeProvenance::StubTier1);
+    let mut exports = Vec::new();
+
+    for func in stub.functions.values() {
+        exports.push((
+            func.name.clone(),
+            ExternalSymbol {
+                name: func.name.clone(),
+                kind: ExternalSymbolKind::Function,
+                type_annotation: func.return_type.clone(),
+                source_path: stub_path.to_path_buf(),
+                source_span: Span::new(0, 0),
+                signature: Some(build_stub_signature(func)),
+                provenance,
+            },
+        ));
+    }
+
+    for class in stub.classes.values() {
+        exports.push((
+            class.name.clone(),
+            ExternalSymbol {
+                name: class.name.clone(),
+                kind: ExternalSymbolKind::Class,
+                type_annotation: None,
+                source_path: stub_path.to_path_buf(),
+                source_span: Span::new(0, 0),
+                signature: Some(format!("class {}", class.name)),
+                provenance,
+            },
+        ));
+    }
+
+    for var in stub.variables.values() {
+        exports.push((
+            var.name.clone(),
+            ExternalSymbol {
+                name: var.name.clone(),
+                kind: ExternalSymbolKind::Variable,
+                type_annotation: var.annotation.clone(),
+                source_path: stub_path.to_path_buf(),
+                source_span: Span::new(0, 0),
+                signature: None,
+                provenance,
+            },
+        ));
+    }
+
+    exports
+}
+
+/// Extract exported symbols from an external `.py` package that ships inline
+/// PEP 561 types (a `py.typed` marker).
+///
+/// Parses and resolves the file, then reuses [`extract_exports`]. Callers MUST
+/// gate this on [`basilisk_stubs::has_py_typed_marker`] — a package without the
+/// marker has not opted in to inline type distribution, so its annotations must
+/// not be trusted. Returns an empty vec if the file cannot be read or parsed.
+/// Implements [ANALYSIS-CROSSLSP].
+fn extract_py_typed_exports(py_path: &std::path::Path) -> Vec<(String, ExternalSymbol)> {
+    let Ok(text) = std::fs::read_to_string(py_path) else {
+        return Vec::new();
+    };
+    let path_str = py_path.to_string_lossy().into_owned();
+    let Ok(parsed) = basilisk_parser::parse_source(text, path_str) else {
+        return Vec::new();
+    };
+    let Ok(resolved) = basilisk_resolver::resolve(&parsed) else {
+        return Vec::new();
+    };
+    extract_exports(&resolved, py_path)
+}
+
+/// Build a function signature string from a parsed stub function.
+fn build_stub_signature(func: &StubFunction) -> String {
+    let mut sig = format!("def {}(", func.name);
+    for (idx, param) in func.params.iter().enumerate() {
+        if idx > 0 {
+            sig.push_str(", ");
+        }
+        sig.push_str(&param.name);
+        if let Some(annotation) = &param.annotation {
+            sig.push_str(": ");
+            sig.push_str(annotation);
+        }
+    }
+    sig.push(')');
+    if let Some(return_type) = &func.return_type {
+        sig.push_str(" -> ");
+        sig.push_str(return_type);
+    }
+    sig
+}
+
 /// Build a function signature string for hover display.
 fn build_function_signature(func: &basilisk_resolver::scope::FunctionInfo, source: &str) -> String {
     let mut sig = format!("def {}(", func.name);
@@ -129,6 +247,13 @@ pub fn populate_cross_module_symbols(index: &WorkspaceIndex) {
         }
     }
 
+    // Third-party type sources resolved outside the workspace — `.pyi` stubs
+    // (typeshed, `*-stubs`, user stubs) and inline-typed `py.typed` packages —
+    // are not in `index.files`, so they never appear in `all_exports`. Parse
+    // them on demand and cache by path to avoid re-parsing per importer.
+    let mut external_exports: std::collections::HashMap<PathBuf, Vec<(String, ExternalSymbol)>> =
+        std::collections::HashMap::new();
+
     // Second pass: for each file, populate imported_symbols from resolved imports.
     for mut entry in index.files.iter_mut() {
         let Some(resolved_arc) = entry.value_mut().resolved.take() else {
@@ -142,7 +267,21 @@ pub fn populate_cross_module_symbols(index: &WorkspaceIndex) {
                 continue;
             };
 
-            let Some(target_exports) = all_exports.get(resolved_path) else {
+            // Prefer workspace exports; otherwise parse an external `.pyi` stub
+            // or an inline-typed `py.typed` package (PEP 561 opt-in only).
+            let target_exports = if let Some(exports) = all_exports.get(resolved_path) {
+                exports
+            } else if resolved_path.extension().is_some_and(|ext| ext == "pyi") {
+                external_exports
+                    .entry(resolved_path.clone())
+                    .or_insert_with(|| extract_stub_exports(resolved_path, &import.module))
+            } else if resolved_path.extension().is_some_and(|ext| ext == "py")
+                && basilisk_stubs::has_py_typed_marker(resolved_path)
+            {
+                external_exports
+                    .entry(resolved_path.clone())
+                    .or_insert_with(|| extract_py_typed_exports(resolved_path))
+            } else {
                 continue;
             };
 
@@ -238,6 +377,182 @@ mod tests {
             .expect("greet should exist");
         assert_eq!(greet_sym.kind, ExternalSymbolKind::Function);
         assert_eq!(greet_sym.source_path, path_a);
+    }
+
+    /// Stage 1 of stub type consumption (issue: "can't get it to pick up stubs"):
+    /// when an import resolves to a `.pyi` stub that is NOT a workspace file, the
+    /// importing module must still receive the stub's symbols (with stub
+    /// provenance) so hover/type-checking get real types. Before this, stubs were
+    /// discovered (`StubPyi`) but never parsed, so `imported_symbols` stayed empty.
+    #[test]
+    fn cross_module_imports_symbols_from_pyi_stub() {
+        let dir = std::env::temp_dir().join(format!("bsk_xmod_stub_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let stub_path = dir.join("acme.pyi");
+        std::fs::write(
+            &stub_path,
+            "def fetch(url: str) -> bytes: ...\nVERSION: str\n",
+        )
+        .unwrap();
+
+        let index = WorkspaceIndex::new(
+            vec![],
+            AnalysisMode::CrossModule,
+            basilisk_config::BasiliskConfig::default(),
+        );
+
+        // File B imports from `acme`, which resolves to an external `.pyi` stub
+        // (e.g. an installed `acme-stubs` package) — NOT a workspace file.
+        let uri_b = make_uri("/tmp/xmod_stub_b.py");
+        let src_b = "from acme import fetch\n\nx = fetch('u')\n";
+        let _ = index.set_open(&uri_b, src_b, 1);
+        let path_b = uri_b.to_file_path().unwrap();
+
+        if let Some(mut entry) = index.files.get_mut(&path_b) {
+            if let Some(resolved_arc) = entry.resolved.take() {
+                let mut resolved =
+                    Arc::try_unwrap(resolved_arc).unwrap_or_else(|arc| (*arc).clone());
+                for import in &mut resolved.imports {
+                    if import.module == "acme" {
+                        import.resolved_path = Some(stub_path.clone());
+                        import.resolution = basilisk_resolver::scope::ImportResolution::StubPyi;
+                    }
+                }
+                entry.resolved = Some(Arc::new(resolved));
+            }
+        }
+
+        populate_cross_module_symbols(&index);
+
+        let entry_b = index.files.get(&path_b).unwrap();
+        let resolved_b = entry_b.resolved.as_ref().unwrap();
+        let fetch_sym = resolved_b
+            .imported_symbols
+            .get("fetch")
+            .expect("`fetch` from the .pyi stub should be in imported_symbols");
+        assert_eq!(fetch_sym.kind, ExternalSymbolKind::Function);
+        assert_eq!(
+            fetch_sym.type_annotation.as_deref(),
+            Some("bytes"),
+            "stub return type must be picked up"
+        );
+        assert_eq!(
+            fetch_sym.provenance,
+            Some(TypeProvenance::StubTier1),
+            "symbols from a .pyi stub must carry stub provenance, not Source"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Stage 2 of stub type consumption: a third-party package that ships inline
+    /// types via a PEP 561 `py.typed` marker (its code is `.py`, not `.pyi`) must
+    /// have its symbols consumed too. Most modern libraries (pydantic, httpx,
+    /// rich) are this case. Gated on `py.typed` — an untyped package's
+    /// annotations must NOT be trusted (PEP 561).
+    #[test]
+    fn cross_module_imports_symbols_from_py_typed_package() {
+        let sp = std::env::temp_dir().join(format!("bsk_xmod_pytyped_{}", std::process::id()));
+        let pkg = sp.join("site-packages").join("widgets");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("py.typed"), "").unwrap();
+        let init_py = pkg.join("__init__.py");
+        std::fs::write(
+            &init_py,
+            "def render(node: int) -> str:\n    return str(node)\n",
+        )
+        .unwrap();
+
+        let index = WorkspaceIndex::new(
+            vec![],
+            AnalysisMode::CrossModule,
+            basilisk_config::BasiliskConfig::default(),
+        );
+
+        let uri_b = make_uri("/tmp/xmod_pytyped_b.py");
+        let src_b = "from widgets import render\n\ny = render(1)\n";
+        let _ = index.set_open(&uri_b, src_b, 1);
+        let path_b = uri_b.to_file_path().unwrap();
+
+        if let Some(mut entry) = index.files.get_mut(&path_b) {
+            if let Some(resolved_arc) = entry.resolved.take() {
+                let mut resolved =
+                    Arc::try_unwrap(resolved_arc).unwrap_or_else(|arc| (*arc).clone());
+                for import in &mut resolved.imports {
+                    if import.module == "widgets" {
+                        import.resolved_path = Some(init_py.clone());
+                        import.resolution = basilisk_resolver::scope::ImportResolution::SourcePy;
+                    }
+                }
+                entry.resolved = Some(Arc::new(resolved));
+            }
+        }
+
+        populate_cross_module_symbols(&index);
+
+        let entry_b = index.files.get(&path_b).unwrap();
+        let resolved_b = entry_b.resolved.as_ref().unwrap();
+        let render_sym = resolved_b
+            .imported_symbols
+            .get("render")
+            .expect("`render` from the py.typed package should be in imported_symbols");
+        assert_eq!(render_sym.kind, ExternalSymbolKind::Function);
+        assert_eq!(
+            render_sym.type_annotation.as_deref(),
+            Some("str"),
+            "py.typed package's inline return type must be picked up"
+        );
+
+        let _ = std::fs::remove_dir_all(&sp);
+    }
+
+    /// A site-packages `.py` package WITHOUT a `py.typed` marker must NOT have its
+    /// annotations consumed (PEP 561: inline types are opt-in). This keeps
+    /// untyped third-party packages untyped so BSK-W0010 still applies.
+    #[test]
+    fn cross_module_skips_non_py_typed_package() {
+        let sp = std::env::temp_dir().join(format!("bsk_xmod_untyped_{}", std::process::id()));
+        let pkg = sp.join("site-packages").join("legacy");
+        std::fs::create_dir_all(&pkg).unwrap();
+        // No py.typed marker.
+        let init_py = pkg.join("__init__.py");
+        std::fs::write(&init_py, "def helper(x: int) -> int:\n    return x\n").unwrap();
+
+        let index = WorkspaceIndex::new(
+            vec![],
+            AnalysisMode::CrossModule,
+            basilisk_config::BasiliskConfig::default(),
+        );
+
+        let uri_b = make_uri("/tmp/xmod_untyped_b.py");
+        let src_b = "from legacy import helper\n\nz = helper(1)\n";
+        let _ = index.set_open(&uri_b, src_b, 1);
+        let path_b = uri_b.to_file_path().unwrap();
+
+        if let Some(mut entry) = index.files.get_mut(&path_b) {
+            if let Some(resolved_arc) = entry.resolved.take() {
+                let mut resolved =
+                    Arc::try_unwrap(resolved_arc).unwrap_or_else(|arc| (*arc).clone());
+                for import in &mut resolved.imports {
+                    if import.module == "legacy" {
+                        import.resolved_path = Some(init_py.clone());
+                        import.resolution = basilisk_resolver::scope::ImportResolution::SourcePy;
+                    }
+                }
+                entry.resolved = Some(Arc::new(resolved));
+            }
+        }
+
+        populate_cross_module_symbols(&index);
+
+        let entry_b = index.files.get(&path_b).unwrap();
+        let resolved_b = entry_b.resolved.as_ref().unwrap();
+        assert!(
+            !resolved_b.imported_symbols.contains_key("helper"),
+            "symbols from a non-py.typed package must NOT be consumed (PEP 561)"
+        );
+
+        let _ = std::fs::remove_dir_all(&sp);
     }
 
     #[test]

--- a/crates/basilisk-lsp/src/hover.rs
+++ b/crates/basilisk-lsp/src/hover.rs
@@ -73,6 +73,35 @@ pub fn hover_at(
         }
     }
 
+    // 2b. Imported symbol with no local definition (e.g. a function/class from a
+    // `.pyi` stub or a py.typed package): show its signature/type from
+    // cross-module resolution so stub types surface on hover.
+    if hit.is_none() {
+        if let Some(name) = identifier_at_offset(source, byte_offset) {
+            if let Some(ext_sym) = resolved.imported_symbols.get(&name) {
+                let mut md = if let Some(sig) = &ext_sym.signature {
+                    format!("```python\n{sig}\n```")
+                } else if let Some(ty) = &ext_sym.type_annotation {
+                    format!("```python\n{name}: {ty}\n```")
+                } else {
+                    String::new()
+                };
+                if let Some(label) = ext_sym
+                    .provenance
+                    .and_then(basilisk_stubs::TypeProvenance::hover_label)
+                {
+                    if !md.is_empty() {
+                        md.push_str("\n\n");
+                    }
+                    let _ = write!(md, "*{label}*");
+                }
+                if !md.is_empty() {
+                    sections.push(md);
+                }
+            }
+        }
+    }
+
     // 3. Import resolution details when the cursor is on an import statement.
     if let Some(import_info) = find_import_at_offset(resolved, byte_offset) {
         let import_md = format_import_hover(import_info);
@@ -214,6 +243,48 @@ mod tests {
         assert!(
             markup.value.contains("os.pyi"),
             "should show resolved path: {}",
+            markup.value
+        );
+    }
+
+    /// Stage 3 of stub type consumption: hovering a symbol imported from a stub
+    /// or py.typed package (one with no local definition) must show its
+    /// signature/type from `imported_symbols`. Before this, hover found no local
+    /// `hit` and rendered nothing for such symbols.
+    #[test]
+    fn test_hover_on_imported_stub_symbol_shows_signature() {
+        use basilisk_resolver::scope::{ExternalSymbol, ExternalSymbolKind};
+        use basilisk_resolver::Span;
+
+        let source = "from acme import fetch\n\nx = fetch('u')\n";
+        let parsed = basilisk_parser::parse_source(source.to_owned(), "test.py".to_owned())
+            .expect("test source should parse");
+        let mut resolved = basilisk_resolver::resolve(&parsed).expect("resolution should not fail");
+
+        let _ = resolved.imported_symbols.insert(
+            "fetch".to_owned(),
+            ExternalSymbol {
+                name: "fetch".to_owned(),
+                kind: ExternalSymbolKind::Function,
+                type_annotation: Some("bytes".to_owned()),
+                source_path: std::path::PathBuf::from("/venv/.../acme-stubs/__init__.pyi"),
+                source_span: Span::new(0, 0),
+                signature: Some("def fetch(url: str) -> bytes".to_owned()),
+                provenance: Some(basilisk_stubs::TypeProvenance::StubTier1),
+            },
+        );
+
+        // Hover on the `fetch` usage in `x = fetch('u')` (not the import line).
+        let offset = source.rfind("fetch").expect("usage present") + 1;
+        let hover = hover_at(&resolved, source, offset, &[]);
+        let hover = hover.expect("hover should be Some for an imported stub symbol");
+        let HoverContents::Markup(markup) = hover.contents else {
+            panic!("expected Markup hover contents");
+        };
+
+        assert!(
+            markup.value.contains("def fetch(url: str) -> bytes"),
+            "hover should show the stub signature: {}",
             markup.value
         );
     }

--- a/crates/basilisk-lsp/src/server/rule_override.rs
+++ b/crates/basilisk-lsp/src/server/rule_override.rs
@@ -89,8 +89,8 @@ mod tests {
     #[test]
     fn insert_when_content_has_no_trailing_newline() {
         let content = "[project]\nname = \"foo\"";
-        let result = insert_rule_override(content, "BSK-W0010", "error");
+        let result = insert_rule_override(content, "BSK-E0152", "warning");
         assert!(result.contains("\n\n[tool.basilisk.rules]\n"));
-        assert!(result.contains("BSK-W0010 = \"error\""));
+        assert!(result.contains("BSK-E0152 = \"warning\""));
     }
 }

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -1673,15 +1673,17 @@ mod tests {
 
     #[test]
     fn config_override_promotes_w0050_to_error_in_lsp() {
-        // The `Error` variant means "keep default severity" — it does NOT promote.
-        // BSK-W0050's default is Warning, so it stays Warning even with RuleSeverity::Error.
+        // `RuleSeverity::Error` promotes a warning-default rule UP to a hard
+        // error, so a project can dial strictness up (e.g. make "no type stubs"
+        // a red error) — not just down. BSK-W0050 defaults to Warning; with the
+        // override it must surface as ERROR through the LSP.
         let idx = make_index_with_rule_override("BSK-W0050", basilisk_config::RuleSeverity::Error);
         let uri = make_uri("/tmp/cfg_promote_w0050.py");
         let lsp_diags = idx.set_open(&uri, SRC_REDUNDANT_ANNOTATION, 1);
         assert_lsp_severity(
             &lsp_diags,
             "BSK-W0050",
-            tower_lsp::lsp_types::DiagnosticSeverity::WARNING,
+            tower_lsp::lsp_types::DiagnosticSeverity::ERROR,
         );
     }
 
@@ -1711,23 +1713,23 @@ mod tests {
     // ── uv_stub_suggestions config ──────────────────────────────────────────
 
     #[test]
-    fn config_uv_stub_suggestions_false_suppresses_w0010() {
-        // BSK-W0010 should be suppressed when uv_stub_suggestions is false.
+    fn config_uv_stub_suggestions_false_suppresses_e0152() {
+        // BSK-E0152 should be suppressed when uv_stub_suggestions is false.
         let config = BasiliskConfig {
             uv_stub_suggestions: false,
             ..Default::default()
         };
         let idx = make_index_with_config(config);
         let uri = make_uri("/tmp/cfg_no_stubs.py");
-        // Even with source that might trigger W0010, the config suppresses it.
+        // Even with source that might trigger E0152, the config suppresses it.
         let src = "import os\n";
         let _ = idx.set_open(&uri, src, 1);
 
         let diags = get_diagnostics(&idx, &uri);
-        let w0010_count = count_code(&diags, "BSK-W0010");
+        let e0152_count = count_code(&diags, "BSK-E0152");
         assert_eq!(
-            w0010_count, 0,
-            "BSK-W0010 should be suppressed when uv_stub_suggestions is false"
+            e0152_count, 0,
+            "BSK-E0152 should be suppressed when uv_stub_suggestions is false"
         );
     }
 

--- a/crates/basilisk-profiler-helper/Cargo.toml
+++ b/crates/basilisk-profiler-helper/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/main.rs"
 [dependencies]
 basilisk-common.workspace = true
 # Shipwright `--version` / `--version --json` contract emitter.
-shipwright          = "0.2"
-shipwright-manifest = "0.2"
+shipwright          = "0.5"
+shipwright-manifest = "0.5"
 py-spy = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/basilisk-profiler-helper/Cargo.toml
+++ b/crates/basilisk-profiler-helper/Cargo.toml
@@ -15,8 +15,8 @@ path = "src/main.rs"
 [dependencies]
 basilisk-common.workspace = true
 # Shipwright `--version` / `--version --json` contract emitter.
-shipwright          = "0.5"
-shipwright-manifest = "0.5"
+shipwright          = "0.5.3"
+shipwright-manifest = "0.5.3"
 py-spy = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/basilisk-stubs/src/lib.rs
+++ b/crates/basilisk-stubs/src/lib.rs
@@ -48,6 +48,27 @@ pub fn typeshed_stub_distribution(module_name: &str) -> Option<&'static str> {
     STUB_DISTRIBUTIONS.get(root).copied()
 }
 
+/// Whether the package containing `resolved_path` ships a PEP 561 `py.typed`
+/// marker (i.e. opts in to inline type distribution).
+///
+/// Walks up from the resolved file looking for a `py.typed` file, stopping at
+/// the `site-packages` boundary — installed packages are its direct children,
+/// so the marker never lives at or above that level. Implements [STUBRES-ENGINE].
+#[must_use]
+pub fn has_py_typed_marker(resolved_path: &std::path::Path) -> bool {
+    let mut dir = resolved_path.parent();
+    while let Some(current) = dir {
+        if current.file_name() == Some(std::ffi::OsStr::new("site-packages")) {
+            return false;
+        }
+        if current.join("py.typed").is_file() {
+            return true;
+        }
+        dir = current.parent();
+    }
+    false
+}
+
 /// Look up the type annotation string for a built-in symbol.
 ///
 /// Returns type information for Python built-in types.

--- a/crates/basilisk-stubs/tests/stubs_tests.rs
+++ b/crates/basilisk-stubs/tests/stubs_tests.rs
@@ -125,7 +125,7 @@ fn lookup_builtin_memoryview_type() {
     );
 }
 
-// Regression for issue #46: BSK-W0010's quick fix must offer the *real*
+// Regression for issue #46: BSK-E0152's quick fix must offer the *real*
 // typeshed distribution name, and nothing when no stub distribution exists.
 
 #[test]

--- a/docs/plans/CHECKER-CROSS-MODULE-PLAN.md
+++ b/docs/plans/CHECKER-CROSS-MODULE-PLAN.md
@@ -45,7 +45,7 @@ See [LSP-UV-INTEGRATION-SPEC.md §LSPUV-DETECT](../specs/LSP-UV-INTEGRATION-SPEC
 
 1. **Zero config**: auto-detect `uv.lock`, `.python-version`, full dependency graph
 2. **Actionable diagnostics**: BSK-E0010 says "run `uv add requests`" with one-click code action
-3. **Stub suggestions**: BSK-W0010 offers `uv add --dev types-requests`
+3. **Stub suggestions**: BSK-E0152 offers `uv add --dev types-requests`
 4. **Hot reload**: `uv.lock` changes picked up via file watcher — no LSP restart
 5. **Workspace support**: uv workspaces map to LSP multi-root with cross-member import resolution
 

--- a/docs/plans/LSP-STUBBING-PLAN.md
+++ b/docs/plans/LSP-STUBBING-PLAN.md
@@ -93,9 +93,9 @@ if !untyped_names.is_empty() && should_suppress_cascade(&diag, &untyped_names, s
 
 Add `pub provenance: Option<TypeProvenance>` field (defaults to `None`). Existing rule code unaffected.
 
-### 2.2 Tag BSK-E0010 and BSK-W0010 with provenance
+### 2.2 Tag BSK-E0010 and BSK-E0152 with provenance
 
-**Files**: `crates/basilisk-checker/src/rules/e0010.rs`, `w0010.rs`
+**Files**: `crates/basilisk-checker/src/rules/e0010.rs`, `e0152.rs`
 
 Set `provenance: Some(TypeProvenance::Untyped)` on emitted diagnostics.
 
@@ -260,7 +260,7 @@ All stub/provenance config via `[tool.basilisk]` — already partially implement
 | `crates/basilisk-checker/src/lib.rs` | Cascade suppression filter in `check_with_config()` |
 | `crates/basilisk-checker/src/diagnostic.rs` | Add `provenance` field to `Diagnostic` |
 | `crates/basilisk-checker/src/rules/e0010.rs` | Tag with provenance |
-| `crates/basilisk-checker/src/rules/w0010.rs` | Tag with provenance |
+| `crates/basilisk-checker/src/rules/e0152.rs` | Tag with provenance |
 | `crates/basilisk-lsp/src/cross_module.rs` | Populate provenance from import resolution |
 | `crates/basilisk-lsp/src/hover.rs` | Provenance + uv metadata in hover |
 | `crates/basilisk-lsp/src/import_resolver.rs` | Add `.basilisk/stubs/` search path |
@@ -274,10 +274,10 @@ All stub/provenance config via `[tool.basilisk]` — already partially implement
 
 1. **Cascade suppression**: Create a Python file that imports an untyped package and uses it extensively. Confirm BSK-E0010 fires once at import, zero downstream errors.
 2. **Provenance hover**: Hover over stdlib import -> "(typeshed)". Hover over untyped import -> "(no type stubs available)".
-3. **Auto-stub generation**: `basilisk stubs generate requests` produces valid `.pyi` in `.basilisk/stubs/`. Re-check shows BSK-E0010 cleared, BSK-W0010 shows "(best-effort stub)".
+3. **Auto-stub generation**: `basilisk stubs generate requests` produces valid `.pyi` in `.basilisk/stubs/`. Re-check shows BSK-E0010 cleared, BSK-E0152 shows "(best-effort stub)".
 4. **Config**: Set `rules."BSK-E0010" = "warning"` in `pyproject.toml`, confirm severity changes.
 5. **uv integration**: In a uv project, confirm hover shows package version and stub status.
-6. **One-click code actions**: BSK-E0010 and BSK-W0010 diagnostics show quick fix code actions. Clicking the quick fix installs the package/stubs automatically. No CLI commands in help text.
+6. **One-click code actions**: BSK-E0010 and BSK-E0152 diagnostics show quick fix code actions. Clicking the quick fix installs the package/stubs automatically. No CLI commands in help text.
 7. **Full CI**: `cargo clippy`, `cargo test`, `cargo fmt --check` all pass.
 
 ---
@@ -300,7 +300,7 @@ All stub/provenance config via `[tool.basilisk]` — already partially implement
 ### Phase 2: Provenance in Hover & Diagnostics ✅ DONE
 - [x] Add `provenance: Option<TypeProvenance>` to `Diagnostic` struct
 - [x] Tag BSK-E0010 diagnostics with `TypeProvenance::Untyped`
-- [x] Tag BSK-W0010 diagnostics with provenance
+- [x] Tag BSK-E0152 diagnostics with provenance
 - [x] Tier-based severity adjustment (Tier3 -> Info) in `check_with_config()`
 - [x] Provenance annotations in hover tooltips
 - [x] uv-enriched hover (package version, stub status) — already done, enhanced with provenance labels
@@ -333,11 +333,11 @@ All stub/provenance config via `[tool.basilisk]` — already partially implement
 ### Phase 4b: Diagnostic Help Text Cleanup ✅ DONE
 - [x] Remove "Run `uv add ...`" CLI instructions from BSK-E0010 help text (`e0010.rs`)
 - [x] Remove "Run `uv sync`" CLI instructions from BSK-E0010 help text
-- [x] Remove "`uv add --dev types-...`" CLI instructions from BSK-W0010 help text
+- [x] Remove "`uv add --dev types-...`" CLI instructions from BSK-E0152 help text
 - [x] Remove "Run `uv lock`" CLI instructions from BSK-W0013 help text
 - [x] Remove "run `uv add --dev pytest`" from pytest-not-found messages (init.rs, test_handlers.rs)
 - [x] Replace with problem descriptions — the code action is the fix, not a CLI command
-- [x] All BSK-E0010/W0010/W0013/W0014 scenarios have corresponding code actions in `code_actions/mod.rs`
+- [x] All BSK-E0010/E0152/W0013/W0014 scenarios have corresponding code actions in `code_actions/mod.rs`
 - [x] Update tests to match new help text
 - [x] All tests passing (18 checker, 57 code action)
 

--- a/docs/specs/CHECKER-STUB-RESOLUTION-SPEC.md
+++ b/docs/specs/CHECKER-STUB-RESOLUTION-SPEC.md
@@ -104,14 +104,14 @@ One diagnostic at the import site is worth more than fifty cascading errors at u
 
 **Principle**: Diagnostics MUST NOT tell users to run CLI commands. The LSP provides one-click code actions that do the work. The user should never leave the editor to fix a missing import.
 
-Every BSK-E0010 and BSK-W0010 diagnostic MUST have an associated code action:
+Every BSK-E0010 and BSK-E0152 diagnostic MUST have an associated code action:
 
 | Diagnostic | Scenario | Code Action | LSP Command |
 |------------|----------|-------------|-------------|
 | BSK-E0010 | Package not installed | "Add dependency: `{pkg}`" | `basilisk.uv.add` |
 | BSK-E0010 | Package not in deps (transitive only) | "Add dependency: `{pkg}`" | `basilisk.uv.add` |
 | BSK-E0010 | Package declared but not synced | "Sync environment" | `basilisk.uv.sync` |
-| BSK-W0010 | Package installed but no type stubs | "Install type stubs: `types-{pkg}`" | `basilisk.uv.addDev` |
+| BSK-E0152 | Package installed but no type stubs | "Install type stubs: `types-{pkg}`" | `basilisk.uv.addDev` |
 
 The code action executes via `workspace/executeCommand`. The LSP spawns `uv` as a subprocess, reports progress via `window/logMessage`, and triggers a full re-resolve on completion — the diagnostic clears automatically.
 

--- a/docs/specs/LSP-ARCHITECTURE-SPEC.md
+++ b/docs/specs/LSP-ARCHITECTURE-SPEC.md
@@ -408,7 +408,7 @@ Validates symbol is renameable, returns `WorkspaceEdit` with `TextEdit` for each
 | (source) | Organize imports | Delegate to `ruff check --select I --fix` |
 
 | BSK-E0010 (uv) | Add dependency | `uv add <package>` via `basilisk.uv.add` command |
-| BSK-W0010 (uv) | Install type stubs | `uv add --dev types-<package>` via `basilisk.uv.addDev` command |
+| BSK-E0152 (uv) | Install type stubs | `uv add --dev types-<package>` via `basilisk.uv.addDev` command |
 | BSK-W0011 (uv) | Add dependency | `uv add <package>` — transitive dep used directly |
 | BSK-W0013 (uv) | Sync environment | `uv sync` via `basilisk.uv.sync` command |
 
@@ -519,7 +519,7 @@ The uv binary is only needed for **commands** (sync, add, remove). Lock file par
 
 | Code | Severity | Default | Gate | Description |
 |------|----------|---------|------|-------------|
-| BSK-W0010 | Warning | Enabled | `uv.stubSuggestions` | Package installed but no type stubs |
+| BSK-E0152 | Error | Enabled | `uv.stubSuggestions` | Package installed but no type stubs (opt down to import untyped libs at your own risk) |
 | BSK-W0011 | Warning | Disabled | `uv.dependencyDiagnostics` | Import of transitive dependency not in `[project.dependencies]` |
 | BSK-W0012 | Info | Disabled | `uv.dependencyDiagnostics` | Declared dependency never imported (whole-module only, skeleton) |
 | BSK-W0013 | Warning | Disabled | `uv.dependencyDiagnostics` | `uv.lock` older than `pyproject.toml` (skeleton) |

--- a/docs/specs/LSP-UV-INTEGRATION-SPEC.md
+++ b/docs/specs/LSP-UV-INTEGRATION-SPEC.md
@@ -179,12 +179,13 @@ With uv integration, BSK-E0010 becomes context-aware:
 | Stdlib module, wrong Python version | `Module "tomllib" requires Python >= 3.11 (project targets 3.10)` | — |
 | Workspace member, not in deps | `Import "my_lib" resolves as workspace member "packages/my_lib"` | — (info, not error) |
 
-### 5.2 Missing Stub Suggestions (BSK-W0010) {#LSPUV-DIAGNOSTICS-MISSING-STUBS}
+### 5.2 Missing Stub Suggestions (BSK-E0152) {#LSPUV-DIAGNOSTICS-MISSING-STUBS}
 
-New warning when a package is installed but has no type information:
+Strict-by-default error when a package is installed but has no type information
+(opt down with `"BSK-E0152" = "warning"` to import untyped libraries at your own risk):
 
 ```
-warning[BSK-W0010]: Package "requests" has no type information
+error[BSK-E0152]: Package "requests" has no type information
   --> src/app.py:3:1
    |
  3 | import requests
@@ -261,7 +262,7 @@ Each workspace member becomes an LSP workspace folder. The LSP server maintains 
 | Trigger | Code Action Title | Command |
 |---------|-------------------|---------|
 | BSK-E0010 (unresolved, package available) | "Add dependency: `requests`" | `basilisk.uv.add` |
-| BSK-W0010 (no stubs) | "Install type stubs: `types-requests`" | `basilisk.uv.addDev` |
+| BSK-E0152 (no stubs) | "Install type stubs: `types-requests`" | `basilisk.uv.addDev` |
 | BSK-W0013 (stale lock) | "Sync environment" | `basilisk.uv.sync` |
 
 ### 7.2 Execution {#LSPUV-ACTIONS-EXECUTION}

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-PLACEHOLDER",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@nimblesite/shipwright-vscode": "^0.2.0",
+        "@nimblesite/shipwright-vscode": "^0.5.3",
         "@preact/signals-core": "^1.14.0",
         "vscode-languageclient": "^9.0.1"
       },
@@ -489,18 +489,18 @@
       }
     },
     "node_modules/@nimblesite/shipwright-core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@nimblesite/shipwright-core/-/shipwright-core-0.2.0.tgz",
-      "integrity": "sha512-G0HYs6XK9ibDRDbKgN+cRqX2F2m/ljx+XhcFP0s6ZA8G5Tm5IMCWZawExBMCrhdpWAv4C/OMNO0RVg6vlWwN7A==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@nimblesite/shipwright-core/-/shipwright-core-0.5.3.tgz",
+      "integrity": "sha512-cKI/GlOj2abIYTO4DO1xQOsE2yPlu6nxW6/T7RyDLSYeB3JGT8vshEN8Pel7jNUpY6JxU2Hyz7B+1CI4sDtIHg==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@nimblesite/shipwright-vscode": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@nimblesite/shipwright-vscode/-/shipwright-vscode-0.2.0.tgz",
-      "integrity": "sha512-zArRRBTsVn0B5C/+Ng5gYHE87DCeNADTcKWYVDQh8efrb4HB+9wfZSv/kONn4240prLguuWlTURJqk3V8LF0BA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@nimblesite/shipwright-vscode/-/shipwright-vscode-0.5.3.tgz",
+      "integrity": "sha512-uHsV8F9QQqS4NP2SsvKnV6YRBix6KuV0npC9ntSjpBpumCz9kqicN4a7nPQeVeCoFlBD7it5Dmz7MBckbn9TRg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@nimblesite/shipwright-core": "0.2.0"
+        "@nimblesite/shipwright-core": "0.5.3"
       },
       "peerDependencies": {
         "vscode": "*"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -721,7 +721,7 @@
     "package": "npm run sync:shipwright && vsce package"
   },
   "dependencies": {
-    "@nimblesite/shipwright-vscode": "^0.2.0",
+    "@nimblesite/shipwright-vscode": "^0.5.3",
     "@preact/signals-core": "^1.14.0",
     "vscode-languageclient": "^9.0.1"
   },

--- a/vscode-extension/src/lsp-client.ts
+++ b/vscode-extension/src/lsp-client.ts
@@ -292,7 +292,12 @@ async function executeCommandMiddleware(
   if (staticToast !== undefined) {
     vscode.window.showInformationMessage(staticToast);
   } else if (pkgCmd !== undefined && args.length > 0) {
-    const pkg = (args[0] as { package: string }).package;
+    // A code action passes the package as a bare string (e.g. ["types-six"]);
+    // the command-palette prompt path passes [{ package: "..." }]. Accept both.
+    const arg = args[0];
+    const pkg = typeof arg === "string"
+      ? arg
+      : (arg as { package?: string } | undefined)?.package;
     const verb = command === "basilisk.uv.remove" ? "Removed" :
       command === "basilisk.uv.addDev" ? "Added dev dependency" : "Added";
     vscode.window.showInformationMessage(`Basilisk: ${verb} ${pkg}.`);

--- a/vscode-extension/src/test/suite/uv-integration.test.ts
+++ b/vscode-extension/src/test/suite/uv-integration.test.ts
@@ -152,7 +152,7 @@ suite('Basilisk uv Integration Tests', () => {
     // Quick-fix success toast names the package (regression)
     // ----------------------------------------------------------------
 
-    // A code action (e.g. the BSK-W0010 "install stubs" fix) invokes
+    // A code action (e.g. the BSK-E0152 "install stubs" fix) invokes
     // basilisk.uv.addDev with a BARE STRING argument, not a `{ package }`
     // object. The success toast must read the package name from either shape;
     // previously it only handled the object form and showed "undefined".

--- a/vscode-extension/src/test/suite/uv-integration.test.ts
+++ b/vscode-extension/src/test/suite/uv-integration.test.ts
@@ -3,11 +3,31 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { getStore } from '../../extension';
+import { createServerCommandHandler } from '../../lsp-client';
 import {
     SUITE_SETUP_TIMEOUT_MS,
     setupLspTestSuite,
     teardownLspTestSuite,
 } from './test-helpers';
+
+/** Run `body`, capturing any `showInformationMessage` toasts, then restore. */
+async function captureInfoToasts(body: () => Promise<unknown>): Promise<string[]> {
+    const messages: string[] = [];
+    const win = vscode.window as {
+        showInformationMessage: typeof vscode.window.showInformationMessage;
+    };
+    const original = win.showInformationMessage;
+    win.showInformationMessage = (async (msg: string) => {
+        messages.push(msg);
+        return undefined;
+    }) as typeof vscode.window.showInformationMessage;
+    try {
+        await body();
+    } finally {
+        win.showInformationMessage = original;
+    }
+    return messages;
+}
 
 suite('Basilisk uv Integration Tests', () => {
     let tmpDir: string;
@@ -125,6 +145,33 @@ suite('Basilisk uv Integration Tests', () => {
             inspected.defaultValue,
             true,
             'Default uv.dependencyDiagnostics should be true'
+        );
+    });
+
+    // ----------------------------------------------------------------
+    // Quick-fix success toast names the package (regression)
+    // ----------------------------------------------------------------
+
+    // A code action (e.g. the BSK-W0010 "install stubs" fix) invokes
+    // basilisk.uv.addDev with a BARE STRING argument, not a `{ package }`
+    // object. The success toast must read the package name from either shape;
+    // previously it only handled the object form and showed "undefined".
+    test('uv.addDev success toast names the package from a bare-string arg', async () => {
+        const fakeClient = {
+            sendRequest: async () => ({ success: true }),
+        } as unknown as Parameters<typeof createServerCommandHandler>[0];
+        const handler = createServerCommandHandler(fakeClient, 'basilisk.uv.addDev');
+
+        // A code action sends the package as a bare string, not { package }.
+        const messages = await captureInfoToasts(async () => handler('types-six'));
+
+        assert.ok(
+            messages.some((m) => m.includes('types-six')),
+            `toast should name the package; got: ${JSON.stringify(messages)}`
+        );
+        assert.ok(
+            !messages.some((m) => m.includes('undefined')),
+            `toast must not say "undefined"; got: ${JSON.stringify(messages)}`
         );
     });
 


### PR DESCRIPTION
## TLDR
Fixes three BSK-E0014 tuple false positives, makes "missing type stubs" a configurable strict-by-default error, wires the CLI to honor project rule-severity config, lands stub consumption + hover, and bumps Shipwright to 0.5.3.

## What Was Added?
- **Homogeneous-tuple assignability** (`types.rs`): new `homogeneous_tuple_elem` helper and a 4-way match so `tuple[X, ...]` (PEP 484 variable-length) accepts literal/fixed-length sources — fixes #45.
- **Bracket-aware dict annotation parsing** (`types_parsing.rs`): `dict[K, V]` now splits args with `split_type_params` (the same splitter `tuple[`/`union[` use) so a nested key type like `tuple[str, str]` isn't severed at its inner comma — fixes #51.
- **Stub consumption**: `cross_module.rs` (`extract_stub_exports`, `extract_py_typed_exports`, populated cross-module symbols) and `hover.rs` (signature/provenance for imported stub symbols); shared `has_py_typed_marker(&Path)` in `basilisk-stubs`.
- New regression tests (see below).

## What Was Changed or Deleted?
- **`BSK-W0010` → `BSK-E0152`** (rule file moved `w0010.rs` → `e0152.rs`): missing type stubs is now a **hard error by default** (`Severity::Warning` → `Severity::Error`), docs URL `warnings/` → `errors/`, spec-id `CHKARCH-DIAG-TYPESAFETY` → `CHKARCH-DIAG`. The code-action matcher, `uv_stub_suggestions` gate, and cascade filter all follow the new code.
- **Severity escalation fixed** (`lib.rs`): `RuleSeverity::Error` was a silent no-op (`=> {}`), so a warning could never be promoted. Both the global and per-path override arms now set `Severity::Error`. Projects can dial strictness *up* or *down*.
- **CLI honors config** (`main.rs`): `process_file` now calls `check_with_config` with the loaded `BasiliskConfig` instead of `check` — `[tool.basilisk.rules]` was previously dropped, so strictness config was ignored in CI.
- **uv toast fix** (`lsp-client.ts`): the success toast reads the package from either a bare-string arg (code-action path) or `{package}` (palette path); previously showed `undefined` for code-action invocations.
- **Conformance threshold 91% → 92%** (135/146); tuples false-positive counts dropped in `conformance_status.csv`.
- **Shipwright 0.2 → 0.5.3** across `basilisk-cli`/`basilisk-profiler-helper` Cargo.toml, `@nimblesite/shipwright-vscode` in `package.json`, version `0.2.0` → `0.5.3`, and lockfiles.

## How Do The Automated Tests Prove It Works?
- `e0014_no_false_positive_on_homogeneous_tuple_str_annotation` — `tuple[str, ...] = (..all strings..)` no longer fires E0014 (#45).
- `e0014_no_false_positive_on_dict_with_tuple_key_annotation` — `dict[tuple[str, str], str] = {..}` no longer fires E0014; genuine dict mismatches (`dict[str,int]={"a":"b"}`) still fire (#51).
- `global_rule_severity_override_promotes_warning_to_error` and `config_override_promotes_w0050_to_error_in_lsp` — a warning-default rule promotes to `Error` via config.
- `collect_and_check_applies_project_rule_severity_override` — the CLI pipeline surfaces a project `"BSK-W0050" = "error"` override as a hard error (exit 1).
- `e0152.rs::defaults_to_error_severity` — missing-stubs defaults to `Severity::Error`.
- `uv-integration.test.ts`: toast names the package from a bare-string arg and never says `undefined`.
- Full suite green locally: 3286 checker tests, 301 VS Code e2e, 96 zed, 31 nvim; all per-crate coverage thresholds met; mutation 90.54% (no regression vs baseline).

## Spec / Doc Changes
- `LSP-ARCHITECTURE-SPEC.md`, `LSP-UV-INTEGRATION-SPEC.md`, `CHECKER-STUB-RESOLUTION-SPEC.md`: `BSK-W0010` → `BSK-E0152`, severity `Warning` → `Error`.
- `LSP-STUBBING-PLAN.md`, `CHECKER-CROSS-MODULE-PLAN.md`: code/path references updated to `BSK-E0152` / `e0152.rs`.

## Breaking Changes
- **Yes.** `BSK-W0010` is renamed to `BSK-E0152` — any suppression or `[tool.basilisk.rules]` entry referencing `BSK-W0010` must be updated.
- **Yes (behavioral).** Missing type stubs now defaults to a **red error** instead of a warning. Projects importing untyped third-party libraries will see errors (failing CI) until they opt down with `[tool.basilisk.rules]` → `"BSK-E0152" = "warning"` (or `"off"`).

Closes #45. Closes #51.
