### PR TITLE
Eliminate 44 PEP-conformance false positives (170→126), zero regression + FP-ceiling/mutation hardening

### DIFF
--- a/conformance/conformance_status.csv
+++ b/conformance/conformance_status.csv
@@ -25,8 +25,8 @@ BSK-E0014|BSK-E0047|BSK-E0136,callables_subtyping.py,callables,PASS,32,0,24
 BSK-E0014|BSK-E0036|BSK-E0044,classes_classvar.py,classes,PASS,17,0,0
 ,classes_override.py,classes,PASS,0,0,0
 BSK-E0111|BSK-E0128,constructors_call_init.py,constructors,PASS,5,0,0
-BSK-E0013|BSK-E0041,constructors_call_metaclass.py,constructors,PASS,2,0,1
-BSK-E0013|BSK-E0074,constructors_call_new.py,constructors,PASS,2,0,2
+BSK-E0041,constructors_call_metaclass.py,constructors,PASS,2,0,0
+BSK-E0074,constructors_call_new.py,constructors,PASS,2,0,0
 BSK-E0144,constructors_call_type.py,constructors,PASS,8,0,0
 BSK-E0153,constructors_callable.py,constructors,PASS,12,0,0
 ,constructors_consistency.py,constructors,PASS,0,0,0
@@ -52,8 +52,8 @@ BSK-E0115,directives_deprecated.py,directives,PASS,12,0,1
 BSK-E0012|BSK-E0013|BSK-E0041,directives_no_type_check.py,directives,PASS,1,0,0
 BSK-E0033,directives_reveal_type.py,directives,PASS,2,0,0
 BSK-E0014,directives_type_checking.py,directives,PASS,0,0,1
-BSK-E0014,directives_type_ignore.py,directives,PASS,0,0,1
-BSK-E0014,directives_type_ignore_file1.py,directives,PASS,0,0,1
+,directives_type_ignore.py,directives,PASS,0,0,0
+,directives_type_ignore_file1.py,directives,PASS,0,0,0
 BSK-E0014,directives_type_ignore_file2.py,directives,PASS,1,0,0
 BSK-E0150,directives_version_platform.py,directives,PASS,3,0,0
 BSK-E0040,enums_behaviors.py,enums,PASS,1,0,0
@@ -62,7 +62,7 @@ BSK-E0061,enums_expansion.py,enums,PASS,1,0,0
 ,enums_member_names.py,enums,PASS,0,0,0
 BSK-E0066,enums_member_values.py,enums,PASS,2,0,0
 BSK-E0046|BSK-E0067,enums_members.py,enums,PASS,7,0,0
-BSK-E0013|BSK-E0053,exceptions_context_managers.py,exceptions,PASS,0,0,6
+BSK-E0053,exceptions_context_managers.py,exceptions,PASS,0,0,4
 BSK-E0027|BSK-E0047|BSK-E0092|BSK-E0132|BSK-E0134,generics_base_class.py,generics,PASS,7,0,0
 BSK-E0026|BSK-E0027|BSK-E0043|BSK-E0148,generics_basic.py,generics,PASS,13,0,0
 BSK-E0030|BSK-E0091|BSK-E0092|BSK-E0130,generics_defaults.py,generics,PASS,5,0,2
@@ -128,7 +128,7 @@ BSK-E0012|BSK-E0014,specialtypes_none.py,specialtypes,PASS,3,0,1
 BSK-E0065,specialtypes_promotions.py,specialtypes,PASS,1,0,0
 BSK-E0014|BSK-E0015|BSK-E0092|BSK-E0145,specialtypes_type.py,specialtypes,PASS,9,0,2
 BSK-E0014|BSK-E0045|BSK-E0147,tuples_type_compat.py,tuples,PASS,16,0,14
-BSK-E0013|BSK-E0014|BSK-E0049|BSK-E0090,tuples_type_form.py,tuples,PASS,11,0,3
+BSK-E0014|BSK-E0049|BSK-E0090,tuples_type_form.py,tuples,PASS,11,0,1
 BSK-E0049|BSK-E0053,tuples_unpacked.py,tuples,PASS,4,0,3
 BSK-E0037,typeddicts_alt_syntax.py,typeddicts,PASS,4,0,0
 BSK-E0029|BSK-E0032,typeddicts_class_syntax.py,typeddicts,PASS,3,0,0

--- a/conformance/conformance_status.csv
+++ b/conformance/conformance_status.csv
@@ -97,7 +97,7 @@ BSK-E0071,historical_positional.py,historical,PASS,4,0,0
 BSK-E0053|BSK-E0127,literals_interactions.py,literals,PASS,4,0,4
 BSK-E0014|BSK-E0051|BSK-E0109|BSK-E0126|BSK-E0129,literals_literalstring.py,literals,PASS,9,0,0
 BSK-E0014|BSK-E0051|BSK-E0068|BSK-E0117|BSK-E0129|BSK-E0130,literals_parameterizations.py,literals,PASS,17,0,0
-BSK-E0014|BSK-E0129,literals_semantics.py,literals,PASS,4,0,2
+BSK-E0014|BSK-E0129,literals_semantics.py,literals,PASS,4,0,1
 BSK-E0111|BSK-E0116|BSK-E0143,namedtuples_define_class.py,namedtuples,PASS,14,0,2
 BSK-E0041|BSK-E0064,namedtuples_define_functional.py,namedtuples,PASS,9,0,0
 BSK-E0073,namedtuples_type_compat.py,namedtuples,PASS,2,0,0
@@ -129,7 +129,7 @@ BSK-E0065,specialtypes_promotions.py,specialtypes,PASS,1,0,0
 BSK-E0015|BSK-E0092|BSK-E0145,specialtypes_type.py,specialtypes,PASS,9,0,0
 BSK-E0014|BSK-E0045|BSK-E0147,tuples_type_compat.py,tuples,PASS,16,0,2
 BSK-E0014|BSK-E0049|BSK-E0090,tuples_type_form.py,tuples,PASS,11,0,0
-BSK-E0014|BSK-E0049|BSK-E0053,tuples_unpacked.py,tuples,PASS,4,0,4
+BSK-E0049|BSK-E0053,tuples_unpacked.py,tuples,PASS,4,0,3
 BSK-E0037,typeddicts_alt_syntax.py,typeddicts,PASS,4,0,0
 BSK-E0029|BSK-E0032,typeddicts_class_syntax.py,typeddicts,PASS,3,0,0
 BSK-E0014|BSK-E0093|BSK-E0132|BSK-E0141,typeddicts_extra_items.py,typeddicts,FAIL,5,18,10

--- a/conformance/conformance_status.csv
+++ b/conformance/conformance_status.csv
@@ -76,7 +76,7 @@ BSK-E0117|BSK-E0130,generics_scoping.py,generics,PASS,10,0,0
 ,generics_self_advanced.py,generics,PASS,0,0,0
 BSK-E0075,generics_self_attributes.py,generics,PASS,2,0,0
 BSK-E0078,generics_self_basic.py,generics,PASS,3,0,0
-BSK-E0077|BSK-E0099,generics_self_protocols.py,generics,PASS,2,0,1
+BSK-E0077,generics_self_protocols.py,generics,PASS,2,0,0
 BSK-E0078|BSK-E0094,generics_self_usage.py,generics,PASS,10,0,2
 BSK-E0042,generics_syntax_compatibility.py,generics,PASS,2,0,0
 BSK-E0043|BSK-E0089|BSK-E0105,generics_syntax_declarations.py,generics,PASS,10,0,0
@@ -96,7 +96,7 @@ BSK-E0130,generics_variance_inference.py,generics,PASS,23,0,0
 BSK-E0071,historical_positional.py,historical,PASS,4,0,0
 BSK-E0053|BSK-E0127,literals_interactions.py,literals,PASS,4,0,4
 BSK-E0014|BSK-E0051|BSK-E0109|BSK-E0126|BSK-E0129,literals_literalstring.py,literals,PASS,9,0,0
-BSK-E0014|BSK-E0051|BSK-E0068|BSK-E0117|BSK-E0129|BSK-E0130,literals_parameterizations.py,literals,PASS,17,0,1
+BSK-E0014|BSK-E0051|BSK-E0068|BSK-E0117|BSK-E0129|BSK-E0130,literals_parameterizations.py,literals,PASS,17,0,0
 BSK-E0014|BSK-E0129,literals_semantics.py,literals,PASS,4,0,2
 BSK-E0111|BSK-E0116|BSK-E0143,namedtuples_define_class.py,namedtuples,PASS,14,0,2
 BSK-E0041|BSK-E0064,namedtuples_define_functional.py,namedtuples,PASS,9,0,0
@@ -122,13 +122,13 @@ BSK-E0110|BSK-E0133,protocols_variance.py,protocols,PASS,5,0,0
 BSK-E0045|BSK-E0058,qualifiers_annotated.py,qualifiers,PASS,20,0,0
 BSK-E0014|BSK-E0041|BSK-E0044|BSK-E0054|BSK-E0064,qualifiers_final_annotation.py,qualifiers,PASS,26,0,0
 BSK-E0034,qualifiers_final_decorator.py,qualifiers,PASS,3,0,0
-BSK-E0014,specialtypes_any.py,specialtypes,PASS,0,0,2
+,specialtypes_any.py,specialtypes,PASS,0,0,0
 BSK-E0062|BSK-E0070,specialtypes_never.py,specialtypes,PASS,3,0,0
-BSK-E0012|BSK-E0014,specialtypes_none.py,specialtypes,PASS,3,0,1
+BSK-E0012|BSK-E0014,specialtypes_none.py,specialtypes,PASS,3,0,0
 BSK-E0065,specialtypes_promotions.py,specialtypes,PASS,1,0,0
-BSK-E0014|BSK-E0015|BSK-E0092|BSK-E0145,specialtypes_type.py,specialtypes,PASS,9,0,2
-BSK-E0014|BSK-E0045|BSK-E0147,tuples_type_compat.py,tuples,PASS,16,0,14
-BSK-E0014|BSK-E0049|BSK-E0090,tuples_type_form.py,tuples,PASS,11,0,1
+BSK-E0015|BSK-E0092|BSK-E0145,specialtypes_type.py,specialtypes,PASS,9,0,0
+BSK-E0014|BSK-E0045|BSK-E0147,tuples_type_compat.py,tuples,PASS,16,0,11
+BSK-E0014|BSK-E0049|BSK-E0090,tuples_type_form.py,tuples,PASS,11,0,0
 BSK-E0049|BSK-E0053,tuples_unpacked.py,tuples,PASS,4,0,3
 BSK-E0037,typeddicts_alt_syntax.py,typeddicts,PASS,4,0,0
 BSK-E0029|BSK-E0032,typeddicts_class_syntax.py,typeddicts,PASS,3,0,0

--- a/conformance/conformance_status.csv
+++ b/conformance/conformance_status.csv
@@ -9,7 +9,7 @@ basilisk_rules,file,category,status,caught,missed,false_positives
 BSK-E0048,aliases_explicit.py,aliases,PASS,21,0,0
 BSK-E0047|BSK-E0048|BSK-E0092,aliases_implicit.py,aliases,PASS,22,0,1
 BSK-E0014|BSK-E0050,aliases_newtype.py,aliases,PASS,14,0,0
-BSK-E0014|BSK-E0104,aliases_recursive.py,aliases,PASS,11,0,18
+BSK-E0014|BSK-E0104,aliases_recursive.py,aliases,PASS,11,0,4
 BSK-E0057|BSK-E0149,aliases_type_statement.py,aliases,PASS,24,0,0
 BSK-E0014|BSK-E0130|BSK-E0151,aliases_typealiastype.py,aliases,PASS,22,0,3
 BSK-E0107,aliases_variance.py,aliases,PASS,4,0,0
@@ -127,9 +127,9 @@ BSK-E0062|BSK-E0070,specialtypes_never.py,specialtypes,PASS,3,0,0
 BSK-E0012|BSK-E0014,specialtypes_none.py,specialtypes,PASS,3,0,0
 BSK-E0065,specialtypes_promotions.py,specialtypes,PASS,1,0,0
 BSK-E0015|BSK-E0092|BSK-E0145,specialtypes_type.py,specialtypes,PASS,9,0,0
-BSK-E0014|BSK-E0045|BSK-E0147,tuples_type_compat.py,tuples,PASS,16,0,11
+BSK-E0014|BSK-E0045|BSK-E0147,tuples_type_compat.py,tuples,PASS,16,0,2
 BSK-E0014|BSK-E0049|BSK-E0090,tuples_type_form.py,tuples,PASS,11,0,0
-BSK-E0049|BSK-E0053,tuples_unpacked.py,tuples,PASS,4,0,3
+BSK-E0014|BSK-E0049|BSK-E0053,tuples_unpacked.py,tuples,PASS,4,0,4
 BSK-E0037,typeddicts_alt_syntax.py,typeddicts,PASS,4,0,0
 BSK-E0029|BSK-E0032,typeddicts_class_syntax.py,typeddicts,PASS,3,0,0
 BSK-E0014|BSK-E0093|BSK-E0132|BSK-E0141,typeddicts_extra_items.py,typeddicts,FAIL,5,18,10

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -43,7 +43,7 @@
   "conformance": {
     "_doc": "Minimum PEP conformance pass percentage (files passing / total files). Ratchet UP only. Current: 136/146 = 93.15% (pinned to python/typing@268d0c4e). 10 files still fail (missed required diagnostics): dataclasses_transform_converter, generics_defaults_specialization, generics_paramspec_components, generics_paramspec_semantics, generics_paramspec_specialization, generics_typevartuple_args, generics_typevartuple_basic, protocols_definition, typeddicts_extra_items, typeddicts_readonly_inheritance.",
     "threshold": 93,
-    "_fp_ceiling_doc": "Maximum total false positives across the suite (diagnostics on lines without a # E annotation). Ratchet DOWN only — the mirror of the pass-percentage gate. Enforced by conformance_tests.rs. Current measured: 161.",
-    "max_false_positives": 161
+    "_fp_ceiling_doc": "Maximum total false positives across the suite (diagnostics on lines without a # E annotation). Ratchet DOWN only — the mirror of the pass-percentage gate. Enforced by conformance_tests.rs. Any change that reintroduces even one FP pushes the total above this ceiling and fails CI. Current measured: 126.",
+    "max_false_positives": 126
   }
 }

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -42,6 +42,8 @@
   },
   "conformance": {
     "_doc": "Minimum PEP conformance pass percentage (files passing / total files). Ratchet UP only. Current: 136/146 = 93.15% (pinned to python/typing@268d0c4e). 10 files still fail (missed required diagnostics): dataclasses_transform_converter, generics_defaults_specialization, generics_paramspec_components, generics_paramspec_semantics, generics_paramspec_specialization, generics_typevartuple_args, generics_typevartuple_basic, protocols_definition, typeddicts_extra_items, typeddicts_readonly_inheritance.",
-    "threshold": 93
+    "threshold": 93,
+    "_fp_ceiling_doc": "Maximum total false positives across the suite (diagnostics on lines without a # E annotation). Ratchet DOWN only — the mirror of the pass-percentage gate. Enforced by conformance_tests.rs. Current measured: 161.",
+    "max_false_positives": 161
   }
 }

--- a/crates/basilisk-checker/src/rules/e0013.rs
+++ b/crates/basilisk-checker/src/rules/e0013.rs
@@ -32,6 +32,44 @@ impl Rule for ReturnTypeMismatch {
     }
 }
 
+/// Returns true when E0013 cannot reliably verify a return against `ty` — at the
+/// top level or nested inside a union, container, optional, callable, or type-form.
+///
+/// Two kinds defeat E0013's value-less return inference:
+/// - `Named`: protocols/classes/aliases (and quote-mangled forward references)
+///   need class-hierarchy/structural analysis E0013 cannot perform.
+/// - `Literal`: verifying a `Literal[v]` target requires the *value* of the
+///   returned expression, but `infer_rhs` only knows the kind (`return True`
+///   infers `Bool`, not `Literal[True]`). Any `Literal`-target check is therefore
+///   unreliable, so it is skipped.
+///
+/// See `check_function` for the rationale.
+fn is_unverifiable_return_type(ty: &InferredType) -> bool {
+    match ty {
+        InferredType::Named(_) | InferredType::Literal(_) => true,
+        InferredType::Optional(inner)
+        | InferredType::List(inner)
+        | InferredType::Set(inner)
+        | InferredType::TypeForm(inner) => is_unverifiable_return_type(inner),
+        InferredType::Dict(key, value) => {
+            is_unverifiable_return_type(key) || is_unverifiable_return_type(value)
+        }
+        InferredType::Union(types) => types.iter().any(is_unverifiable_return_type),
+        // The variable-length form `tuple[X, ...]` parses the `...` terminator to
+        // `Named("...")`; that is a structural marker handled by `is_assignable_to`,
+        // not an unresolvable type, so it must not trigger the skip.
+        InferredType::Tuple(types) => types.iter().any(|elem| {
+            !matches!(elem, InferredType::Named(name) if name == "...")
+                && is_unverifiable_return_type(elem)
+        }),
+        InferredType::Callable(info) => {
+            is_unverifiable_return_type(&info.return_type)
+                || info.param_types.iter().any(is_unverifiable_return_type)
+        }
+        _ => false,
+    }
+}
+
 fn check_function(func: &FunctionInfo, module: &ResolvedModule, out: &mut Vec<Diagnostic>) {
     // Generator functions have their own return type validation (E0120).
     // Return values in generators go through Generator[Y, S, R]'s ReturnType,
@@ -55,7 +93,15 @@ fn check_function(func: &FunctionInfo, module: &ResolvedModule, out: &mut Vec<Di
     // analysis that E0013 cannot perform.  A concrete return like `list[int]`
     // IS assignable to `Sequence[float]` at runtime, but `InferredType` has no
     // knowledge of the class hierarchy.  Skip the check to avoid FPs.
-    if matches!(declared_type, InferredType::Named(_)) {
+    //
+    // This applies recursively: a union or container that *contains* a Named or
+    // Literal type is equally unverifiable. Quoted forward references such as
+    // `"int | Meta2"` parse (after `|`-splitting) into a union of `Named`
+    // fragments with no concrete member, so a valid `return 1` would otherwise
+    // be flagged. Empty-tuple forms like `tuple[()]` parse the `()` to
+    // `Named("()")`. `Literal[...]` targets need the returned value, which the
+    // kind-only return inference does not have. All are skipped.
+    if is_unverifiable_return_type(&declared_type) {
         return;
     }
 

--- a/crates/basilisk-checker/src/rules/e0014/alias_match.rs
+++ b/crates/basilisk-checker/src/rules/e0014/alias_match.rs
@@ -1,0 +1,203 @@
+//! Implements [BSK-E0014] from [CHKARCH-DIAG-TYPESAFETY]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#chkarch-diag-typesafety
+//! Recursive type-alias value matching for BSK-E0014.
+//!
+//! Legacy type aliases such as
+//!
+//! ```python
+//! Json = Union[None, int, str, float, list["Json"], dict[str, "Json"]]
+//! j1: Json = [1, {"a": 1}]   # OK
+//! j4: Json = {"a": 1, "b": 3j}  # E: complex is not a Json value
+//! ```
+//!
+//! cannot be validated by the plain `is_assignable_to` check because the
+//! annotation is a `Named` reference and the right-hand side is a literal
+//! structure. This module resolves a bare alias name to its (possibly
+//! recursive) definition and verifies whether the inferred RHS literal type
+//! *positively* matches it.
+//!
+//! **Positive-match semantics.** A value matches only when every part is
+//! demonstrably compatible. `Unknown`/`Any` values do **not** positively match a
+//! concrete target (the checker cannot prove compatibility), so genuinely
+//! incompatible assignments keep firing — this preserves the true positives that
+//! the recursive-alias fixtures expect.
+
+use std::collections::HashMap;
+
+use crate::span_util::slice_span;
+use crate::types::InferredType;
+use basilisk_resolver::{ResolvedModule, VariableInfo};
+
+/// Maximum alias-expansion depth — a safety bound for self-referential aliases.
+const MAX_DEPTH: u32 = 24;
+
+/// Collect module-level value-style type aliases whose definition is a `Union`.
+///
+/// These are legacy aliases written as `Name = Union[...]` or `Name = a | b | …`
+/// (no annotation). Restricting to `Union` definitions deliberately excludes
+/// generic (`list[...]`-bodied) aliases that would need TypeVar substitution.
+pub(super) fn collect_union_aliases(module: &ResolvedModule) -> HashMap<String, InferredType> {
+    let mut aliases = HashMap::new();
+    for var in &module.module_vars {
+        if var.has_annotation {
+            continue;
+        }
+        let Some(def) = alias_definition(var, &module.source) else {
+            continue;
+        };
+        if matches!(def, InferredType::Union(_)) {
+            let _ = aliases.insert(var.name.to_ascii_lowercase(), def);
+        }
+    }
+    aliases
+}
+
+/// Parse a variable's RHS source text into the alias definition type.
+fn alias_definition(var: &VariableInfo, source: &str) -> Option<InferredType> {
+    let rhs_span = var.rhs_span?;
+    let rhs_text = slice_span(source, rhs_span)?.trim();
+    if rhs_text.is_empty() {
+        return None;
+    }
+    Some(InferredType::from_annotation(rhs_text))
+}
+
+/// Returns `true` when `value` positively matches the (possibly recursive)
+/// alias `target`. See the module docs for the positive-match contract.
+pub(super) fn alias_assignable(
+    value: &InferredType,
+    target: &InferredType,
+    aliases: &HashMap<String, InferredType>,
+    depth: u32,
+) -> bool {
+    if depth > MAX_DEPTH {
+        return false;
+    }
+
+    // `Never` is the empty type (e.g. an empty list/dict literal element) and
+    // vacuously matches any target.
+    if matches!(value, InferredType::Never) {
+        return true;
+    }
+
+    // A union value matches only when every member matches the target.
+    if let InferredType::Union(members) = value {
+        return members
+            .iter()
+            .all(|member| alias_assignable(member, target, aliases, depth + 1));
+    }
+
+    match target {
+        InferredType::Named(name) => match_named_target(value, name, aliases, depth),
+        InferredType::Union(branches) => branches
+            .iter()
+            .any(|branch| alias_assignable(value, branch, aliases, depth + 1)),
+        InferredType::List(elem) => match value {
+            InferredType::List(v) => alias_assignable(v, elem, aliases, depth + 1),
+            _ => false,
+        },
+        InferredType::Set(elem) => match value {
+            InferredType::Set(v) => alias_assignable(v, elem, aliases, depth + 1),
+            _ => false,
+        },
+        InferredType::Dict(key, val) => match value {
+            InferredType::Dict(vkey, vval) => {
+                alias_assignable(vkey, key, aliases, depth + 1)
+                    && alias_assignable(vval, val, aliases, depth + 1)
+            }
+            _ => false,
+        },
+        InferredType::Tuple(target_elems) => match_tuple_target(value, target_elems, aliases, depth),
+        InferredType::Any => true,
+        _ => positive_base_match(value, target),
+    }
+}
+
+/// Match a value against a `Named` target, resolving alias references and the
+/// `Mapping[K, V]` ABC (which the parser leaves as a `Named`).
+fn match_named_target(
+    value: &InferredType,
+    name: &str,
+    aliases: &HashMap<String, InferredType>,
+    depth: u32,
+) -> bool {
+    // `Mapping[K, V]` arrives as a Named; treat it structurally like a dict.
+    if let Some(dict) = parse_mapping_named(name) {
+        return alias_assignable(value, &dict, aliases, depth + 1);
+    }
+
+    let base = alias_base(name);
+    if let Some(def) = aliases.get(base) {
+        return alias_assignable(value, def, aliases, depth + 1);
+    }
+
+    // A non-alias class name: a value positively matches only when it is the
+    // same named type (by base name).
+    match value {
+        InferredType::Named(value_name) => alias_base(value_name) == base,
+        _ => false,
+    }
+}
+
+/// Match a value against a tuple target, handling the homogeneous
+/// `tuple[X, ...]` form (the parser stores the `...` terminator as `Named`).
+fn match_tuple_target(
+    value: &InferredType,
+    target_elems: &[InferredType],
+    aliases: &HashMap<String, InferredType>,
+    depth: u32,
+) -> bool {
+    let InferredType::Tuple(value_elems) = value else {
+        return false;
+    };
+    if let [elem, InferredType::Named(terminator)] = target_elems {
+        if terminator == "..." {
+            return value_elems
+                .iter()
+                .all(|ve| alias_assignable(ve, elem, aliases, depth + 1));
+        }
+    }
+    value_elems.len() == target_elems.len()
+        && value_elems
+            .iter()
+            .zip(target_elems.iter())
+            .all(|(ve, te)| alias_assignable(ve, te, aliases, depth + 1))
+}
+
+/// Positive structural match for primitive base types. Notably `Unknown`/`Any`
+/// values do NOT match a concrete base type — the checker cannot prove it.
+fn positive_base_match(value: &InferredType, target: &InferredType) -> bool {
+    use InferredType::{Bool, Bytes, Float, Int, Literal, LiteralString, None_, Str};
+    use crate::types::LiteralValue;
+    match target {
+        Int => matches!(value, Int | Bool | Literal(LiteralValue::Int(_) | LiteralValue::Bool(_))),
+        Float => matches!(
+            value,
+            Float | Int | Bool | Literal(LiteralValue::Float(_) | LiteralValue::Int(_))
+        ),
+        Str => matches!(value, Str | LiteralString | Literal(LiteralValue::Str(_))),
+        Bool => matches!(value, Bool | Literal(LiteralValue::Bool(_))),
+        Bytes => matches!(value, Bytes | Literal(LiteralValue::Bytes(_))),
+        None_ => matches!(value, None_),
+        _ => value == target,
+    }
+}
+
+/// Extract the alias-lookup base from a `Named` text: strip surrounding quotes
+/// and any `[...]` subscript, returning the bare lowercase name.
+fn alias_base(name: &str) -> &str {
+    let trimmed = name.trim_matches(|c| c == '"' || c == '\'');
+    trimmed.split('[').next().unwrap_or(trimmed).trim()
+}
+
+/// Parse a `mapping[K, V]` Named into a `Dict(K, V)` so it can be matched
+/// structurally against a dict literal value.
+fn parse_mapping_named(name: &str) -> Option<InferredType> {
+    let inner = name.strip_prefix("mapping[")?.strip_suffix(']')?;
+    let parts = crate::types_parsing::split_type_params(inner);
+    if parts.len() != 2 {
+        return None;
+    }
+    let key = InferredType::from_annotation(parts.first().map_or("", |s| s.trim()));
+    let val = InferredType::from_annotation(parts.get(1).map_or("", |s| s.trim()));
+    Some(InferredType::Dict(Box::new(key), Box::new(val)))
+}

--- a/crates/basilisk-checker/src/rules/e0014/alias_match.rs
+++ b/crates/basilisk-checker/src/rules/e0014/alias_match.rs
@@ -34,7 +34,7 @@ const MAX_DEPTH: u32 = 24;
 ///
 /// These are legacy aliases written as `Name = Union[...]` or `Name = a | b | …`
 /// (no annotation). Restricting to `Union` definitions deliberately excludes
-/// generic (`list[...]`-bodied) aliases that would need TypeVar substitution.
+/// generic (`list[...]`-bodied) aliases that would need `TypeVar` substitution.
 pub(super) fn collect_union_aliases(module: &ResolvedModule) -> HashMap<String, InferredType> {
     let mut aliases = HashMap::new();
     for var in &module.module_vars {
@@ -100,13 +100,15 @@ pub(super) fn alias_assignable(
             _ => false,
         },
         InferredType::Dict(key, val) => match value {
-            InferredType::Dict(vkey, vval) => {
-                alias_assignable(vkey, key, aliases, depth + 1)
-                    && alias_assignable(vval, val, aliases, depth + 1)
+            InferredType::Dict(value_key, value_val) => {
+                alias_assignable(value_key, key, aliases, depth + 1)
+                    && alias_assignable(value_val, val, aliases, depth + 1)
             }
             _ => false,
         },
-        InferredType::Tuple(target_elems) => match_tuple_target(value, target_elems, aliases, depth),
+        InferredType::Tuple(target_elems) => {
+            match_tuple_target(value, target_elems, aliases, depth)
+        }
         InferredType::Any => true,
         _ => positive_base_match(value, target),
     }
@@ -166,10 +168,13 @@ fn match_tuple_target(
 /// Positive structural match for primitive base types. Notably `Unknown`/`Any`
 /// values do NOT match a concrete base type — the checker cannot prove it.
 fn positive_base_match(value: &InferredType, target: &InferredType) -> bool {
-    use InferredType::{Bool, Bytes, Float, Int, Literal, LiteralString, None_, Str};
     use crate::types::LiteralValue;
+    use InferredType::{Bool, Bytes, Float, Int, Literal, LiteralString, None_, Str};
     match target {
-        Int => matches!(value, Int | Bool | Literal(LiteralValue::Int(_) | LiteralValue::Bool(_))),
+        Int => matches!(
+            value,
+            Int | Bool | Literal(LiteralValue::Int(_) | LiteralValue::Bool(_))
+        ),
         Float => matches!(
             value,
             Float | Int | Bool | Literal(LiteralValue::Float(_) | LiteralValue::Int(_))
@@ -193,11 +198,6 @@ fn alias_base(name: &str) -> &str {
 /// structurally against a dict literal value.
 fn parse_mapping_named(name: &str) -> Option<InferredType> {
     let inner = name.strip_prefix("mapping[")?.strip_suffix(']')?;
-    let parts = crate::types_parsing::split_type_params(inner);
-    if parts.len() != 2 {
-        return None;
-    }
-    let key = InferredType::from_annotation(parts.first().map_or("", |s| s.trim()));
-    let val = InferredType::from_annotation(parts.get(1).map_or("", |s| s.trim()));
+    let (key, val) = crate::types_parsing::parse_key_value_args(inner)?;
     Some(InferredType::Dict(Box::new(key), Box::new(val)))
 }

--- a/crates/basilisk-checker/src/rules/e0014/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0014/mod.rs
@@ -226,7 +226,12 @@ fn check_vars(
                         ) {
                             None
                         } else {
-                            Some((var, annotation_text.to_owned(), inferred_type, declared_type))
+                            Some((
+                                var,
+                                annotation_text.to_owned(),
+                                inferred_type,
+                                declared_type,
+                            ))
                         };
                     }
                 }

--- a/crates/basilisk-checker/src/rules/e0014/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0014/mod.rs
@@ -129,6 +129,13 @@ fn check_vars(
         .filter(|var| var.has_annotation && var.rhs_span.is_some())
         .filter_map(|var| {
             let annotation_text = extract_annotation(source, var.name_span)?;
+
+            // Quoted forward-reference annotations (e.g. `"Literal[Color.RED]"`)
+            // are not evaluated as value types here; skip to avoid false positives.
+            if annotation_text.starts_with('"') || annotation_text.starts_with('\'') {
+                return None;
+            }
+
             let declared_type = InferredType::from_annotation(annotation_text);
 
             // TypeForm assignments require type-expression validation, not

--- a/crates/basilisk-checker/src/rules/e0014/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0014/mod.rs
@@ -13,6 +13,7 @@
 //! The check is performed by extracting the annotation text from the source
 //! around the variable's name span and comparing it against the RHS kind.
 
+mod alias_match;
 mod dataclass_check;
 mod literal_parse;
 mod tuple_check;
@@ -45,6 +46,7 @@ impl Rule for AssignmentTypeMismatch {
         let skip = SkipNames {
             typeddict: collect_typeddict_names(module),
             type_alias: collect_type_alias_names(module),
+            value_aliases: alias_match::collect_union_aliases(module),
         };
         check_vars(
             &module.module_vars,
@@ -108,6 +110,9 @@ struct SkipNames {
     typeddict: std::collections::HashSet<String>,
     /// PEP 695 type alias names (lowercase).
     type_alias: std::collections::HashSet<String>,
+    /// Legacy `Name = Union[...]` value aliases (lowercase → definition), used
+    /// for recursive-alias value matching.
+    value_aliases: std::collections::HashMap<String, InferredType>,
 }
 
 /// Check a slice of annotated variables for type mismatches.
@@ -203,6 +208,26 @@ fn check_vars(
                         if let Some(param_type) = param_types.get(rhs_name) {
                             inferred_type = param_type.clone();
                         }
+                    }
+                }
+            }
+
+            // A bare reference to a legacy `Union` alias (e.g. a recursive
+            // `Json` alias) needs value-level matching against the expanded
+            // definition rather than the `Named`-vs-literal comparison below.
+            if let InferredType::Named(ref name) = declared_type {
+                if !name.contains('[') {
+                    if let Some(def) = skip.value_aliases.get(name.as_str()) {
+                        return if alias_match::alias_assignable(
+                            &inferred_type,
+                            def,
+                            &skip.value_aliases,
+                            0,
+                        ) {
+                            None
+                        } else {
+                            Some((var, annotation_text.to_owned(), inferred_type, declared_type))
+                        };
                     }
                 }
             }

--- a/crates/basilisk-checker/src/suppression.rs
+++ b/crates/basilisk-checker/src/suppression.rs
@@ -47,9 +47,27 @@ pub fn parse_source_overrides(source: &str) -> SourceOverrides {
     let mut line_overrides = Vec::new();
     let mut block_starts: Vec<(usize, LineOverride)> = Vec::new();
     let mut block_overrides = Vec::new();
+    // Whether a docstring, import, or executable statement has been seen yet.
+    // A file-level `# type: ignore` is only valid before any such line.
+    let mut seen_substantial = false;
 
     for (line_idx, line) in source.lines().enumerate() {
         let trimmed = line.trim();
+
+        // File-level `# type: ignore` (PEP 484): a standalone `# type: ignore`
+        // on its own line, before any docstring/import/executable code, silences
+        // all errors in the file. Only blank lines and comments (shebang lines,
+        // coding cookies) may precede it.
+        if file_mode.is_none() && trimmed == "# type: ignore" && !seen_substantial {
+            file_mode = Some(FileOverride::Specific {
+                mode: RuleMode::Ignore,
+                codes: Vec::new(),
+            });
+            continue;
+        }
+        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+            seen_substantial = true;
+        }
 
         // File-level directives (must be standalone comment lines).
         if trimmed == "# basilisk: relaxed" {
@@ -100,12 +118,11 @@ pub fn parse_source_overrides(source: &str) -> SourceOverrides {
         // Per-line directives: `# type: ignore`, `# type: warning[CODE]`, etc.
         // These appear at the end of a line with code.
         if let Some(rest) = find_comment_directive(line, "# type: ignore") {
-            let codes = parse_bracketed_codes(rest);
             line_overrides.push((
                 line_idx,
                 LineOverride {
                     mode: RuleMode::Ignore,
-                    codes,
+                    codes: parse_ignore_codes(rest),
                 },
             ));
         } else if let Some(rest) = find_comment_directive(line, "# type: disabled") {
@@ -228,6 +245,23 @@ fn find_comment_directive<'a>(line: &'a str, directive: &str) -> Option<&'a str>
         .map(|pos| &line[pos + directive.len()..])
 }
 
+/// Parse the code list for a `# type: ignore[...]` directive.
+///
+/// Per the typing spec, a `# type: ignore` comment silences *all* errors on the
+/// line; any bracketed content is type-checker-specific. Basilisk honours
+/// code-specific suppression only when every bracketed token is a Basilisk code
+/// (`BSK-…`). Any other content — mypy's `# type: ignore[assignment]`, an
+/// arbitrary tag, or no brackets at all — suppresses every error on the line, as
+/// the spec requires. (`Vec::new()` means "all rules" in `override_matches`.)
+fn parse_ignore_codes(rest: &str) -> Vec<String> {
+    let codes = parse_bracketed_codes(rest);
+    if codes.iter().all(|code| code.starts_with("BSK-")) {
+        codes
+    } else {
+        Vec::new()
+    }
+}
+
 /// Parse bracketed codes like `[BSK-E0010, BSK-E0011]` from the start of a string.
 fn parse_bracketed_codes(rest: &str) -> Vec<String> {
     let rest = rest.trim();
@@ -337,6 +371,64 @@ mod tests {
         assert_eq!(overrides.line_overrides.len(), 1);
         assert_eq!(overrides.line_overrides[0].1.mode, RuleMode::Info);
         assert!(overrides.line_overrides[0].1.codes.is_empty());
+    }
+
+    #[test]
+    fn test_type_ignore_non_basilisk_bracket_suppresses_all() {
+        // PEP 484: `# type: ignore[<anything>]` silences all errors on the line.
+        // A non-Basilisk tag must not be treated as a code-specific filter.
+        let source = "z: int = \"\"  # type: ignore[additional_stuff]\n";
+        let overrides = parse_source_overrides(source);
+        assert_eq!(overrides.line_overrides.len(), 1);
+        assert_eq!(overrides.line_overrides[0].1.mode, RuleMode::Ignore);
+        assert!(
+            overrides.line_overrides[0].1.codes.is_empty(),
+            "non-Basilisk bracket content must suppress all rules"
+        );
+        // And it actually suppresses an arbitrary diagnostic code.
+        assert!(override_matches(
+            "BSK-E0014",
+            &overrides.line_overrides[0].1.codes
+        ));
+    }
+
+    #[test]
+    fn test_type_ignore_basilisk_bracket_stays_code_specific() {
+        let source = "x = foo()  # type: ignore[BSK-E0010]\n";
+        let overrides = parse_source_overrides(source);
+        assert_eq!(overrides.line_overrides[0].1.codes, vec!["BSK-E0010"]);
+        assert!(!override_matches(
+            "BSK-E0014",
+            &overrides.line_overrides[0].1.codes
+        ));
+    }
+
+    #[test]
+    fn test_file_level_type_ignore_before_docstring() {
+        // A standalone `# type: ignore` after only a shebang and blank line, before
+        // the docstring, silences the whole file.
+        let source =
+            "#!/usr/bin/env python\n\n# type: ignore\n\n\"\"\"Doc.\"\"\"\n\nx: int = \"\"\n";
+        let overrides = parse_source_overrides(source);
+        match &overrides.file_mode {
+            Some(FileOverride::Specific { mode, codes }) => {
+                assert_eq!(*mode, RuleMode::Ignore);
+                assert!(codes.is_empty());
+            }
+            other => panic!("Expected file-level Ignore, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_type_ignore_after_code_is_not_file_level() {
+        // The same comment after a docstring/code is NOT file-level (it must still
+        // report errors elsewhere in the file).
+        let source = "\"\"\"Doc.\"\"\"\n\n# type: ignore\n\nx: int = \"\"\n";
+        let overrides = parse_source_overrides(source);
+        assert!(
+            overrides.file_mode.is_none(),
+            "comment after the docstring must not become a file-level directive"
+        );
     }
 
     #[test]

--- a/crates/basilisk-checker/src/types.rs
+++ b/crates/basilisk-checker/src/types.rs
@@ -233,6 +233,9 @@ impl InferredType {
             )
             // None is always assignable to Optional[T]
             | (InferredType::None_, InferredType::Optional(_)) => true,
+            // `None` satisfies `Hashable` (it defines `__hash__`). The annotation
+            // parser lowercases names, so the ABC arrives as `Named("hashable")`.
+            (InferredType::None_, InferredType::Named(name)) if name == "hashable" => true,
             // Optional types are assignable to their non-optional counterparts
             (InferredType::Optional(inner), other) => inner.is_assignable_to(other),
             (inner, InferredType::Optional(other)) => inner.is_assignable_to(other),
@@ -254,8 +257,13 @@ impl InferredType {
                     // Target `tuple[X, ...]`: every element of a fixed-length source
                     // tuple must be assignable to `X` (empty tuple is vacuously valid).
                     (None, Some(b_elem)) => a.iter().all(|elem| elem.is_assignable_to(b_elem)),
-                    // Target is fixed-length: a variable-length source cannot satisfy it.
-                    (Some(_), None) => false,
+                    // Target is fixed-length: a variable-length source cannot
+                    // satisfy it — EXCEPT `tuple[Any, ...]` / `tuple[Unknown, ...]`,
+                    // which are bidirectionally compatible with any tuple (PEP 484
+                    // gradual typing).
+                    (Some(source_elem), None) => {
+                        matches!(source_elem, InferredType::Any | InferredType::Unknown)
+                    }
                     // Both fixed-length: require equal arity and positional assignability.
                     (None, None) => {
                         a.len() == b.len()

--- a/crates/basilisk-checker/src/types.rs
+++ b/crates/basilisk-checker/src/types.rs
@@ -361,7 +361,7 @@ fn homogeneous_tuple_elem(elems: &[InferredType]) -> Option<&InferredType> {
 }
 
 /// Returns `true` when a tuple element is an unpacked variadic segment — either
-/// `*tuple[...]` or a `*Ts` TypeVarTuple. The annotation parser stores these as
+/// `*tuple[...]` or a `*Ts` `TypeVarTuple`. The annotation parser stores these as
 /// `Named` text beginning with `*`.
 fn is_unpacked_tuple_elem(elem: &InferredType) -> bool {
     matches!(elem, InferredType::Named(name) if name.starts_with('*'))
@@ -405,35 +405,42 @@ fn parse_star_segment(name: &str) -> StarSegment {
 /// single unpacked `*tuple[...]` / `*Ts` segment (PEP 646), using
 /// prefix/middle/suffix decomposition.
 fn tuple_assignable_with_star(source: &[InferredType], target: &[InferredType]) -> bool {
-    // Only a fixed-length source is supported here; a variadic source against a
-    // variadic target needs full unification (handled elsewhere / conservatively).
+    // Unhandled shapes return `true` (assignable) rather than `false`: this is a
+    // best-effort matcher and must never manufacture a false positive. Only a
+    // pattern we actually decompose may return `false` (a real mismatch).
+    //
+    // A variadic source, multiple unpacked segments, or a `*Ts` we can't read
+    // all need full PEP 646 unification — be permissive.
     if source.iter().any(is_unpacked_tuple_elem) {
-        return false;
+        return true;
     }
     let Some(star_idx) = target.iter().position(is_unpacked_tuple_elem) else {
-        return false;
+        return true;
     };
-    let prefix = &target[..star_idx];
-    let suffix = &target[star_idx + 1..];
+    let (prefix, rest) = target.split_at(star_idx);
+    let Some((star_elem, suffix)) = rest.split_first() else {
+        return true;
+    };
     // Only one unpacked segment is supported.
     if suffix.iter().any(is_unpacked_tuple_elem) {
-        return false;
+        return true;
     }
+    let InferredType::Named(star_name) = star_elem else {
+        return true;
+    };
 
-    match parse_star_segment(match &target[star_idx] {
-        InferredType::Named(name) => name,
-        _ => return false,
-    }) {
+    match parse_star_segment(star_name) {
         StarSegment::Variadic(elem) => {
-            if source.len() < prefix.len() + suffix.len() {
+            let Some(middle_len) = source.len().checked_sub(prefix.len() + suffix.len()) else {
                 return false;
-            }
-            let middle_end = source.len() - suffix.len();
+            };
             prefix_suffix_match(source, prefix, suffix)
                 && match elem {
                     None => true,
-                    Some(elem_ty) => source[prefix.len()..middle_end]
+                    Some(elem_ty) => source
                         .iter()
+                        .skip(prefix.len())
+                        .take(middle_len)
                         .all(|s| s.is_assignable_to(&elem_ty)),
                 }
         }
@@ -441,10 +448,11 @@ fn tuple_assignable_with_star(source: &[InferredType], target: &[InferredType]) 
             if source.len() != prefix.len() + middle.len() + suffix.len() {
                 return false;
             }
-            let middle_end = prefix.len() + middle.len();
             prefix_suffix_match(source, prefix, suffix)
-                && source[prefix.len()..middle_end]
+                && source
                     .iter()
+                    .skip(prefix.len())
+                    .take(middle.len())
                     .zip(middle.iter())
                     .all(|(s, m)| s.is_assignable_to(m))
         }
@@ -452,19 +460,20 @@ fn tuple_assignable_with_star(source: &[InferredType], target: &[InferredType]) 
 }
 
 /// Check that a source tuple's leading elements match `prefix` and trailing
-/// elements match `suffix` (both fixed, non-starred).
+/// elements match `suffix` (both fixed, non-starred). Callers guarantee
+/// `source.len() >= prefix.len() + suffix.len()`.
 fn prefix_suffix_match(
     source: &[InferredType],
     prefix: &[InferredType],
     suffix: &[InferredType],
 ) -> bool {
-    let suffix_start = source.len() - suffix.len();
-    source[..prefix.len()]
+    source
         .iter()
         .zip(prefix.iter())
         .all(|(s, p)| s.is_assignable_to(p))
-        && source[suffix_start..]
+        && source
             .iter()
-            .zip(suffix.iter())
+            .rev()
+            .zip(suffix.iter().rev())
             .all(|(s, q)| s.is_assignable_to(q))
 }

--- a/crates/basilisk-checker/src/types.rs
+++ b/crates/basilisk-checker/src/types.rs
@@ -250,6 +250,11 @@ impl InferredType {
                 a_key.is_assignable_to(b_key) && a_val.is_assignable_to(b_val)
             }
             (InferredType::Tuple(a), InferredType::Tuple(b)) => {
+                // A target with an unpacked `*tuple[...]` / `*Ts` segment (PEP 646)
+                // needs prefix/middle/suffix matching, not positional equality.
+                if b.iter().any(is_unpacked_tuple_elem) {
+                    return tuple_assignable_with_star(a, b);
+                }
                 match (homogeneous_tuple_elem(a), homogeneous_tuple_elem(b)) {
                     // Target `tuple[X, ...]` (PEP 484 homogeneous variable-length):
                     // a source `tuple[Y, ...]` matches when `Y` is assignable to `X`.
@@ -353,4 +358,113 @@ fn homogeneous_tuple_elem(elems: &[InferredType]) -> Option<&InferredType> {
         [elem, InferredType::Named(terminator)] if terminator == "..." => Some(elem),
         _ => None,
     }
+}
+
+/// Returns `true` when a tuple element is an unpacked variadic segment — either
+/// `*tuple[...]` or a `*Ts` TypeVarTuple. The annotation parser stores these as
+/// `Named` text beginning with `*`.
+fn is_unpacked_tuple_elem(elem: &InferredType) -> bool {
+    matches!(elem, InferredType::Named(name) if name.starts_with('*'))
+}
+
+/// What an unpacked `*tuple[...]` / `*Ts` segment consumes from a source tuple.
+enum StarSegment {
+    /// `*tuple[X, ...]` or `*Ts` — zero or more elements, each assignable to the
+    /// element type (`None` ⇒ any, for `*Ts` / `*tuple[Any, ...]`).
+    Variadic(Option<InferredType>),
+    /// `*tuple[X, Y]` — a fixed run of elements consumed positionally.
+    Fixed(Vec<InferredType>),
+}
+
+/// Parse an unpacked tuple element (`Named("*tuple[...]")` / `Named("*ts")`).
+fn parse_star_segment(name: &str) -> StarSegment {
+    let Some(inner) = name
+        .strip_prefix("*tuple[")
+        .and_then(|rest| rest.strip_suffix(']'))
+    else {
+        // `*Ts` (a TypeVarTuple) — any number of elements of any type.
+        return StarSegment::Variadic(None);
+    };
+    let parts = crate::types_parsing::split_type_params(inner);
+    if matches!(parts.last(), Some(last) if last.trim() == "...") {
+        // `*tuple[X, ...]` — homogeneous, zero or more of `X`.
+        let elem = parts
+            .first()
+            .map(|p| InferredType::from_annotation(p.trim()));
+        return StarSegment::Variadic(elem);
+    }
+    StarSegment::Fixed(
+        parts
+            .iter()
+            .map(|p| InferredType::from_annotation(p.trim()))
+            .collect(),
+    )
+}
+
+/// Match a fixed-length source tuple against a target tuple that contains a
+/// single unpacked `*tuple[...]` / `*Ts` segment (PEP 646), using
+/// prefix/middle/suffix decomposition.
+fn tuple_assignable_with_star(source: &[InferredType], target: &[InferredType]) -> bool {
+    // Only a fixed-length source is supported here; a variadic source against a
+    // variadic target needs full unification (handled elsewhere / conservatively).
+    if source.iter().any(is_unpacked_tuple_elem) {
+        return false;
+    }
+    let Some(star_idx) = target.iter().position(is_unpacked_tuple_elem) else {
+        return false;
+    };
+    let prefix = &target[..star_idx];
+    let suffix = &target[star_idx + 1..];
+    // Only one unpacked segment is supported.
+    if suffix.iter().any(is_unpacked_tuple_elem) {
+        return false;
+    }
+
+    match parse_star_segment(match &target[star_idx] {
+        InferredType::Named(name) => name,
+        _ => return false,
+    }) {
+        StarSegment::Variadic(elem) => {
+            if source.len() < prefix.len() + suffix.len() {
+                return false;
+            }
+            let middle_end = source.len() - suffix.len();
+            prefix_suffix_match(source, prefix, suffix)
+                && match elem {
+                    None => true,
+                    Some(elem_ty) => source[prefix.len()..middle_end]
+                        .iter()
+                        .all(|s| s.is_assignable_to(&elem_ty)),
+                }
+        }
+        StarSegment::Fixed(middle) => {
+            if source.len() != prefix.len() + middle.len() + suffix.len() {
+                return false;
+            }
+            let middle_end = prefix.len() + middle.len();
+            prefix_suffix_match(source, prefix, suffix)
+                && source[prefix.len()..middle_end]
+                    .iter()
+                    .zip(middle.iter())
+                    .all(|(s, m)| s.is_assignable_to(m))
+        }
+    }
+}
+
+/// Check that a source tuple's leading elements match `prefix` and trailing
+/// elements match `suffix` (both fixed, non-starred).
+fn prefix_suffix_match(
+    source: &[InferredType],
+    prefix: &[InferredType],
+    suffix: &[InferredType],
+) -> bool {
+    let suffix_start = source.len() - suffix.len();
+    source[..prefix.len()]
+        .iter()
+        .zip(prefix.iter())
+        .all(|(s, p)| s.is_assignable_to(p))
+        && source[suffix_start..]
+            .iter()
+            .zip(suffix.iter())
+            .all(|(s, q)| s.is_assignable_to(q))
 }

--- a/crates/basilisk-checker/src/types_parsing.rs
+++ b/crates/basilisk-checker/src/types_parsing.rs
@@ -84,13 +84,12 @@ fn parse_container_annotation(annotation: &str) -> InferredType {
         let inner = &annotation[5..annotation.len() - 1];
         // Bracket-aware split so a nested key type (e.g. `tuple[str, str]`) is
         // not severed at its inner comma — same splitter `tuple[`/`union[` use.
-        let parts = split_type_params(inner);
-        if parts.len() == 2 {
-            let key_type = InferredType::from_annotation(parts.first().map_or("", |s| s.trim()));
-            let value_type = InferredType::from_annotation(parts.get(1).map_or("", |s| s.trim()));
-            return InferredType::Dict(Box::new(key_type), Box::new(value_type));
-        }
-        return InferredType::Named(annotation.to_owned());
+        return match parse_key_value_args(inner) {
+            Some((key_type, value_type)) => {
+                InferredType::Dict(Box::new(key_type), Box::new(value_type))
+            }
+            None => InferredType::Named(annotation.to_owned()),
+        };
     }
     if annotation.starts_with("set[") && annotation.ends_with(']') {
         let inner = &annotation[4..annotation.len() - 1];
@@ -166,9 +165,17 @@ fn parse_single_literal(val: &str) -> InferredType {
     if let Ok(num) = val.parse::<i64>() {
         return InferredType::Literal(LiteralValue::Int(num));
     }
-    if let Some(hex) = val.strip_prefix("0x").or_else(|| val.strip_prefix("0X")) {
-        if let Ok(num) = i64::from_str_radix(hex, 16) {
-            return InferredType::Literal(LiteralValue::Int(num));
+    // Non-decimal integer literals: `Literal[0x14]`, `Literal[0o24]`, `Literal[0b10100]`
+    // are all the value `20` and must compare equal across spellings.
+    for (prefix_lower, prefix_upper, radix) in [("0x", "0X", 16), ("0o", "0O", 8), ("0b", "0B", 2)]
+    {
+        if let Some(digits) = val
+            .strip_prefix(prefix_lower)
+            .or_else(|| val.strip_prefix(prefix_upper))
+        {
+            if let Ok(num) = i64::from_str_radix(&digits.replace('_', ""), radix) {
+                return InferredType::Literal(LiteralValue::Int(num));
+            }
         }
     }
 
@@ -187,6 +194,19 @@ fn parse_single_literal(val: &str) -> InferredType {
     }
 
     InferredType::Named(val.to_owned())
+}
+
+/// Parse the `K, V` inside a two-argument subscript (`dict[K, V]`,
+/// `Mapping[K, V]`) into key and value [`InferredType`]s. Returns `None` unless
+/// exactly two top-level, bracket-aware arguments are present.
+pub(super) fn parse_key_value_args(inner: &str) -> Option<(InferredType, InferredType)> {
+    let parts = split_type_params(inner);
+    if parts.len() != 2 {
+        return None;
+    }
+    let key = InferredType::from_annotation(parts.first().map_or("", |s| s.trim()));
+    let value = InferredType::from_annotation(parts.get(1).map_or("", |s| s.trim()));
+    Some((key, value))
 }
 
 /// Split type parameters by top-level commas, respecting bracket nesting.

--- a/crates/basilisk-checker/src/types_parsing.rs
+++ b/crates/basilisk-checker/src/types_parsing.rs
@@ -23,9 +23,16 @@ impl InferredType {
             "bytes" => InferredType::Bytes,
             "none" => InferredType::None_,
             // Bare `tuple` is `tuple[Any, ...]` — equivalent to Any for assignment.
-            "any" | "object" | "final" | "tuple" => InferredType::Any,
+            // Bare `type` is `type[Any]` (any class object) — Any-like for assignment.
+            "any" | "object" | "final" | "tuple" | "type" => InferredType::Any,
             "never" => InferredType::Never,
             "literalstring" => InferredType::LiteralString,
+            // A bare `Callable` annotation is `Callable[..., Any]` (PEP 484):
+            // empty `param_types` represents the arbitrary-parameter form.
+            "callable" => InferredType::Callable(CallableInfo {
+                param_types: Vec::new(),
+                return_type: Box::new(InferredType::Any),
+            }),
             // Bare generics without `[...]` are implicitly parameterised with Any.
             "list" => InferredType::List(Box::new(InferredType::Any)),
             "dict" => InferredType::Dict(Box::new(InferredType::Any), Box::new(InferredType::Any)),
@@ -91,6 +98,10 @@ fn parse_container_annotation(annotation: &str) -> InferredType {
     }
     if annotation.starts_with("tuple[") && annotation.ends_with(']') {
         let inner = &annotation[6..annotation.len() - 1];
+        // `tuple[()]` is the PEP 484 spelling of the empty-tuple type.
+        if inner.trim() == "()" {
+            return InferredType::Tuple(Vec::new());
+        }
         let parts = split_type_params(inner);
         let elem_types: Vec<InferredType> = parts
             .iter()

--- a/crates/basilisk-checker/tests/fp_elimination_tests.rs
+++ b/crates/basilisk-checker/tests/fp_elimination_tests.rs
@@ -1,0 +1,218 @@
+//! Tests for [CHKARCH-DIAG-TYPESAFETY]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#chkarch-diag-typesafety
+//! Coarse e2e tests locking in the BSK-E0014 false-positive eliminations from
+//! `docs/plans/CHECK-ELIMINATE-FALSE-POSITIVES.md`.
+//!
+//! Each test asserts BOTH directions: the valid (`# OK`) forms are NOT flagged
+//! (the eliminated false positive), and the genuinely-incompatible forms ARE
+//! still flagged (the true positive that must keep firing). This pairing is what
+//! kills mutants that would otherwise silently re-introduce a false positive or
+//! drop a real diagnostic.
+#![allow(
+    clippy::allow_attributes,
+    clippy::uninlined_format_args,
+    clippy::needless_raw_string_hashes,
+    missing_docs,
+    dead_code
+)]
+
+mod common;
+
+use common::{has_code, run};
+
+const E0014: &str = "BSK-E0014";
+
+fn e0014_count(diags: &[common::Diagnostic]) -> usize {
+    diags.iter().filter(|d| d.code.code == E0014).count()
+}
+
+// ── Recursive value aliases (e0014/alias_match.rs) ────────────────────────
+
+#[test]
+fn recursive_union_alias_accepts_valid_and_rejects_invalid(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Union
+
+Json = Union[None, int, str, float, list["Json"], dict[str, "Json"]]
+
+ok1: Json = [1, {"a": 1}]
+ok2: Json = 3.4
+ok3: Json = [1.2, None, [1.2, [""]]]
+bad1: Json = {"a": 1, "b": 3j}
+bad2: Json = [2, 3j]
+"#;
+    let diags = run(source)?;
+    // Valid recursive-alias assignments must NOT be flagged.
+    assert!(
+        !has_code(&diags, E0014) || e0014_count(&diags) == 2,
+        "expected exactly the two invalid Json assignments to be flagged, got {} E0014",
+        e0014_count(&diags)
+    );
+    assert_eq!(
+        e0014_count(&diags),
+        2,
+        "the two complex-number assignments (3j) must still fire E0014"
+    );
+    Ok(())
+}
+
+#[test]
+fn recursive_tuple_and_mapping_aliases() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Mapping
+
+RecursiveTuple = str | int | tuple["RecursiveTuple", ...]
+RecursiveMapping = str | int | Mapping[str, "RecursiveMapping"]
+
+t_ok1: RecursiveTuple = (1, 1)
+t_ok2: RecursiveTuple = (1, "1", 1, "2")
+t_bad: RecursiveTuple = (1, [1])
+
+m_ok1: RecursiveMapping = {"1": "1", "2": 1}
+m_ok2: RecursiveMapping = {"1": "1", "3": {}}
+m_bad: RecursiveMapping = {"1": [1]}
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        e0014_count(&diags),
+        2,
+        "only the two list-bearing assignments must fire E0014, got {}",
+        e0014_count(&diags)
+    );
+    Ok(())
+}
+
+// ── Variadic tuples (types.rs tuple_assignable_with_star) ──────────────────
+
+#[test]
+fn variadic_tuple_star_targets() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def f(a: tuple[str, str]):
+    ok1: tuple[int, *tuple[str]] = (1, "")
+    ok2: tuple[int, *tuple[str, ...]] = (1,)
+    ok3: tuple[int, *tuple[str, ...], int] = (1, 2)
+    ok4: tuple[str, str, *tuple[int, ...]] = a
+    ok5: tuple[*tuple[str, ...], str] = a
+    bad1: tuple[*tuple[str, ...], str, str, str] = a
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        e0014_count(&diags),
+        1,
+        "only the too-short `bad1` assignment must fire E0014, got {}",
+        e0014_count(&diags)
+    );
+    Ok(())
+}
+
+#[test]
+fn gradual_variadic_tuple_source_is_assignable() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Any
+
+def f(any_tuple: tuple[Any, ...], int_tuple: tuple[int, ...]):
+    ok: tuple[int, int] = any_tuple
+    bad: tuple[int, int] = int_tuple
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        e0014_count(&diags),
+        1,
+        "`tuple[Any, ...]` is gradual (OK); `tuple[int, ...]`→fixed must fire, got {}",
+        e0014_count(&diags)
+    );
+    Ok(())
+}
+
+// ── Bare generics & special forms (types_parsing.rs / types.rs) ────────────
+
+#[test]
+fn bare_callable_and_type_are_any_like() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Callable, Any
+
+def f(val1: Callable, v: type):
+    t1: Callable[[], Any] = val1
+    t2: Callable[[int, str], None] = val1
+    x1: Callable[..., Any] = v
+    x2: Callable[[int, int], int] = v
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        e0014_count(&diags),
+        0,
+        "bare Callable/type assignments must not be flagged, got {}",
+        e0014_count(&diags)
+    );
+    Ok(())
+}
+
+#[test]
+fn none_is_hashable_but_not_iterable() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Hashable, Iterable
+
+none1: Hashable = None
+none2: Iterable = None
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        e0014_count(&diags),
+        1,
+        "None→Hashable is OK; None→Iterable must fire, got {}",
+        e0014_count(&diags)
+    );
+    Ok(())
+}
+
+#[test]
+fn empty_tuple_type() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+t10: tuple[()] = ()
+"#;
+    let diags = run(source)?;
+    assert!(
+        !has_code(&diags, E0014),
+        "`tuple[()] = ()` must not be flagged"
+    );
+    Ok(())
+}
+
+#[test]
+fn non_decimal_literal_equivalence() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Literal
+
+def f(c: Literal[0b10100]):
+    ok: Literal[0x14] = c
+    bad: Literal[3] = 4
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        e0014_count(&diags),
+        1,
+        "0x14 == 0b10100 (both 20) is OK; Literal[3]=4 must fire, got {}",
+        e0014_count(&diags)
+    );
+    Ok(())
+}
+
+#[test]
+fn quoted_forward_ref_annotation_is_skipped() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Literal
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+
+def f(a: Literal[Color.RED]):
+    x2: "Literal[Color.RED]" = a
+"#;
+    let diags = run(source)?;
+    assert!(
+        !has_code(&diags, E0014),
+        "whole-quoted annotations must be skipped by E0014"
+    );
+    Ok(())
+}

--- a/crates/basilisk-checker/tests/mutation_kill_tests.rs
+++ b/crates/basilisk-checker/tests/mutation_kill_tests.rs
@@ -480,6 +480,77 @@ d: float = 3.14
     Ok(())
 }
 
+// ═══════════════════════════════════════════════════════════════════════
+// E0014 check_vars: quoted forward-reference annotation skip (line 140)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Kills mutant: e0014/mod.rs:140 `replace || with &&` in the whole-quoted
+/// annotation guard (`starts_with('"') || starts_with('\'')`). A quoted
+/// forward-reference annotation must NOT be evaluated as a value type (so it
+/// produces no E0014), while an unquoted, genuinely-mismatched annotation MUST
+/// still fire. Flipping `||`→`&&` (or dropping either `starts_with`) makes the
+/// guard never skip, so the quoted lines would be processed and fire E0014 —
+/// observably changing the count.
+#[mutation_safe(rule = "e0014", fns = "check_vars")]
+#[test]
+fn mutant_e0014_quoted_annotation_skip() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+a: "int" = "hello"
+b: 'int' = 'hello'
+c: int = "hello"
+"#;
+    let diagnostics = run(source)?;
+    let e0014 = e0014_count(&diagnostics);
+    assert_eq!(
+        e0014, 1,
+        "only the unquoted `c: int = \"hello\"` mismatch fires; both quoted \
+         annotations are skipped, got {e0014}: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0014")
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// E0014 check_vars: bare recursive-Union-alias interception (line 219)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Kills mutant: e0014/mod.rs:219 `delete !` in the bare-alias guard
+/// (`!name.contains('[')`). A bare reference to a legacy recursive `Union`
+/// alias must be matched value-by-value against its expanded definition: a
+/// valid `Json` value is accepted (no E0014) and only an invalid member
+/// (complex `3j`) fires. Deleting the `!` flips the guard so bare alias names
+/// are no longer intercepted, falling back to the `Named`-vs-literal compare,
+/// which rejects the valid value too — raising the E0014 count.
+#[mutation_safe(rule = "e0014", fns = "check_vars")]
+#[test]
+fn mutant_e0014_recursive_union_alias() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Union
+
+Json = Union[None, int, str, float, list["Json"], dict[str, "Json"]]
+
+ok: Json = [1, {"a": 1}]
+bad: Json = {"a": 3j}
+"#;
+    let diagnostics = run(source)?;
+    let e0014 = e0014_count(&diagnostics);
+    assert_eq!(
+        e0014, 1,
+        "the valid recursive-alias value is accepted; only the complex `3j` \
+         value fires, got {e0014}: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0014")
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
 fn e0001_count(diagnostics: &[basilisk_checker::Diagnostic]) -> usize {
     diagnostics
         .iter()

--- a/crates/basilisk-checker/tests/mutation_kill_tests.rs
+++ b/crates/basilisk-checker/tests/mutation_kill_tests.rs
@@ -502,7 +502,8 @@ c: int = "hello"
     let diagnostics = run(source)?;
     let e0014 = e0014_count(&diagnostics);
     assert_eq!(
-        e0014, 1,
+        e0014,
+        1,
         "only the unquoted `c: int = \"hello\"` mismatch fires; both quoted \
          annotations are skipped, got {e0014}: {:?}",
         diagnostics
@@ -539,7 +540,8 @@ bad: Json = {"a": 3j}
     let diagnostics = run(source)?;
     let e0014 = e0014_count(&diagnostics);
     assert_eq!(
-        e0014, 1,
+        e0014,
+        1,
         "the valid recursive-alias value is accepted; only the complex `3j` \
          value fires, got {e0014}: {:?}",
         diagnostics

--- a/crates/basilisk-cli/tests/conformance_tests.rs
+++ b/crates/basilisk-cli/tests/conformance_tests.rs
@@ -386,33 +386,41 @@ fn category(name: &str) -> &str {
 /// `coverage-thresholds.json`.  Falls back to 0 if the file is missing or
 /// malformed so the test still runs (the coverage script enforces separately).
 fn read_conformance_threshold() -> usize {
+    read_conformance_field("threshold").unwrap_or(0)
+}
+
+/// The maximum total false positives allowed across the suite, from
+/// `coverage-thresholds.json` → `conformance.max_false_positives`.
+///
+/// Ratchets DOWN only — like the pass-percentage gate but in the opposite
+/// direction. Returns `None` when the key is absent (gate disabled).
+fn read_conformance_fp_ceiling() -> Option<usize> {
+    read_conformance_field("max_false_positives")
+}
+
+/// Read a numeric field nested under the `"conformance"` object in
+/// `coverage-thresholds.json`.
+///
+/// Minimal JSON extraction — avoids adding a serde dependency to this test
+/// crate. Looks for `"conformance"` then the first occurrence of the requested
+/// key, then parses the following integer.
+fn read_conformance_field(key: &str) -> Option<usize> {
     let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let Some(repo_root) = manifest
+    let repo_root = manifest
         .ancestors()
-        .find(|p| p.join("Cargo.toml").exists() && p.join("crates").exists())
-    else {
-        return 0;
-    };
-    let path = repo_root.join("coverage-thresholds.json");
-    let Ok(content) = fs::read_to_string(&path) else {
-        return 0;
-    };
-    // Minimal JSON extraction — avoids adding a serde dependency to this test
-    // crate.  We look for `"conformance"` → `"threshold"` → number.
-    let Some(conformance_idx) = content.find("\"conformance\"") else {
-        return 0;
-    };
+        .find(|p| p.join("Cargo.toml").exists() && p.join("crates").exists())?;
+    let content = fs::read_to_string(repo_root.join("coverage-thresholds.json")).ok()?;
+    let conformance_idx = content.find("\"conformance\"")?;
     let rest = &content[conformance_idx..];
-    let Some(threshold_idx) = rest.find("\"threshold\"") else {
-        return 0;
-    };
-    let after = &rest[threshold_idx + "\"threshold\"".len()..];
+    let key_pat = format!("\"{key}\"");
+    let key_idx = rest.find(&key_pat)?;
+    let after = &rest[key_idx + key_pat.len()..];
     // Skip `:` and whitespace, then parse the number.
-    let num_start = after.find(|c: char| c.is_ascii_digit()).unwrap_or(0);
+    let num_start = after.find(|c: char| c.is_ascii_digit())?;
     let num_end = after[num_start..]
         .find(|c: char| !c.is_ascii_digit())
         .map_or(after.len(), |i| num_start + i);
-    after[num_start..num_end].parse().unwrap_or(0)
+    after[num_start..num_end].parse().ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -472,6 +480,18 @@ fn conformance_score() {
         "  Conformance gate: {pct}% ({}/{}) >= {threshold}% threshold — PASS",
         totals.pass, totals.files
     );
+
+    // Enforce the false-positive ceiling from coverage-thresholds.json.
+    // False positives ratchet DOWN only: introducing new ones fails the gate.
+    if let Some(ceiling) = read_conformance_fp_ceiling() {
+        assert!(
+            totals.fp <= ceiling,
+            "PEP conformance false-positive regression: {} FPs > {ceiling} ceiling. \
+             False positives ratchet DOWN only — eliminate new ones before merging.",
+            totals.fp
+        );
+        println!("  FP gate: {} <= {ceiling} ceiling — PASS", totals.fp);
+    }
 }
 
 type CategoryMap = BTreeMap<String, (usize, usize)>;

--- a/crates/basilisk-resolver/src/visitor/protocol_ext.rs
+++ b/crates/basilisk-resolver/src/visitor/protocol_ext.rs
@@ -211,25 +211,38 @@ pub(super) fn check_expr_for_protocol_call(
             }
         }
         // Check if a Protocol/abstract class is passed as an argument.
-        for arg in &call.arguments.args {
-            if let Some(arg_name) = expr_simple_name(arg) {
-                let arg_str = arg_name.as_str();
-                if protocol_names.contains(arg_str) {
-                    out.push(ProtocolInstantiationViolation {
-                        class_name: arg_name,
-                        span: text_range_to_span(call.range),
-                        is_abstract: false,
-                    });
-                } else if abstract_names.contains(arg_str) {
-                    out.push(ProtocolInstantiationViolation {
-                        class_name: arg_name,
-                        span: text_range_to_span(call.range),
-                        is_abstract: true,
-                    });
+        // Type-checking utilities (assert_type, reveal_type, cast, ...) reference
+        // their type arguments nominally and never instantiate them, so passing a
+        // Protocol/abstract class to them is valid — skip their argument lists.
+        let callee_is_type_utility = expr_simple_name(&call.func)
+            .is_some_and(|name| is_type_checking_utility(name.as_str()));
+        if !callee_is_type_utility {
+            for arg in &call.arguments.args {
+                if let Some(arg_name) = expr_simple_name(arg) {
+                    let arg_str = arg_name.as_str();
+                    if protocol_names.contains(arg_str) {
+                        out.push(ProtocolInstantiationViolation {
+                            class_name: arg_name,
+                            span: text_range_to_span(call.range),
+                            is_abstract: false,
+                        });
+                    } else if abstract_names.contains(arg_str) {
+                        out.push(ProtocolInstantiationViolation {
+                            class_name: arg_name,
+                            span: text_range_to_span(call.range),
+                            is_abstract: true,
+                        });
+                    }
                 }
             }
         }
     }
+}
+
+/// Returns `true` for type-checking utility functions whose arguments are type
+/// expressions referenced nominally, not values to be instantiated.
+fn is_type_checking_utility(name: &str) -> bool {
+    matches!(name, "assert_type" | "reveal_type" | "cast")
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/plans/CHECK-ELIMINATE-FALSE-POSITIVES.md
+++ b/docs/plans/CHECK-ELIMINATE-FALSE-POSITIVES.md
@@ -202,7 +202,48 @@ The remaining ~125 FPs cannot be fixed without fundamental engine work. The chec
 
 ## Execution log
 
-### 2026-06-03 — clean FP reduction: 170 → 161 (zero conformance regression)
+### 2026-06-03 (session 2) — FP reduction 161 → 136 and counting (zero conformance regression)
+
+Verification harness: [`scripts/fp_verify.sh`](../../scripts/fp_verify.sh) rebuilds, runs
+the conformance suite, and diffs `conformance_status.csv` against a saved baseline,
+flagging any PASS→FAIL flip, `caught` drop, or `missed` rise plus the per-file FP delta.
+Run after **every** change; revert anything that regresses. Baseline advances only to
+verified-better states.
+
+Throughout: **PASS=136, caught=858, missed=95 unchanged**; only `fp` moves (down).
+
+| # | Change | Files | FPs | Status |
+|---|--------|-------|-----|--------|
+| 1 | Bare `Callable` → `Callable[..., Any]`, bare `type` → `type[Any]` (≈Any); `tuple[()]` → empty tuple; `None` assignable to `Hashable`; skip whole-quoted annotations in E0014; E0099 skips type-utility (`assert_type`/`reveal_type`/`cast`) args | types_parsing.rs, types.rs, e0014/mod.rs, protocol_ext.rs | **−8** | DONE (161→153) |
+| 2 | `tuple[Any,...]` / `tuple[Unknown,...]` source assignable to fixed-length target (PEP 484 gradual) | types.rs | **−3** | DONE (153→150) |
+| 3 | Recursive **value-alias** matcher: resolve bare `Name = Union[...]` aliases (Json/RecursiveTuple/RecursiveMapping) and positively match the inferred literal against the expanded (recursive) definition. Positive-match semantics keep `Unknown` (e.g. `3j`) from matching, so the `# E` lines still fire | e0014/alias_match.rs (new), e0014/mod.rs | **−14** | DONE (150→136) |
+
+**Why the alias matcher is TP-safe:** it only *suppresses* when the value demonstrably
+matches the alias; `Unknown`/`Any` never positively match a concrete target, so the
+fixtures' incompatible assignments (`3j`, stray `list`s) keep firing. Restricted to
+`Union`-bodied aliases referenced by a bare name → excludes the 4 generic-alias FPs
+(`GenericTypeAlias1/2`, which need TypeVar substitution — see Deferred).
+
+**Deferred this session (need engine/resolver work, out of scope for a no-regression PR):**
+
+- **Callable/protocol structural subtyping** (callables_subtyping 24, callables_annotation 16,
+  protocols_subtyping 7, protocols_merging 2 ≈ **49 FPs**). These are *load-bearing*: E0014's
+  `Named`-base-mismatch catches both the OK and the `# E` lines (mirror-image assignments like
+  `f3: PosOnly2 = standard` OK vs `f1: Standard2 = pos_only` E). Eliminating the FPs requires
+  real PEP 484 callable subtyping with **parameter-kind awareness** (positional-only `/`,
+  keyword-only `*`, `*args`/`**kwargs` supertype rules, defaults, overloads, ParamSpec). Blocked
+  on a prerequisite: `ParameterInfo` does not capture parameter kind today — a resolver expansion
+  is needed first. Suppressing without it would drop ~40 TPs and slip conformance.
+- **Variadic-tuple star matching** (tuples_type_compat 11): PEP 646 `*tuple[...]` prefix/middle/suffix.
+- **Recursive generic aliases** (aliases_recursive 4): TypeVar substitution.
+- **TypedDict structural assignability** (E0014 readonly_*/inheritance 8, E0093 extra_items/ReadOnly 7).
+- **`assert_type` narrowing** (E0053 15): flow narrowing (isinstance/`is`/TypeGuard/TypeIs) + Union/tuple-unpack syntactic equivalence.
+- **Constructors** (E0111 9): dataclass_transform class/converter, NamedTuple subscript/inheritance, type-erasure.
+- **Scattered singles** (E0012/E0048/E0054/E0069/E0060/E0115/E0130/E0094/E0078/E0092/E0139/E0112/E0140/E0041/E0143).
+
+---
+
+### 2026-06-03 (session 1) — clean FP reduction: 170 → 161 (zero conformance regression)
 
 Measured against `main`. Every change verified empirically: re-ran the harness and
 diffed `conformance_status.csv` for PASS→FAIL flips AND `caught`/`missed` deltas.

--- a/docs/plans/CHECK-ELIMINATE-FALSE-POSITIVES.md
+++ b/docs/plans/CHECK-ELIMINATE-FALSE-POSITIVES.md
@@ -2,9 +2,69 @@
 
 ## Context
 
-The conformance suite tracks ~230 false positives across 60+ files. False positives are diagnostics Basilisk reports on lines that have NO `# E` annotation — meaning the typing spec says these lines are **valid code** but Basilisk incorrectly flags them. This erodes user trust and blocks adoption.
+False positives are diagnostics Basilisk reports on lines that have NO `# E`
+annotation — the typing spec says the line is **valid code** but Basilisk flags
+it anyway. They erode user trust and block adoption.
 
-The conformance harness (`crates/basilisk-cli/tests/conformance_tests.rs:272-275`) counts FPs but only prints verbose output for **missed** errors, not for FPs. We need to fix the checker rules that over-report.
+The conformance harness (`crates/basilisk-cli/tests/conformance_tests.rs`) now
+prints per-FP verbose output (`FP <file>: count=N lines=[(line, rule)…]`, see
+`diag_line_rules`). Run `cargo test --test conformance_tests --release -- --nocapture`
+and `grep '  FP    '` to get the exact rule→line mapping.
+
+### CURRENT STATE (measured 2026-06-03, on `main` after PR #73)
+
+- **136/146 PASS (93.15%)**, threshold pinned at 93 in `coverage-thresholds.json`.
+- **170 false positives** across 50 files. (The earlier "18 FPs" claim in this
+  doc's history was a never-merged aspiration — the real number is 170.)
+
+> **HARD INVARIANT.** Conformance is monotonic: PASS count only goes UP, FP count
+> only goes DOWN. A file PASSES iff `missed == 0`. Flipping ONE file PASS→FAIL
+> drops us to 92.46% < 93 → CI fails. **Every FP fix must reduce FPs with ZERO
+> new missed diagnostics.** Verify empirically: after each change re-run the
+> harness and diff `conformance_status.csv` against baseline — no file may regress
+> PASS→FAIL and total `missed` must not increase.
+
+### FP distribution by rule (the real target list)
+
+| Rule | FPs | What it is | Dominant pattern |
+|------|-----|------------|------------------|
+| **E0014** | **~105** | assignment type mismatch | `local: NamedType = param` — param-type-map lookup yields a `Named`/`Callable` type that the `_ => false` catch-all in `is_assignable_to` rejects. E0014 is a *literal-mismatch* checker; protocol/callable/alias assignability belongs to E0136/E0121/E0099. |
+| E0053 | 15 | `assert_type` equivalence | text-based type equivalence misses spec-equal forms |
+| E0111 | 9 | constructor calls | over-strict arg checking on transformed/namedtuple/erased classes |
+| E0093 | 7 | TypedDict | `extra_items`/`ReadOnly`/`Final` field semantics |
+| E0013 | 7 | return type mismatch | base↔Literal and structural return widening |
+| E0012 | 4 | TypeVarTuple unpack | — |
+| E0130 / E0047 | 3 each | scoping / forward refs | — |
+| ~15 rules | 1–2 each | scattered | per-rule edge cases |
+
+---
+
+## Strategy (this PR)
+
+Fix the rules in descending FP order, **verifying empirically after each** against
+the saved baseline (`/tmp/conf_baseline.csv`). Group the E0014 mass into surgical,
+TP-safe guards rather than rewriting the (text-based) rule wholesale.
+
+- **FIX A — E0014 param-lookup conservatism** (`e0014/mod.rs` param branch). Only
+  adopt a parameter/variable's inferred type when *both* it and the declared type
+  are **value-adjudicable** (Int/Str/Float/Bool/Bytes/None/Literal/builtin
+  containers thereof) — never `Named`/`Callable`/`TypeForm`. Preserves the
+  `Literal[False] = a` (a: Literal[0]) TP while killing every `local: Named = param`
+  FP. Target ≈ 56 FPs (callables_annotation, callables_subtyping, protocols_*,
+  specialtypes_*, typeddicts_readonly_consistency).
+- **FIX B — E0014 TypedDict skip broadening**: when the declared type is a TypedDict,
+  skip for *all* RHS shapes (not just dict literals); E0093 owns TD field checking.
+- **FIX C — directives**: recognise `# type: ignore[code]` bracket form, file-level
+  `# type: ignore` before docstring, and suppress assignments under
+  `if not TYPE_CHECKING:` (3 FPs).
+- **FIX D — E0053** (15 FPs), **FIX E — E0013** (7 FPs), **FIX F — E0111** (9 FPs):
+  independent rules; root-cause + TP-safe patch per cluster.
+
+### Enforcement upgrade
+
+Add `conformance.max_false_positives` to `coverage-thresholds.json` and assert it
+in the harness (ratchet DOWN only), making FP a true quality gate alongside the
+PASS-percentage gate — "quality metrics only increase per PR".
 
 ---
 
@@ -140,25 +200,56 @@ The remaining ~125 FPs cannot be fixed without fundamental engine work. The chec
 
 ---
 
-## Execution Order
+## Execution log
 
-### Phase 1: Rule-Specific Fixes (Steps 0-6) — MOSTLY COMPLETE
+### 2026-06-03 — clean FP reduction: 170 → 161 (zero conformance regression)
 
-| Step | Est. FPs Fixed | Effort | Risk | Status |
-|------|---------------|--------|------|--------|
-| 0. FP verbose reporting | 0 (tooling) | Low | None | DONE |
-| 1. E0104 recursive aliases | ~20 | Low | Low | DONE (2 FPs fixed) |
-| 2. E0136 callable subtyping | ~25 | Medium | Medium | Pending |
-| 3. E0014 assignment mismatch | ~110 | Medium | Medium | **DONE (108 FPs fixed)** |
-| 4. E0093 TypedDict | ~15 | Medium | Low | Partial (9 FPs fixed, 7 remain) |
-| 5. E0121/E0110/E0133 protocols | ~25 | High | Medium | Partial (12 FPs fixed) |
-| 6. E0013 return type mismatch | ~7 | Low | Low | **DONE (7 FPs fixed)** |
-| 7. File-level `# type: ignore` | ~1 | Low | None | **DONE** |
-| 8. Remaining scatter | ~20 | High | Low | In Progress |
+Measured against `main`. Every change verified empirically: re-ran the harness and
+diffed `conformance_status.csv` for PASS→FAIL flips AND `caught`/`missed` deltas.
 
-### Phase 2: Type Narrowing and Full Inference — DONE
+| Change | Rule | FPs removed | Result |
+|--------|------|-------------|--------|
+| `is_unverifiable_return_type` recursive skip (Named **and** Literal at any nesting) | E0013 | **7 (all of them)** | **DONE.** E0013 is now FP-free. Quoted forward-ref unions (`"int \| Meta2"`), `tuple[()]`, and `Literal[...]`/`Literal`-tuple returns are unverifiable by kind-only return inference; skipping them loses no TP (verified: the suite's only Literal-return sites are the OK cases fixed + `...`-body overload stubs + `LiteralString`). |
+| File-level `# type: ignore` + spec-compliant `# type: ignore[<non-BSK>]` | suppression (E0014 FPs) | **2** | **DONE.** Standalone top-of-file `# type: ignore` (only blank/comment lines before) silences the file; bracketed non-Basilisk tags suppress all per PEP 484, while `[BSK-…]` stays code-specific. TP at `directives_type_ignore_file2.py:14` preserved (comment after docstring). |
+| FP-ceiling gate | harness | 0 (enforcement) | **DONE.** `conformance.max_false_positives` in `coverage-thresholds.json`, asserted in `conformance_tests.rs`. Ratchets DOWN only — mirrors the pass-% gate. Set to **161**. |
 
-Type narrowing engine, expression inference, constraint solver, and subtyping context all implemented. See [CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md](CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md). FPs reduced from 57 to 18.
+**Rejected (would reduce `caught` — violates the monotonic invariant):**
+
+- **E0014 param-lookup conservatism (FIX A)** — removed ~58 FPs but flipped 4 files
+  PASS→FAIL (callables_annotation/subtyping, protocols_subtyping,
+  typeddicts_readonly_consistency add +47 `missed`). In those files E0014 is the
+  *de-facto partial subtyping checker* (it catches the `# E` lines via Named/Callable
+  comparison while FP-ing on the OK ones). Reverted. This cluster needs **real
+  callable/protocol subtyping** (Steps 2/5), not suppression.
+- **E0014 transitive-TypedDict skip (FIX B)** — removed 5 FPs but dropped `caught`
+  858→856 (+2 `missed` on the already-FAIL `typeddicts_extra_items` /
+  `typeddicts_readonly_inheritance`): E0014's blanket dict→TD flag was *accidentally*
+  catching `# E` lines that E0093 misses. Reverted. Needs E0093 field-level work.
+
+**Deferred (needs engine work, out of scope for a no-regression PR):**
+
+- **E0053 (assert_type, 15 FPs)** — 11 are flow narrowing (`isinstance`/`TypeGuard`/
+  `is`-comparison); the rest are Union-syntax / unpacked-tuple equivalence in the
+  resolver's `types_match` (high blast radius, medium confidence). Needs the
+  narrowing engine + semantic type normalisation.
+- **E0111 (constructor calls, 9 FPs)** — multiple distinct causes (generic-NamedTuple
+  subscript, NamedTuple inheritance, `@dataclass_transform` frozen bases) across a
+  FAIL file. Each is its own investigation; high regression risk in one pass.
+- **E0014 mass (~96 remaining)** — callables/protocols/recursive-aliases/tuples all
+  require real subtyping or value-level recursive-alias checking.
+
+### Historical notes (pre-2026-06-03, partially superseded)
+
+The status table below predates the measured baseline above; several "DONE (N FPs)"
+claims describe branches that did not land on `main` (the real baseline was 170 FPs,
+not the 18 this doc once claimed). Kept for the root-cause analysis it contains.
+
+| Step | Rule | Notes |
+|------|------|-------|
+| 0 | FP verbose reporting | DONE (`diag_line_rules` in `conformance_tests.rs`) |
+| 1 | E0104 recursive aliases | container-wrapped recursion allowed |
+| 2 | E0136 callable subtyping | **still needed** (see Rejected/FIX A) |
+| 5 | E0121/E0110/E0133 protocols | **still needed** (see Rejected/FIX A) |
 
 ---
 

--- a/docs/plans/CHECK-ELIMINATE-FALSE-POSITIVES.md
+++ b/docs/plans/CHECK-ELIMINATE-FALSE-POSITIVES.md
@@ -304,52 +304,37 @@ After each step:
 
 ---
 
-## TODO
+## TODO — live checklist (ratchets DOWN; tick as eliminated)
 
-> **Total: 18 FPs** (down from 251→177→57→18, as of 2026-03-21)
+> **Total: 126 FPs** (this session: 161 → 126, −35, ZERO conformance regression).
+> Gate: `coverage-thresholds.json` `max_false_positives = 126` (ratchet DOWN only).
+> Each item verified via [`scripts/fp_verify.sh`](../../scripts/fp_verify.sh): no PASS→FAIL,
+> `caught`≥858, `missed`≤95.
 
-### FP Breakdown by Rule (from conformance test verbose output)
+### Done this session (−35)
 
-| Rule | FPs | Files |
-|------|-----|-------|
-| BSK-E0094 | 2 | generics_self_usage (2) |
-| BSK-E0093 | 2 | typeddicts_final (1), typeddicts_readonly_update (1) |
-| BSK-E0140 | 2 | callables_kwargs (1), typeddicts_readonly_kwargs (1) |
-| BSK-E0014 | 2 | dataclasses_transform_converter (1), directives_type_checking (1) |
-| BSK-E0149 | 1 | generics_syntax_scoping (1, triple-reported) |
-| BSK-E0141 | 1 | typeddicts_extra_items (1) |
-| BSK-E0132 | 1 | typeddicts_extra_items (1) |
-| BSK-E0139 | 1 | generics_typevartuple_specialization (1) |
-| BSK-E0143 | 1 | namedtuples_usage (1) |
-| BSK-E0115 | 1 | directives_deprecated (1) |
-| BSK-E0112 | 1 | narrowing_typeguard (1) |
-| BSK-E0099 | 1 | generics_self_protocols (1) |
-| BSK-E0092 | 1 | generics_paramspec_specialization (1) |
-| BSK-E0078 | 1 | generics_self_usage (1) |
-| BSK-E0069 | 1 | dataclasses_transform_func (1) |
+- [x] Bare `Callable` → `Callable[..., Any]`, bare `type` → Any (`types_parsing.rs`)
+- [x] `tuple[()]` → empty tuple type (`types_parsing.rs`)
+- [x] `None` assignable to `Hashable` (`types.rs`)
+- [x] Skip whole-quoted forward-ref annotations in E0014 (`e0014/mod.rs`)
+- [x] E0099 skips `assert_type`/`reveal_type`/`cast` arguments (`protocol_ext.rs`)
+- [x] `tuple[Any,...]`/`tuple[Unknown,...]` source → fixed-length target (gradual) (`types.rs`)
+- [x] Recursive `Union` value-alias matcher (Json/RecursiveTuple/RecursiveMapping) (`e0014/alias_match.rs`)
+- [x] PEP 646 variadic-tuple `*tuple[...]` star matching (`types.rs`)
+- [x] Non-decimal `Literal` integer equivalence (`0x14`==`0o24`==`0b10100`) (`types_parsing.rs`)
+- [x] Shared `parse_key_value_args` helper (dedup `dict[]`/`Mapping[]` parsing)
+- [x] Mutation-hardening e2e tests (`tests/fp_elimination_tests.rs`) + FP-ceiling ratchet → 126
 
-### Completed (120+ FPs eliminated, 177 -> 57 as of 2026-03-21)
+### Remaining — deferred engine work (need narrowing / structural subtyping / resolver expansion)
 
-- [x] Step 0: Add FP verbose reporting to conformance harness — `diag_line_rules` HashMap in `conformance_tests.rs`
-- [x] BSK-E0014: bare generics (`list`, `dict`, `set`, `tuple`) + `complex` type recognition — 7 FPs fixed
-- [x] BSK-E0104: recursive alias cycle detection — allow container-wrapped recursion — 2 FPs fixed
-- [x] BSK-E0061: enum `assert_type` — only flag when first arg is enum-typed param — 8 FPs fixed
-- [x] BSK-E0111: constructor calls — add builtin base classes, dataclass inheritance, `__init_subclass__` — 9 FPs fixed
-- [x] BSK-E0149: PEP 695 type param extraction — fixed `extract_pep695_type_params` to check `=` for `type` statements, preventing RHS subscripts from being treated as type params — 18 FPs fixed
-- [x] BSK-E0093: TypedDict `Required`/`NotRequired`/`ReadOnly` — added `is_field_required()` helper and `strip_td_wrappers()` for value type comparison — 9 FPs fixed
-- [x] BSK-E0110: protocol variance — treat invariant containers as variance-neutral; add `tuple`/`Tuple` to covariant containers — 5 FPs fixed
-- [x] BSK-E0121: protocol conformance — check class attributes (not just methods) for protocol member satisfaction — 7 FPs fixed
-- [x] BSK-E0130: TypeVar scoping — skip docstrings, comments, and multi-line function signature continuations — 6 FPs fixed
-- [x] BSK-E0014: **massive FP elimination** — suppress when RHS is non-literal (variable/param/call) and involves Named/Callable/Tuple types; suppress when declared type is Named (unresolved alias); `contains_unresolvable` recursive check; `# type: ignore` line-level support — **101 FPs fixed**
-- [x] BSK-E0013: return type mismatch — `contains_named` recursive check for declared types with Named inside unions/tuples; `is_base_to_literal` for Bool→Literal[True/False] and Int→Literal[N] etc. — **7 FPs fixed**
-- [x] BSK-E0053: `assert_type` — variadic tuple equivalence in `types_match` — **4 FPs fixed**
-- [x] File-level `# type: ignore` support in `suppression.rs` — detect standalone `# type: ignore` before executable code and suppress all diagnostics — **1 FP fixed**
-
-### Remaining: 18 FPs across 15 files (scattered, low-count rules)
-
-All remaining FPs are 1-2 per rule — no single rule dominates. See updated breakdown table above.
-
-**Notable**: E0094 (2), E0093 (2), E0140 (2), E0014 (2) are the only rules with >1 FP. All others have exactly 1.
+- [ ] **Callable/protocol structural subtyping** (~49): callables_subtyping (24), callables_annotation (16), protocols_subtyping (7), protocols_merging (2). Blocked on resolver capturing parameter **kind** (positional-only `/`, keyword-only `*`) in `ParameterInfo`, then full PEP 484 callable subtyping. Load-bearing — suppression drops ~40 TPs.
+- [ ] **TypedDict structural assignability** (~17): E0014 readonly_consistency (5)/readonly_inheritance (2)/inheritance (1); E0093 extra_items/ReadOnly/final/update (7+); PEP 728/705.
+- [ ] **`assert_type` flow narrowing** (E0053 ~11): isinstance/`is`/TypeGuard/TypeIs (exceptions_context_managers 4, literals_interactions 4, narrowing_typeguard 2, narrowing_typeis 1) + Union/tuple-unpack syntactic equivalence (annotations_typeexpr 1, tuples_unpacked 3).
+- [ ] **Constructors** (E0111 9): dataclass_transform class/converter/meta, NamedTuple subscript/inheritance, type-erasure.
+- [ ] **Recursive generic aliases** (4): TypeVar substitution (GenericTypeAlias1/2 in aliases_recursive).
+- [ ] **E0012 TypeVarTuple arity** (4): needs argument-type resolution in E0012.
+- [ ] **E0130 TypeVar scoping** (3), **E0047 ParamSpec annotations** (≈4), and scattered singles (E0048/E0054/E0069/E0060/E0115/E0094/E0078/E0092/E0139/E0112/E0140/E0041/E0143).
+- [ ] **`if not TYPE_CHECKING:` block bodies** (E0014 directives_type_checking 1): resolver must mark statements unreachable to the checker.
 
 ---
 

--- a/mutation_testing/mutation_scores.json
+++ b/mutation_testing/mutation_scores.json
@@ -1,12 +1,12 @@
 {
   "scores": {
     "working": {
-      "caught": 67,
-      "date": "2026-05-31",
-      "kill_rate": 90.54,
+      "caught": 69,
+      "date": "2026-06-03",
+      "kill_rate": 90.79,
       "missed": 7,
       "timeout": 0,
-      "total": 81,
+      "total": 83,
       "unviable": 7
     }
   },

--- a/scripts/fp_verify.sh
+++ b/scripts/fp_verify.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# FP-elimination verification harness.
+#
+# Runs the PEP conformance suite, captures per-FP rule mapping, and diffs the
+# regenerated conformance_status.csv against a saved baseline to enforce the
+# HARD INVARIANT: no file may regress PASS->FAIL, total `caught` may not drop,
+# total `missed` may not rise, and `fp` must trend DOWN.
+#
+# Usage:
+#   scripts/fp_verify.sh                  # verify against /tmp/conf_baseline.csv
+#   scripts/fp_verify.sh --save-baseline  # snapshot current CSV as the baseline
+set -euo pipefail
+
+ROOT="/Users/christianfindlay/Documents/Code/Basilisk"
+cd "$ROOT"
+BASELINE="/tmp/conf_baseline.csv"
+CSV="conformance/conformance_status.csv"
+FPLOG="/tmp/fp_current.txt"
+
+if [[ "${1:-}" == "--save-baseline" ]]; then
+  cp "$CSV" "$BASELINE"
+  echo "baseline saved: $BASELINE"
+  exit 0
+fi
+
+# Run the conformance suite (release), capturing FP lines.
+cargo test --test conformance_tests --release -- --nocapture 2>&1 \
+  | grep -E '^  FP ' | sort > "$FPLOG" || true
+
+echo "=== totals (current) ==="
+awk -F, 'NR>1{c+=$5;m+=$6;f+=$7; if($4=="PASS")p++; else if($4=="FAIL")fl++} \
+  END{printf "PASS=%d FAIL=%d caught=%d missed=%d fp=%d\n",p,fl,c,m,f}' "$CSV"
+
+echo "=== totals (baseline) ==="
+awk -F, 'NR>1{c+=$5;m+=$6;f+=$7; if($4=="PASS")p++; else if($4=="FAIL")fl++} \
+  END{printf "PASS=%d FAIL=%d caught=%d missed=%d fp=%d\n",p,fl,c,m,f}' "$BASELINE"
+
+echo "=== per-file regressions (status flip / caught down / missed up) ==="
+# Join baseline and current by filename (col 2); flag any regression.
+awk -F, '
+  FNR==NR { if(FNR>1){bs[$2]=$4; bc[$2]=$5; bm[$2]=$6; bf[$2]=$7} next }
+  FNR>1 {
+    f=$2
+    if (f in bs) {
+      reg=""
+      if (bs[f]=="PASS" && $4!="PASS") reg=reg" STATUS:"bs[f]"->"$4
+      if ($5+0 < bc[f]+0)             reg=reg" CAUGHT:"bc[f]"->"$5
+      if ($6+0 > bm[f]+0)             reg=reg" MISSED:"bm[f]"->"$6
+      if (reg!="") printf "  REGRESSION %s:%s\n", f, reg
+    }
+  }
+' "$BASELINE" "$CSV" || true
+echo "(none above = clean)"
+
+echo "=== FP delta by file (baseline -> current; only changes) ==="
+awk -F, '
+  FNR==NR { if(FNR>1) bf[$2]=$7; next }
+  FNR>1 { if ($7+0 != bf[$2]+0) printf "  %s: fp %s -> %s\n", $2, bf[$2], $7 }
+' "$BASELINE" "$CSV" || true
+echo "(none above = no FP change)"


### PR DESCRIPTION
## TLDR
Eliminate 44 PEP-conformance false positives (170 → 126) with zero conformance regression, and lock the win in place with a ratcheting FP ceiling plus mutation-kill tests.

## What Was Added?
- **`crates/basilisk-checker/src/rules/e0014/alias_match.rs`** — recursive value-matcher for legacy `Name = Union[...]` aliases (including self-referential ones like `Json`). Uses *positive-match* semantics so genuinely-incompatible assignments still fire; `Unknown`/`Any` values never spuriously match a concrete target.
- **`crates/basilisk-checker/tests/fp_elimination_tests.rs`** — 9 bidirectional coarse e2e tests; each asserts the eliminated false positive is gone AND the paired true positive still fires.
- **FP-ceiling gate in `crates/basilisk-cli/tests/conformance_tests.rs`** — reads `conformance.max_false_positives` from `coverage-thresholds.json` and fails CI if the suite-wide FP total exceeds it (ratchets DOWN only — the mirror of the pass-percentage gate).
- **`scripts/fp_verify.sh`** — rebuild + conformance + CSV-diff harness that flags any PASS→FAIL flip, caught-count drop, or missed-count rise, plus the FP delta.
- Two `#[mutation_safe(rule = "e0014", fns = "check_vars")]` tests in `mutation_kill_tests.rs` covering the two new `check_vars` branches.

## What Was Changed or Deleted?
False positives removed across several engine paths (all behind the no-regression invariant):
- **`types_parsing.rs`** — bare `Callable`/`type` parse as Any-like; `tuple[()]` → empty-tuple type; non-decimal int literals (`0x`/`0o`/`0b`) compare equal across spellings; shared `parse_key_value_args` helper de-duplicates `dict[…]`/`Mapping[…]` parsing.
- **`types.rs`** — PEP 646 variadic-tuple star matching (`tuple[int, *tuple[str, ...], int]` etc.; unhandled shapes never manufacture an FP); gradual `tuple[Any, ...]` source assignable to a fixed tuple; `None` is `Hashable`.
- **`e0014/mod.rs`** — whole-quoted forward-reference annotations are skipped; bare references to legacy `Union` aliases are intercepted for value-level matching.
- **`e0013.rs`** — `is_unverifiable_return_type` recursively skips return-type checks E0013 cannot verify (`Named`/`Literal` and their nestings), while preserving the `tuple[X, ...]` terminator path.
- **`suppression.rs`** — honours a file-level `# type: ignore` (PEP 484) placed before any substantial line, and treats mypy-style `# type: ignore[assignment]` (non-`BSK-` codes) as a blanket line suppression.
- **`protocol_ext.rs`** — E0099 no longer arg-checks type-checking utilities (`assert_type`/`reveal_type`/`cast`).
- **`coverage-thresholds.json`** — `max_false_positives` 161 → 126 (tightened to the measured value). **`mutation_scores.json`** working-scope baseline ratcheted 90.54% → 90.79%.

## How Do The Automated Tests Prove It Works?
- **Conformance gate (`conformance_score` test):** suite-wide false positives **170 → 126 (−44)** while **PASS = 136/146, caught = 858, missed = 95 are all unchanged** — no file flips PASS→FAIL, `caught` never drops, `missed` never rises. The new FP ceiling (126) fails CI if even one FP returns.
- **`fp_elimination_tests.rs` (9 tests):** e.g. `recursive_union_alias_accepts_valid_and_rejects_invalid` (valid `Json` values pass, two `3j` complex values still fire), `variadic_tuple_star_targets` (only the too-short tuple fires), `gradual_variadic_tuple_source_is_assignable`, `bare_callable_and_type_are_any_like`, `none_is_hashable_but_not_iterable`, `empty_tuple_type`, `non_decimal_literal_equivalence`, `quoted_forward_ref_annotation_is_skipped`.
- **Mutation testing:** the two new `check_vars` branches introduced mutants `e0014/mod.rs:140 replace || with &&` and `:219 delete !`; the two added `mutation_safe` tests kill both — working-scope score 67→69 caught, 7 missed unchanged, kill_rate **90.79% ≥ 90.54%** baseline.

## Spec / Doc Changes
- `docs/plans/CHECK-ELIMINATE-FALSE-POSITIVES.md` — execution log, the −44 breakdown, and a bottom checklist (done items ticked; remaining engine-blocked clusters — callable/protocol structural subtyping, TypedDict structural, narrowing, constructors — documented as deferred with unblocking notes). All code references `[CHKARCH-DIAG-TYPESAFETY]` / `[CHKARCH-TESTING]`.

## Breaking Changes
- [x] None
