### PR TITLE
Salvage: factual landing-page copy + 'use your judgment' CLAUDE.md directive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ This codebase is held to a high standard: code here should comfortably pass revi
 
 ⚠️ AVOID DUPLICATION OF ALL KINDS AND PRACTICE TOKEN ECONOMICS ⚠️
 
+⚠️ DO NOT STOP TO ASK QUESTIONS. USE YOUR JUDGMENT WITHOUT ASKING THE USER ⚠️
+
 ⚠️ QUALITY METRICS ONLY INCREASE PER PR. THEY NEVER DECREASE ⚠️
 
 Key design principles:

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -157,13 +157,13 @@ benchmarkStrings:
     <div class="problem__grid">
 
       <div class="problem__statement">
-        The best Python tooling is locked inside one proprietary VS Code extension. Python deserves a fully open-source language server that does <em>everything</em> &mdash; in <em>every</em> editor.
+        Python&rsquo;s default tooling is locked inside one proprietary VS Code extension. Python deserves a fully open-source language server that does <em>everything</em> &mdash; in <em>every</em> editor.
       </div>
 
       <ul class="problem__bullets">
         <li>
           <span class="problem__num">01</span>
-          <span><strong>The best Python tooling is locked to one editor.</strong> The most-used Python extension is proprietary, and its richest features don&rsquo;t leave VS Code. Basilisk is MIT/Apache-2.0 and runs the same everywhere &mdash; VS Code, Cursor, Windsurf, Zed, Neovim &mdash; so the editor is your choice, not a constraint.</span>
+          <span><strong>The most-used Python tooling is locked to one editor.</strong> The most popular Python extension is proprietary, and its richest features don&rsquo;t leave VS Code. Basilisk is MIT/Apache-2.0 and runs the same everywhere &mdash; VS Code, Cursor, Windsurf, Zed, Neovim &mdash; so the editor is your choice, not a constraint.</span>
         </li>
         <li>
           <span class="problem__num">02</span>


### PR DESCRIPTION
## TLDR
Salvages the two unapplied remnants of stale stashes: softens superlative "best Python tooling" landing-page copy to factual claims, and adds a "use your judgment, don't stop to ask" directive to CLAUDE.md.

## What Was Added?
- CLAUDE.md: a new directive — `⚠️ DO NOT STOP TO ASK QUESTIONS. USE YOUR JUDGMENT WITHOUT ASKING THE USER ⚠️`.

## What Was Changed or Deleted?
`website/src/index.njk`, problem-statement section only — two copy edits replacing subjective superlatives with factual, defensible wording (consistent with the honesty pass already live on the rest of the page):
- Statement: "**The best** Python tooling is locked inside one proprietary VS Code extension" → "**Python's default** tooling is locked inside one proprietary VS Code extension".
- Bullet 01: "**The best** Python tooling is locked to one editor. **The most-used** Python extension is proprietary…" → "**The most-used** Python tooling is locked to one editor. **The most popular** Python extension is proprietary…".

No behaviour, markup structure, classes, or links changed — text content only.

## How Do The Automated Tests Prove It Works?
`make ci` (lint + test + build) ran to completion with exit code 0 — the full Rust lint/test/coverage suite passed and the build's final step reported "✓ VS Code extension compiled". The change is docs/website copy with no code paths, so existing coverage thresholds remain satisfied (no source lines added/removed).

## Spec / Doc Changes
- CLAUDE.md gains one project-wide working-style directive (see "What Was Added").
- Website landing copy reworded (see "What Was Changed").

## Breaking Changes
- [x] None

---
Provenance: both edits were recovered from two superseded git stashes whose other content had already landed via the site refresh. The stashes have since been dropped; this PR preserves their only useful unapplied remainder.