### PR TITLE
feat(cli): opt-in result cache for `basilisk check` + honest warm/cold benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,8 @@ dependencies = [
  "basilisk-uv",
  "ruff_python_ast",
  "ruff_text_size",
+ "serde",
+ "serde_json",
  "tempfile",
 ]
 
@@ -244,6 +246,7 @@ dependencies = [
  "basilisk-checker",
  "basilisk-common",
  "basilisk-config",
+ "basilisk-db",
  "basilisk-lsp",
  "basilisk-parser",
  "basilisk-resolver",
@@ -292,6 +295,12 @@ dependencies = [
 [[package]]
 name = "basilisk-db"
 version = "0.0.0-PLACEHOLDER"
+dependencies = [
+ "basilisk-common",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
 
 [[package]]
 name = "basilisk-lsp"
@@ -327,6 +336,7 @@ version = "0.0.0-PLACEHOLDER"
 name = "basilisk-parser"
 version = "0.0.0-PLACEHOLDER"
 dependencies = [
+ "basilisk-common",
  "ruff_python_ast",
  "ruff_python_parser",
  "thiserror 2.0.18",
@@ -370,6 +380,7 @@ dependencies = [
  "basilisk-test-utils",
  "ruff_python_ast",
  "ruff_text_size",
+ "serde",
  "thiserror 2.0.18",
 ]
 
@@ -377,11 +388,13 @@ dependencies = [
 name = "basilisk-stubs"
 version = "0.0.0-PLACEHOLDER"
 dependencies = [
+ "basilisk-common",
  "phf",
  "phf_codegen",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_text_size",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",

--- a/benchmarks/fixtures/e0011_explicit_any.py
+++ b/benchmarks/fixtures/e0011_explicit_any.py
@@ -1,0 +1,4001 @@
+from typing import Any
+def any_fn_1(arg_1: Any) -> int:
+    return 1
+def any_fn_2(arg_2: Any) -> int:
+    return 1
+def any_fn_3(arg_3: Any) -> int:
+    return 1
+def any_fn_4(arg_4: Any) -> int:
+    return 1
+def any_fn_5(arg_5: Any) -> int:
+    return 1
+def any_fn_6(arg_6: Any) -> int:
+    return 1
+def any_fn_7(arg_7: Any) -> int:
+    return 1
+def any_fn_8(arg_8: Any) -> int:
+    return 1
+def any_fn_9(arg_9: Any) -> int:
+    return 1
+def any_fn_10(arg_10: Any) -> int:
+    return 1
+def any_fn_11(arg_11: Any) -> int:
+    return 1
+def any_fn_12(arg_12: Any) -> int:
+    return 1
+def any_fn_13(arg_13: Any) -> int:
+    return 1
+def any_fn_14(arg_14: Any) -> int:
+    return 1
+def any_fn_15(arg_15: Any) -> int:
+    return 1
+def any_fn_16(arg_16: Any) -> int:
+    return 1
+def any_fn_17(arg_17: Any) -> int:
+    return 1
+def any_fn_18(arg_18: Any) -> int:
+    return 1
+def any_fn_19(arg_19: Any) -> int:
+    return 1
+def any_fn_20(arg_20: Any) -> int:
+    return 1
+def any_fn_21(arg_21: Any) -> int:
+    return 1
+def any_fn_22(arg_22: Any) -> int:
+    return 1
+def any_fn_23(arg_23: Any) -> int:
+    return 1
+def any_fn_24(arg_24: Any) -> int:
+    return 1
+def any_fn_25(arg_25: Any) -> int:
+    return 1
+def any_fn_26(arg_26: Any) -> int:
+    return 1
+def any_fn_27(arg_27: Any) -> int:
+    return 1
+def any_fn_28(arg_28: Any) -> int:
+    return 1
+def any_fn_29(arg_29: Any) -> int:
+    return 1
+def any_fn_30(arg_30: Any) -> int:
+    return 1
+def any_fn_31(arg_31: Any) -> int:
+    return 1
+def any_fn_32(arg_32: Any) -> int:
+    return 1
+def any_fn_33(arg_33: Any) -> int:
+    return 1
+def any_fn_34(arg_34: Any) -> int:
+    return 1
+def any_fn_35(arg_35: Any) -> int:
+    return 1
+def any_fn_36(arg_36: Any) -> int:
+    return 1
+def any_fn_37(arg_37: Any) -> int:
+    return 1
+def any_fn_38(arg_38: Any) -> int:
+    return 1
+def any_fn_39(arg_39: Any) -> int:
+    return 1
+def any_fn_40(arg_40: Any) -> int:
+    return 1
+def any_fn_41(arg_41: Any) -> int:
+    return 1
+def any_fn_42(arg_42: Any) -> int:
+    return 1
+def any_fn_43(arg_43: Any) -> int:
+    return 1
+def any_fn_44(arg_44: Any) -> int:
+    return 1
+def any_fn_45(arg_45: Any) -> int:
+    return 1
+def any_fn_46(arg_46: Any) -> int:
+    return 1
+def any_fn_47(arg_47: Any) -> int:
+    return 1
+def any_fn_48(arg_48: Any) -> int:
+    return 1
+def any_fn_49(arg_49: Any) -> int:
+    return 1
+def any_fn_50(arg_50: Any) -> int:
+    return 1
+def any_fn_51(arg_51: Any) -> int:
+    return 1
+def any_fn_52(arg_52: Any) -> int:
+    return 1
+def any_fn_53(arg_53: Any) -> int:
+    return 1
+def any_fn_54(arg_54: Any) -> int:
+    return 1
+def any_fn_55(arg_55: Any) -> int:
+    return 1
+def any_fn_56(arg_56: Any) -> int:
+    return 1
+def any_fn_57(arg_57: Any) -> int:
+    return 1
+def any_fn_58(arg_58: Any) -> int:
+    return 1
+def any_fn_59(arg_59: Any) -> int:
+    return 1
+def any_fn_60(arg_60: Any) -> int:
+    return 1
+def any_fn_61(arg_61: Any) -> int:
+    return 1
+def any_fn_62(arg_62: Any) -> int:
+    return 1
+def any_fn_63(arg_63: Any) -> int:
+    return 1
+def any_fn_64(arg_64: Any) -> int:
+    return 1
+def any_fn_65(arg_65: Any) -> int:
+    return 1
+def any_fn_66(arg_66: Any) -> int:
+    return 1
+def any_fn_67(arg_67: Any) -> int:
+    return 1
+def any_fn_68(arg_68: Any) -> int:
+    return 1
+def any_fn_69(arg_69: Any) -> int:
+    return 1
+def any_fn_70(arg_70: Any) -> int:
+    return 1
+def any_fn_71(arg_71: Any) -> int:
+    return 1
+def any_fn_72(arg_72: Any) -> int:
+    return 1
+def any_fn_73(arg_73: Any) -> int:
+    return 1
+def any_fn_74(arg_74: Any) -> int:
+    return 1
+def any_fn_75(arg_75: Any) -> int:
+    return 1
+def any_fn_76(arg_76: Any) -> int:
+    return 1
+def any_fn_77(arg_77: Any) -> int:
+    return 1
+def any_fn_78(arg_78: Any) -> int:
+    return 1
+def any_fn_79(arg_79: Any) -> int:
+    return 1
+def any_fn_80(arg_80: Any) -> int:
+    return 1
+def any_fn_81(arg_81: Any) -> int:
+    return 1
+def any_fn_82(arg_82: Any) -> int:
+    return 1
+def any_fn_83(arg_83: Any) -> int:
+    return 1
+def any_fn_84(arg_84: Any) -> int:
+    return 1
+def any_fn_85(arg_85: Any) -> int:
+    return 1
+def any_fn_86(arg_86: Any) -> int:
+    return 1
+def any_fn_87(arg_87: Any) -> int:
+    return 1
+def any_fn_88(arg_88: Any) -> int:
+    return 1
+def any_fn_89(arg_89: Any) -> int:
+    return 1
+def any_fn_90(arg_90: Any) -> int:
+    return 1
+def any_fn_91(arg_91: Any) -> int:
+    return 1
+def any_fn_92(arg_92: Any) -> int:
+    return 1
+def any_fn_93(arg_93: Any) -> int:
+    return 1
+def any_fn_94(arg_94: Any) -> int:
+    return 1
+def any_fn_95(arg_95: Any) -> int:
+    return 1
+def any_fn_96(arg_96: Any) -> int:
+    return 1
+def any_fn_97(arg_97: Any) -> int:
+    return 1
+def any_fn_98(arg_98: Any) -> int:
+    return 1
+def any_fn_99(arg_99: Any) -> int:
+    return 1
+def any_fn_100(arg_100: Any) -> int:
+    return 1
+def any_fn_101(arg_101: Any) -> int:
+    return 1
+def any_fn_102(arg_102: Any) -> int:
+    return 1
+def any_fn_103(arg_103: Any) -> int:
+    return 1
+def any_fn_104(arg_104: Any) -> int:
+    return 1
+def any_fn_105(arg_105: Any) -> int:
+    return 1
+def any_fn_106(arg_106: Any) -> int:
+    return 1
+def any_fn_107(arg_107: Any) -> int:
+    return 1
+def any_fn_108(arg_108: Any) -> int:
+    return 1
+def any_fn_109(arg_109: Any) -> int:
+    return 1
+def any_fn_110(arg_110: Any) -> int:
+    return 1
+def any_fn_111(arg_111: Any) -> int:
+    return 1
+def any_fn_112(arg_112: Any) -> int:
+    return 1
+def any_fn_113(arg_113: Any) -> int:
+    return 1
+def any_fn_114(arg_114: Any) -> int:
+    return 1
+def any_fn_115(arg_115: Any) -> int:
+    return 1
+def any_fn_116(arg_116: Any) -> int:
+    return 1
+def any_fn_117(arg_117: Any) -> int:
+    return 1
+def any_fn_118(arg_118: Any) -> int:
+    return 1
+def any_fn_119(arg_119: Any) -> int:
+    return 1
+def any_fn_120(arg_120: Any) -> int:
+    return 1
+def any_fn_121(arg_121: Any) -> int:
+    return 1
+def any_fn_122(arg_122: Any) -> int:
+    return 1
+def any_fn_123(arg_123: Any) -> int:
+    return 1
+def any_fn_124(arg_124: Any) -> int:
+    return 1
+def any_fn_125(arg_125: Any) -> int:
+    return 1
+def any_fn_126(arg_126: Any) -> int:
+    return 1
+def any_fn_127(arg_127: Any) -> int:
+    return 1
+def any_fn_128(arg_128: Any) -> int:
+    return 1
+def any_fn_129(arg_129: Any) -> int:
+    return 1
+def any_fn_130(arg_130: Any) -> int:
+    return 1
+def any_fn_131(arg_131: Any) -> int:
+    return 1
+def any_fn_132(arg_132: Any) -> int:
+    return 1
+def any_fn_133(arg_133: Any) -> int:
+    return 1
+def any_fn_134(arg_134: Any) -> int:
+    return 1
+def any_fn_135(arg_135: Any) -> int:
+    return 1
+def any_fn_136(arg_136: Any) -> int:
+    return 1
+def any_fn_137(arg_137: Any) -> int:
+    return 1
+def any_fn_138(arg_138: Any) -> int:
+    return 1
+def any_fn_139(arg_139: Any) -> int:
+    return 1
+def any_fn_140(arg_140: Any) -> int:
+    return 1
+def any_fn_141(arg_141: Any) -> int:
+    return 1
+def any_fn_142(arg_142: Any) -> int:
+    return 1
+def any_fn_143(arg_143: Any) -> int:
+    return 1
+def any_fn_144(arg_144: Any) -> int:
+    return 1
+def any_fn_145(arg_145: Any) -> int:
+    return 1
+def any_fn_146(arg_146: Any) -> int:
+    return 1
+def any_fn_147(arg_147: Any) -> int:
+    return 1
+def any_fn_148(arg_148: Any) -> int:
+    return 1
+def any_fn_149(arg_149: Any) -> int:
+    return 1
+def any_fn_150(arg_150: Any) -> int:
+    return 1
+def any_fn_151(arg_151: Any) -> int:
+    return 1
+def any_fn_152(arg_152: Any) -> int:
+    return 1
+def any_fn_153(arg_153: Any) -> int:
+    return 1
+def any_fn_154(arg_154: Any) -> int:
+    return 1
+def any_fn_155(arg_155: Any) -> int:
+    return 1
+def any_fn_156(arg_156: Any) -> int:
+    return 1
+def any_fn_157(arg_157: Any) -> int:
+    return 1
+def any_fn_158(arg_158: Any) -> int:
+    return 1
+def any_fn_159(arg_159: Any) -> int:
+    return 1
+def any_fn_160(arg_160: Any) -> int:
+    return 1
+def any_fn_161(arg_161: Any) -> int:
+    return 1
+def any_fn_162(arg_162: Any) -> int:
+    return 1
+def any_fn_163(arg_163: Any) -> int:
+    return 1
+def any_fn_164(arg_164: Any) -> int:
+    return 1
+def any_fn_165(arg_165: Any) -> int:
+    return 1
+def any_fn_166(arg_166: Any) -> int:
+    return 1
+def any_fn_167(arg_167: Any) -> int:
+    return 1
+def any_fn_168(arg_168: Any) -> int:
+    return 1
+def any_fn_169(arg_169: Any) -> int:
+    return 1
+def any_fn_170(arg_170: Any) -> int:
+    return 1
+def any_fn_171(arg_171: Any) -> int:
+    return 1
+def any_fn_172(arg_172: Any) -> int:
+    return 1
+def any_fn_173(arg_173: Any) -> int:
+    return 1
+def any_fn_174(arg_174: Any) -> int:
+    return 1
+def any_fn_175(arg_175: Any) -> int:
+    return 1
+def any_fn_176(arg_176: Any) -> int:
+    return 1
+def any_fn_177(arg_177: Any) -> int:
+    return 1
+def any_fn_178(arg_178: Any) -> int:
+    return 1
+def any_fn_179(arg_179: Any) -> int:
+    return 1
+def any_fn_180(arg_180: Any) -> int:
+    return 1
+def any_fn_181(arg_181: Any) -> int:
+    return 1
+def any_fn_182(arg_182: Any) -> int:
+    return 1
+def any_fn_183(arg_183: Any) -> int:
+    return 1
+def any_fn_184(arg_184: Any) -> int:
+    return 1
+def any_fn_185(arg_185: Any) -> int:
+    return 1
+def any_fn_186(arg_186: Any) -> int:
+    return 1
+def any_fn_187(arg_187: Any) -> int:
+    return 1
+def any_fn_188(arg_188: Any) -> int:
+    return 1
+def any_fn_189(arg_189: Any) -> int:
+    return 1
+def any_fn_190(arg_190: Any) -> int:
+    return 1
+def any_fn_191(arg_191: Any) -> int:
+    return 1
+def any_fn_192(arg_192: Any) -> int:
+    return 1
+def any_fn_193(arg_193: Any) -> int:
+    return 1
+def any_fn_194(arg_194: Any) -> int:
+    return 1
+def any_fn_195(arg_195: Any) -> int:
+    return 1
+def any_fn_196(arg_196: Any) -> int:
+    return 1
+def any_fn_197(arg_197: Any) -> int:
+    return 1
+def any_fn_198(arg_198: Any) -> int:
+    return 1
+def any_fn_199(arg_199: Any) -> int:
+    return 1
+def any_fn_200(arg_200: Any) -> int:
+    return 1
+def any_fn_201(arg_201: Any) -> int:
+    return 1
+def any_fn_202(arg_202: Any) -> int:
+    return 1
+def any_fn_203(arg_203: Any) -> int:
+    return 1
+def any_fn_204(arg_204: Any) -> int:
+    return 1
+def any_fn_205(arg_205: Any) -> int:
+    return 1
+def any_fn_206(arg_206: Any) -> int:
+    return 1
+def any_fn_207(arg_207: Any) -> int:
+    return 1
+def any_fn_208(arg_208: Any) -> int:
+    return 1
+def any_fn_209(arg_209: Any) -> int:
+    return 1
+def any_fn_210(arg_210: Any) -> int:
+    return 1
+def any_fn_211(arg_211: Any) -> int:
+    return 1
+def any_fn_212(arg_212: Any) -> int:
+    return 1
+def any_fn_213(arg_213: Any) -> int:
+    return 1
+def any_fn_214(arg_214: Any) -> int:
+    return 1
+def any_fn_215(arg_215: Any) -> int:
+    return 1
+def any_fn_216(arg_216: Any) -> int:
+    return 1
+def any_fn_217(arg_217: Any) -> int:
+    return 1
+def any_fn_218(arg_218: Any) -> int:
+    return 1
+def any_fn_219(arg_219: Any) -> int:
+    return 1
+def any_fn_220(arg_220: Any) -> int:
+    return 1
+def any_fn_221(arg_221: Any) -> int:
+    return 1
+def any_fn_222(arg_222: Any) -> int:
+    return 1
+def any_fn_223(arg_223: Any) -> int:
+    return 1
+def any_fn_224(arg_224: Any) -> int:
+    return 1
+def any_fn_225(arg_225: Any) -> int:
+    return 1
+def any_fn_226(arg_226: Any) -> int:
+    return 1
+def any_fn_227(arg_227: Any) -> int:
+    return 1
+def any_fn_228(arg_228: Any) -> int:
+    return 1
+def any_fn_229(arg_229: Any) -> int:
+    return 1
+def any_fn_230(arg_230: Any) -> int:
+    return 1
+def any_fn_231(arg_231: Any) -> int:
+    return 1
+def any_fn_232(arg_232: Any) -> int:
+    return 1
+def any_fn_233(arg_233: Any) -> int:
+    return 1
+def any_fn_234(arg_234: Any) -> int:
+    return 1
+def any_fn_235(arg_235: Any) -> int:
+    return 1
+def any_fn_236(arg_236: Any) -> int:
+    return 1
+def any_fn_237(arg_237: Any) -> int:
+    return 1
+def any_fn_238(arg_238: Any) -> int:
+    return 1
+def any_fn_239(arg_239: Any) -> int:
+    return 1
+def any_fn_240(arg_240: Any) -> int:
+    return 1
+def any_fn_241(arg_241: Any) -> int:
+    return 1
+def any_fn_242(arg_242: Any) -> int:
+    return 1
+def any_fn_243(arg_243: Any) -> int:
+    return 1
+def any_fn_244(arg_244: Any) -> int:
+    return 1
+def any_fn_245(arg_245: Any) -> int:
+    return 1
+def any_fn_246(arg_246: Any) -> int:
+    return 1
+def any_fn_247(arg_247: Any) -> int:
+    return 1
+def any_fn_248(arg_248: Any) -> int:
+    return 1
+def any_fn_249(arg_249: Any) -> int:
+    return 1
+def any_fn_250(arg_250: Any) -> int:
+    return 1
+def any_fn_251(arg_251: Any) -> int:
+    return 1
+def any_fn_252(arg_252: Any) -> int:
+    return 1
+def any_fn_253(arg_253: Any) -> int:
+    return 1
+def any_fn_254(arg_254: Any) -> int:
+    return 1
+def any_fn_255(arg_255: Any) -> int:
+    return 1
+def any_fn_256(arg_256: Any) -> int:
+    return 1
+def any_fn_257(arg_257: Any) -> int:
+    return 1
+def any_fn_258(arg_258: Any) -> int:
+    return 1
+def any_fn_259(arg_259: Any) -> int:
+    return 1
+def any_fn_260(arg_260: Any) -> int:
+    return 1
+def any_fn_261(arg_261: Any) -> int:
+    return 1
+def any_fn_262(arg_262: Any) -> int:
+    return 1
+def any_fn_263(arg_263: Any) -> int:
+    return 1
+def any_fn_264(arg_264: Any) -> int:
+    return 1
+def any_fn_265(arg_265: Any) -> int:
+    return 1
+def any_fn_266(arg_266: Any) -> int:
+    return 1
+def any_fn_267(arg_267: Any) -> int:
+    return 1
+def any_fn_268(arg_268: Any) -> int:
+    return 1
+def any_fn_269(arg_269: Any) -> int:
+    return 1
+def any_fn_270(arg_270: Any) -> int:
+    return 1
+def any_fn_271(arg_271: Any) -> int:
+    return 1
+def any_fn_272(arg_272: Any) -> int:
+    return 1
+def any_fn_273(arg_273: Any) -> int:
+    return 1
+def any_fn_274(arg_274: Any) -> int:
+    return 1
+def any_fn_275(arg_275: Any) -> int:
+    return 1
+def any_fn_276(arg_276: Any) -> int:
+    return 1
+def any_fn_277(arg_277: Any) -> int:
+    return 1
+def any_fn_278(arg_278: Any) -> int:
+    return 1
+def any_fn_279(arg_279: Any) -> int:
+    return 1
+def any_fn_280(arg_280: Any) -> int:
+    return 1
+def any_fn_281(arg_281: Any) -> int:
+    return 1
+def any_fn_282(arg_282: Any) -> int:
+    return 1
+def any_fn_283(arg_283: Any) -> int:
+    return 1
+def any_fn_284(arg_284: Any) -> int:
+    return 1
+def any_fn_285(arg_285: Any) -> int:
+    return 1
+def any_fn_286(arg_286: Any) -> int:
+    return 1
+def any_fn_287(arg_287: Any) -> int:
+    return 1
+def any_fn_288(arg_288: Any) -> int:
+    return 1
+def any_fn_289(arg_289: Any) -> int:
+    return 1
+def any_fn_290(arg_290: Any) -> int:
+    return 1
+def any_fn_291(arg_291: Any) -> int:
+    return 1
+def any_fn_292(arg_292: Any) -> int:
+    return 1
+def any_fn_293(arg_293: Any) -> int:
+    return 1
+def any_fn_294(arg_294: Any) -> int:
+    return 1
+def any_fn_295(arg_295: Any) -> int:
+    return 1
+def any_fn_296(arg_296: Any) -> int:
+    return 1
+def any_fn_297(arg_297: Any) -> int:
+    return 1
+def any_fn_298(arg_298: Any) -> int:
+    return 1
+def any_fn_299(arg_299: Any) -> int:
+    return 1
+def any_fn_300(arg_300: Any) -> int:
+    return 1
+def any_fn_301(arg_301: Any) -> int:
+    return 1
+def any_fn_302(arg_302: Any) -> int:
+    return 1
+def any_fn_303(arg_303: Any) -> int:
+    return 1
+def any_fn_304(arg_304: Any) -> int:
+    return 1
+def any_fn_305(arg_305: Any) -> int:
+    return 1
+def any_fn_306(arg_306: Any) -> int:
+    return 1
+def any_fn_307(arg_307: Any) -> int:
+    return 1
+def any_fn_308(arg_308: Any) -> int:
+    return 1
+def any_fn_309(arg_309: Any) -> int:
+    return 1
+def any_fn_310(arg_310: Any) -> int:
+    return 1
+def any_fn_311(arg_311: Any) -> int:
+    return 1
+def any_fn_312(arg_312: Any) -> int:
+    return 1
+def any_fn_313(arg_313: Any) -> int:
+    return 1
+def any_fn_314(arg_314: Any) -> int:
+    return 1
+def any_fn_315(arg_315: Any) -> int:
+    return 1
+def any_fn_316(arg_316: Any) -> int:
+    return 1
+def any_fn_317(arg_317: Any) -> int:
+    return 1
+def any_fn_318(arg_318: Any) -> int:
+    return 1
+def any_fn_319(arg_319: Any) -> int:
+    return 1
+def any_fn_320(arg_320: Any) -> int:
+    return 1
+def any_fn_321(arg_321: Any) -> int:
+    return 1
+def any_fn_322(arg_322: Any) -> int:
+    return 1
+def any_fn_323(arg_323: Any) -> int:
+    return 1
+def any_fn_324(arg_324: Any) -> int:
+    return 1
+def any_fn_325(arg_325: Any) -> int:
+    return 1
+def any_fn_326(arg_326: Any) -> int:
+    return 1
+def any_fn_327(arg_327: Any) -> int:
+    return 1
+def any_fn_328(arg_328: Any) -> int:
+    return 1
+def any_fn_329(arg_329: Any) -> int:
+    return 1
+def any_fn_330(arg_330: Any) -> int:
+    return 1
+def any_fn_331(arg_331: Any) -> int:
+    return 1
+def any_fn_332(arg_332: Any) -> int:
+    return 1
+def any_fn_333(arg_333: Any) -> int:
+    return 1
+def any_fn_334(arg_334: Any) -> int:
+    return 1
+def any_fn_335(arg_335: Any) -> int:
+    return 1
+def any_fn_336(arg_336: Any) -> int:
+    return 1
+def any_fn_337(arg_337: Any) -> int:
+    return 1
+def any_fn_338(arg_338: Any) -> int:
+    return 1
+def any_fn_339(arg_339: Any) -> int:
+    return 1
+def any_fn_340(arg_340: Any) -> int:
+    return 1
+def any_fn_341(arg_341: Any) -> int:
+    return 1
+def any_fn_342(arg_342: Any) -> int:
+    return 1
+def any_fn_343(arg_343: Any) -> int:
+    return 1
+def any_fn_344(arg_344: Any) -> int:
+    return 1
+def any_fn_345(arg_345: Any) -> int:
+    return 1
+def any_fn_346(arg_346: Any) -> int:
+    return 1
+def any_fn_347(arg_347: Any) -> int:
+    return 1
+def any_fn_348(arg_348: Any) -> int:
+    return 1
+def any_fn_349(arg_349: Any) -> int:
+    return 1
+def any_fn_350(arg_350: Any) -> int:
+    return 1
+def any_fn_351(arg_351: Any) -> int:
+    return 1
+def any_fn_352(arg_352: Any) -> int:
+    return 1
+def any_fn_353(arg_353: Any) -> int:
+    return 1
+def any_fn_354(arg_354: Any) -> int:
+    return 1
+def any_fn_355(arg_355: Any) -> int:
+    return 1
+def any_fn_356(arg_356: Any) -> int:
+    return 1
+def any_fn_357(arg_357: Any) -> int:
+    return 1
+def any_fn_358(arg_358: Any) -> int:
+    return 1
+def any_fn_359(arg_359: Any) -> int:
+    return 1
+def any_fn_360(arg_360: Any) -> int:
+    return 1
+def any_fn_361(arg_361: Any) -> int:
+    return 1
+def any_fn_362(arg_362: Any) -> int:
+    return 1
+def any_fn_363(arg_363: Any) -> int:
+    return 1
+def any_fn_364(arg_364: Any) -> int:
+    return 1
+def any_fn_365(arg_365: Any) -> int:
+    return 1
+def any_fn_366(arg_366: Any) -> int:
+    return 1
+def any_fn_367(arg_367: Any) -> int:
+    return 1
+def any_fn_368(arg_368: Any) -> int:
+    return 1
+def any_fn_369(arg_369: Any) -> int:
+    return 1
+def any_fn_370(arg_370: Any) -> int:
+    return 1
+def any_fn_371(arg_371: Any) -> int:
+    return 1
+def any_fn_372(arg_372: Any) -> int:
+    return 1
+def any_fn_373(arg_373: Any) -> int:
+    return 1
+def any_fn_374(arg_374: Any) -> int:
+    return 1
+def any_fn_375(arg_375: Any) -> int:
+    return 1
+def any_fn_376(arg_376: Any) -> int:
+    return 1
+def any_fn_377(arg_377: Any) -> int:
+    return 1
+def any_fn_378(arg_378: Any) -> int:
+    return 1
+def any_fn_379(arg_379: Any) -> int:
+    return 1
+def any_fn_380(arg_380: Any) -> int:
+    return 1
+def any_fn_381(arg_381: Any) -> int:
+    return 1
+def any_fn_382(arg_382: Any) -> int:
+    return 1
+def any_fn_383(arg_383: Any) -> int:
+    return 1
+def any_fn_384(arg_384: Any) -> int:
+    return 1
+def any_fn_385(arg_385: Any) -> int:
+    return 1
+def any_fn_386(arg_386: Any) -> int:
+    return 1
+def any_fn_387(arg_387: Any) -> int:
+    return 1
+def any_fn_388(arg_388: Any) -> int:
+    return 1
+def any_fn_389(arg_389: Any) -> int:
+    return 1
+def any_fn_390(arg_390: Any) -> int:
+    return 1
+def any_fn_391(arg_391: Any) -> int:
+    return 1
+def any_fn_392(arg_392: Any) -> int:
+    return 1
+def any_fn_393(arg_393: Any) -> int:
+    return 1
+def any_fn_394(arg_394: Any) -> int:
+    return 1
+def any_fn_395(arg_395: Any) -> int:
+    return 1
+def any_fn_396(arg_396: Any) -> int:
+    return 1
+def any_fn_397(arg_397: Any) -> int:
+    return 1
+def any_fn_398(arg_398: Any) -> int:
+    return 1
+def any_fn_399(arg_399: Any) -> int:
+    return 1
+def any_fn_400(arg_400: Any) -> int:
+    return 1
+def any_fn_401(arg_401: Any) -> int:
+    return 1
+def any_fn_402(arg_402: Any) -> int:
+    return 1
+def any_fn_403(arg_403: Any) -> int:
+    return 1
+def any_fn_404(arg_404: Any) -> int:
+    return 1
+def any_fn_405(arg_405: Any) -> int:
+    return 1
+def any_fn_406(arg_406: Any) -> int:
+    return 1
+def any_fn_407(arg_407: Any) -> int:
+    return 1
+def any_fn_408(arg_408: Any) -> int:
+    return 1
+def any_fn_409(arg_409: Any) -> int:
+    return 1
+def any_fn_410(arg_410: Any) -> int:
+    return 1
+def any_fn_411(arg_411: Any) -> int:
+    return 1
+def any_fn_412(arg_412: Any) -> int:
+    return 1
+def any_fn_413(arg_413: Any) -> int:
+    return 1
+def any_fn_414(arg_414: Any) -> int:
+    return 1
+def any_fn_415(arg_415: Any) -> int:
+    return 1
+def any_fn_416(arg_416: Any) -> int:
+    return 1
+def any_fn_417(arg_417: Any) -> int:
+    return 1
+def any_fn_418(arg_418: Any) -> int:
+    return 1
+def any_fn_419(arg_419: Any) -> int:
+    return 1
+def any_fn_420(arg_420: Any) -> int:
+    return 1
+def any_fn_421(arg_421: Any) -> int:
+    return 1
+def any_fn_422(arg_422: Any) -> int:
+    return 1
+def any_fn_423(arg_423: Any) -> int:
+    return 1
+def any_fn_424(arg_424: Any) -> int:
+    return 1
+def any_fn_425(arg_425: Any) -> int:
+    return 1
+def any_fn_426(arg_426: Any) -> int:
+    return 1
+def any_fn_427(arg_427: Any) -> int:
+    return 1
+def any_fn_428(arg_428: Any) -> int:
+    return 1
+def any_fn_429(arg_429: Any) -> int:
+    return 1
+def any_fn_430(arg_430: Any) -> int:
+    return 1
+def any_fn_431(arg_431: Any) -> int:
+    return 1
+def any_fn_432(arg_432: Any) -> int:
+    return 1
+def any_fn_433(arg_433: Any) -> int:
+    return 1
+def any_fn_434(arg_434: Any) -> int:
+    return 1
+def any_fn_435(arg_435: Any) -> int:
+    return 1
+def any_fn_436(arg_436: Any) -> int:
+    return 1
+def any_fn_437(arg_437: Any) -> int:
+    return 1
+def any_fn_438(arg_438: Any) -> int:
+    return 1
+def any_fn_439(arg_439: Any) -> int:
+    return 1
+def any_fn_440(arg_440: Any) -> int:
+    return 1
+def any_fn_441(arg_441: Any) -> int:
+    return 1
+def any_fn_442(arg_442: Any) -> int:
+    return 1
+def any_fn_443(arg_443: Any) -> int:
+    return 1
+def any_fn_444(arg_444: Any) -> int:
+    return 1
+def any_fn_445(arg_445: Any) -> int:
+    return 1
+def any_fn_446(arg_446: Any) -> int:
+    return 1
+def any_fn_447(arg_447: Any) -> int:
+    return 1
+def any_fn_448(arg_448: Any) -> int:
+    return 1
+def any_fn_449(arg_449: Any) -> int:
+    return 1
+def any_fn_450(arg_450: Any) -> int:
+    return 1
+def any_fn_451(arg_451: Any) -> int:
+    return 1
+def any_fn_452(arg_452: Any) -> int:
+    return 1
+def any_fn_453(arg_453: Any) -> int:
+    return 1
+def any_fn_454(arg_454: Any) -> int:
+    return 1
+def any_fn_455(arg_455: Any) -> int:
+    return 1
+def any_fn_456(arg_456: Any) -> int:
+    return 1
+def any_fn_457(arg_457: Any) -> int:
+    return 1
+def any_fn_458(arg_458: Any) -> int:
+    return 1
+def any_fn_459(arg_459: Any) -> int:
+    return 1
+def any_fn_460(arg_460: Any) -> int:
+    return 1
+def any_fn_461(arg_461: Any) -> int:
+    return 1
+def any_fn_462(arg_462: Any) -> int:
+    return 1
+def any_fn_463(arg_463: Any) -> int:
+    return 1
+def any_fn_464(arg_464: Any) -> int:
+    return 1
+def any_fn_465(arg_465: Any) -> int:
+    return 1
+def any_fn_466(arg_466: Any) -> int:
+    return 1
+def any_fn_467(arg_467: Any) -> int:
+    return 1
+def any_fn_468(arg_468: Any) -> int:
+    return 1
+def any_fn_469(arg_469: Any) -> int:
+    return 1
+def any_fn_470(arg_470: Any) -> int:
+    return 1
+def any_fn_471(arg_471: Any) -> int:
+    return 1
+def any_fn_472(arg_472: Any) -> int:
+    return 1
+def any_fn_473(arg_473: Any) -> int:
+    return 1
+def any_fn_474(arg_474: Any) -> int:
+    return 1
+def any_fn_475(arg_475: Any) -> int:
+    return 1
+def any_fn_476(arg_476: Any) -> int:
+    return 1
+def any_fn_477(arg_477: Any) -> int:
+    return 1
+def any_fn_478(arg_478: Any) -> int:
+    return 1
+def any_fn_479(arg_479: Any) -> int:
+    return 1
+def any_fn_480(arg_480: Any) -> int:
+    return 1
+def any_fn_481(arg_481: Any) -> int:
+    return 1
+def any_fn_482(arg_482: Any) -> int:
+    return 1
+def any_fn_483(arg_483: Any) -> int:
+    return 1
+def any_fn_484(arg_484: Any) -> int:
+    return 1
+def any_fn_485(arg_485: Any) -> int:
+    return 1
+def any_fn_486(arg_486: Any) -> int:
+    return 1
+def any_fn_487(arg_487: Any) -> int:
+    return 1
+def any_fn_488(arg_488: Any) -> int:
+    return 1
+def any_fn_489(arg_489: Any) -> int:
+    return 1
+def any_fn_490(arg_490: Any) -> int:
+    return 1
+def any_fn_491(arg_491: Any) -> int:
+    return 1
+def any_fn_492(arg_492: Any) -> int:
+    return 1
+def any_fn_493(arg_493: Any) -> int:
+    return 1
+def any_fn_494(arg_494: Any) -> int:
+    return 1
+def any_fn_495(arg_495: Any) -> int:
+    return 1
+def any_fn_496(arg_496: Any) -> int:
+    return 1
+def any_fn_497(arg_497: Any) -> int:
+    return 1
+def any_fn_498(arg_498: Any) -> int:
+    return 1
+def any_fn_499(arg_499: Any) -> int:
+    return 1
+def any_fn_500(arg_500: Any) -> int:
+    return 1
+def any_fn_501(arg_501: Any) -> int:
+    return 1
+def any_fn_502(arg_502: Any) -> int:
+    return 1
+def any_fn_503(arg_503: Any) -> int:
+    return 1
+def any_fn_504(arg_504: Any) -> int:
+    return 1
+def any_fn_505(arg_505: Any) -> int:
+    return 1
+def any_fn_506(arg_506: Any) -> int:
+    return 1
+def any_fn_507(arg_507: Any) -> int:
+    return 1
+def any_fn_508(arg_508: Any) -> int:
+    return 1
+def any_fn_509(arg_509: Any) -> int:
+    return 1
+def any_fn_510(arg_510: Any) -> int:
+    return 1
+def any_fn_511(arg_511: Any) -> int:
+    return 1
+def any_fn_512(arg_512: Any) -> int:
+    return 1
+def any_fn_513(arg_513: Any) -> int:
+    return 1
+def any_fn_514(arg_514: Any) -> int:
+    return 1
+def any_fn_515(arg_515: Any) -> int:
+    return 1
+def any_fn_516(arg_516: Any) -> int:
+    return 1
+def any_fn_517(arg_517: Any) -> int:
+    return 1
+def any_fn_518(arg_518: Any) -> int:
+    return 1
+def any_fn_519(arg_519: Any) -> int:
+    return 1
+def any_fn_520(arg_520: Any) -> int:
+    return 1
+def any_fn_521(arg_521: Any) -> int:
+    return 1
+def any_fn_522(arg_522: Any) -> int:
+    return 1
+def any_fn_523(arg_523: Any) -> int:
+    return 1
+def any_fn_524(arg_524: Any) -> int:
+    return 1
+def any_fn_525(arg_525: Any) -> int:
+    return 1
+def any_fn_526(arg_526: Any) -> int:
+    return 1
+def any_fn_527(arg_527: Any) -> int:
+    return 1
+def any_fn_528(arg_528: Any) -> int:
+    return 1
+def any_fn_529(arg_529: Any) -> int:
+    return 1
+def any_fn_530(arg_530: Any) -> int:
+    return 1
+def any_fn_531(arg_531: Any) -> int:
+    return 1
+def any_fn_532(arg_532: Any) -> int:
+    return 1
+def any_fn_533(arg_533: Any) -> int:
+    return 1
+def any_fn_534(arg_534: Any) -> int:
+    return 1
+def any_fn_535(arg_535: Any) -> int:
+    return 1
+def any_fn_536(arg_536: Any) -> int:
+    return 1
+def any_fn_537(arg_537: Any) -> int:
+    return 1
+def any_fn_538(arg_538: Any) -> int:
+    return 1
+def any_fn_539(arg_539: Any) -> int:
+    return 1
+def any_fn_540(arg_540: Any) -> int:
+    return 1
+def any_fn_541(arg_541: Any) -> int:
+    return 1
+def any_fn_542(arg_542: Any) -> int:
+    return 1
+def any_fn_543(arg_543: Any) -> int:
+    return 1
+def any_fn_544(arg_544: Any) -> int:
+    return 1
+def any_fn_545(arg_545: Any) -> int:
+    return 1
+def any_fn_546(arg_546: Any) -> int:
+    return 1
+def any_fn_547(arg_547: Any) -> int:
+    return 1
+def any_fn_548(arg_548: Any) -> int:
+    return 1
+def any_fn_549(arg_549: Any) -> int:
+    return 1
+def any_fn_550(arg_550: Any) -> int:
+    return 1
+def any_fn_551(arg_551: Any) -> int:
+    return 1
+def any_fn_552(arg_552: Any) -> int:
+    return 1
+def any_fn_553(arg_553: Any) -> int:
+    return 1
+def any_fn_554(arg_554: Any) -> int:
+    return 1
+def any_fn_555(arg_555: Any) -> int:
+    return 1
+def any_fn_556(arg_556: Any) -> int:
+    return 1
+def any_fn_557(arg_557: Any) -> int:
+    return 1
+def any_fn_558(arg_558: Any) -> int:
+    return 1
+def any_fn_559(arg_559: Any) -> int:
+    return 1
+def any_fn_560(arg_560: Any) -> int:
+    return 1
+def any_fn_561(arg_561: Any) -> int:
+    return 1
+def any_fn_562(arg_562: Any) -> int:
+    return 1
+def any_fn_563(arg_563: Any) -> int:
+    return 1
+def any_fn_564(arg_564: Any) -> int:
+    return 1
+def any_fn_565(arg_565: Any) -> int:
+    return 1
+def any_fn_566(arg_566: Any) -> int:
+    return 1
+def any_fn_567(arg_567: Any) -> int:
+    return 1
+def any_fn_568(arg_568: Any) -> int:
+    return 1
+def any_fn_569(arg_569: Any) -> int:
+    return 1
+def any_fn_570(arg_570: Any) -> int:
+    return 1
+def any_fn_571(arg_571: Any) -> int:
+    return 1
+def any_fn_572(arg_572: Any) -> int:
+    return 1
+def any_fn_573(arg_573: Any) -> int:
+    return 1
+def any_fn_574(arg_574: Any) -> int:
+    return 1
+def any_fn_575(arg_575: Any) -> int:
+    return 1
+def any_fn_576(arg_576: Any) -> int:
+    return 1
+def any_fn_577(arg_577: Any) -> int:
+    return 1
+def any_fn_578(arg_578: Any) -> int:
+    return 1
+def any_fn_579(arg_579: Any) -> int:
+    return 1
+def any_fn_580(arg_580: Any) -> int:
+    return 1
+def any_fn_581(arg_581: Any) -> int:
+    return 1
+def any_fn_582(arg_582: Any) -> int:
+    return 1
+def any_fn_583(arg_583: Any) -> int:
+    return 1
+def any_fn_584(arg_584: Any) -> int:
+    return 1
+def any_fn_585(arg_585: Any) -> int:
+    return 1
+def any_fn_586(arg_586: Any) -> int:
+    return 1
+def any_fn_587(arg_587: Any) -> int:
+    return 1
+def any_fn_588(arg_588: Any) -> int:
+    return 1
+def any_fn_589(arg_589: Any) -> int:
+    return 1
+def any_fn_590(arg_590: Any) -> int:
+    return 1
+def any_fn_591(arg_591: Any) -> int:
+    return 1
+def any_fn_592(arg_592: Any) -> int:
+    return 1
+def any_fn_593(arg_593: Any) -> int:
+    return 1
+def any_fn_594(arg_594: Any) -> int:
+    return 1
+def any_fn_595(arg_595: Any) -> int:
+    return 1
+def any_fn_596(arg_596: Any) -> int:
+    return 1
+def any_fn_597(arg_597: Any) -> int:
+    return 1
+def any_fn_598(arg_598: Any) -> int:
+    return 1
+def any_fn_599(arg_599: Any) -> int:
+    return 1
+def any_fn_600(arg_600: Any) -> int:
+    return 1
+def any_fn_601(arg_601: Any) -> int:
+    return 1
+def any_fn_602(arg_602: Any) -> int:
+    return 1
+def any_fn_603(arg_603: Any) -> int:
+    return 1
+def any_fn_604(arg_604: Any) -> int:
+    return 1
+def any_fn_605(arg_605: Any) -> int:
+    return 1
+def any_fn_606(arg_606: Any) -> int:
+    return 1
+def any_fn_607(arg_607: Any) -> int:
+    return 1
+def any_fn_608(arg_608: Any) -> int:
+    return 1
+def any_fn_609(arg_609: Any) -> int:
+    return 1
+def any_fn_610(arg_610: Any) -> int:
+    return 1
+def any_fn_611(arg_611: Any) -> int:
+    return 1
+def any_fn_612(arg_612: Any) -> int:
+    return 1
+def any_fn_613(arg_613: Any) -> int:
+    return 1
+def any_fn_614(arg_614: Any) -> int:
+    return 1
+def any_fn_615(arg_615: Any) -> int:
+    return 1
+def any_fn_616(arg_616: Any) -> int:
+    return 1
+def any_fn_617(arg_617: Any) -> int:
+    return 1
+def any_fn_618(arg_618: Any) -> int:
+    return 1
+def any_fn_619(arg_619: Any) -> int:
+    return 1
+def any_fn_620(arg_620: Any) -> int:
+    return 1
+def any_fn_621(arg_621: Any) -> int:
+    return 1
+def any_fn_622(arg_622: Any) -> int:
+    return 1
+def any_fn_623(arg_623: Any) -> int:
+    return 1
+def any_fn_624(arg_624: Any) -> int:
+    return 1
+def any_fn_625(arg_625: Any) -> int:
+    return 1
+def any_fn_626(arg_626: Any) -> int:
+    return 1
+def any_fn_627(arg_627: Any) -> int:
+    return 1
+def any_fn_628(arg_628: Any) -> int:
+    return 1
+def any_fn_629(arg_629: Any) -> int:
+    return 1
+def any_fn_630(arg_630: Any) -> int:
+    return 1
+def any_fn_631(arg_631: Any) -> int:
+    return 1
+def any_fn_632(arg_632: Any) -> int:
+    return 1
+def any_fn_633(arg_633: Any) -> int:
+    return 1
+def any_fn_634(arg_634: Any) -> int:
+    return 1
+def any_fn_635(arg_635: Any) -> int:
+    return 1
+def any_fn_636(arg_636: Any) -> int:
+    return 1
+def any_fn_637(arg_637: Any) -> int:
+    return 1
+def any_fn_638(arg_638: Any) -> int:
+    return 1
+def any_fn_639(arg_639: Any) -> int:
+    return 1
+def any_fn_640(arg_640: Any) -> int:
+    return 1
+def any_fn_641(arg_641: Any) -> int:
+    return 1
+def any_fn_642(arg_642: Any) -> int:
+    return 1
+def any_fn_643(arg_643: Any) -> int:
+    return 1
+def any_fn_644(arg_644: Any) -> int:
+    return 1
+def any_fn_645(arg_645: Any) -> int:
+    return 1
+def any_fn_646(arg_646: Any) -> int:
+    return 1
+def any_fn_647(arg_647: Any) -> int:
+    return 1
+def any_fn_648(arg_648: Any) -> int:
+    return 1
+def any_fn_649(arg_649: Any) -> int:
+    return 1
+def any_fn_650(arg_650: Any) -> int:
+    return 1
+def any_fn_651(arg_651: Any) -> int:
+    return 1
+def any_fn_652(arg_652: Any) -> int:
+    return 1
+def any_fn_653(arg_653: Any) -> int:
+    return 1
+def any_fn_654(arg_654: Any) -> int:
+    return 1
+def any_fn_655(arg_655: Any) -> int:
+    return 1
+def any_fn_656(arg_656: Any) -> int:
+    return 1
+def any_fn_657(arg_657: Any) -> int:
+    return 1
+def any_fn_658(arg_658: Any) -> int:
+    return 1
+def any_fn_659(arg_659: Any) -> int:
+    return 1
+def any_fn_660(arg_660: Any) -> int:
+    return 1
+def any_fn_661(arg_661: Any) -> int:
+    return 1
+def any_fn_662(arg_662: Any) -> int:
+    return 1
+def any_fn_663(arg_663: Any) -> int:
+    return 1
+def any_fn_664(arg_664: Any) -> int:
+    return 1
+def any_fn_665(arg_665: Any) -> int:
+    return 1
+def any_fn_666(arg_666: Any) -> int:
+    return 1
+def any_fn_667(arg_667: Any) -> int:
+    return 1
+def any_fn_668(arg_668: Any) -> int:
+    return 1
+def any_fn_669(arg_669: Any) -> int:
+    return 1
+def any_fn_670(arg_670: Any) -> int:
+    return 1
+def any_fn_671(arg_671: Any) -> int:
+    return 1
+def any_fn_672(arg_672: Any) -> int:
+    return 1
+def any_fn_673(arg_673: Any) -> int:
+    return 1
+def any_fn_674(arg_674: Any) -> int:
+    return 1
+def any_fn_675(arg_675: Any) -> int:
+    return 1
+def any_fn_676(arg_676: Any) -> int:
+    return 1
+def any_fn_677(arg_677: Any) -> int:
+    return 1
+def any_fn_678(arg_678: Any) -> int:
+    return 1
+def any_fn_679(arg_679: Any) -> int:
+    return 1
+def any_fn_680(arg_680: Any) -> int:
+    return 1
+def any_fn_681(arg_681: Any) -> int:
+    return 1
+def any_fn_682(arg_682: Any) -> int:
+    return 1
+def any_fn_683(arg_683: Any) -> int:
+    return 1
+def any_fn_684(arg_684: Any) -> int:
+    return 1
+def any_fn_685(arg_685: Any) -> int:
+    return 1
+def any_fn_686(arg_686: Any) -> int:
+    return 1
+def any_fn_687(arg_687: Any) -> int:
+    return 1
+def any_fn_688(arg_688: Any) -> int:
+    return 1
+def any_fn_689(arg_689: Any) -> int:
+    return 1
+def any_fn_690(arg_690: Any) -> int:
+    return 1
+def any_fn_691(arg_691: Any) -> int:
+    return 1
+def any_fn_692(arg_692: Any) -> int:
+    return 1
+def any_fn_693(arg_693: Any) -> int:
+    return 1
+def any_fn_694(arg_694: Any) -> int:
+    return 1
+def any_fn_695(arg_695: Any) -> int:
+    return 1
+def any_fn_696(arg_696: Any) -> int:
+    return 1
+def any_fn_697(arg_697: Any) -> int:
+    return 1
+def any_fn_698(arg_698: Any) -> int:
+    return 1
+def any_fn_699(arg_699: Any) -> int:
+    return 1
+def any_fn_700(arg_700: Any) -> int:
+    return 1
+def any_fn_701(arg_701: Any) -> int:
+    return 1
+def any_fn_702(arg_702: Any) -> int:
+    return 1
+def any_fn_703(arg_703: Any) -> int:
+    return 1
+def any_fn_704(arg_704: Any) -> int:
+    return 1
+def any_fn_705(arg_705: Any) -> int:
+    return 1
+def any_fn_706(arg_706: Any) -> int:
+    return 1
+def any_fn_707(arg_707: Any) -> int:
+    return 1
+def any_fn_708(arg_708: Any) -> int:
+    return 1
+def any_fn_709(arg_709: Any) -> int:
+    return 1
+def any_fn_710(arg_710: Any) -> int:
+    return 1
+def any_fn_711(arg_711: Any) -> int:
+    return 1
+def any_fn_712(arg_712: Any) -> int:
+    return 1
+def any_fn_713(arg_713: Any) -> int:
+    return 1
+def any_fn_714(arg_714: Any) -> int:
+    return 1
+def any_fn_715(arg_715: Any) -> int:
+    return 1
+def any_fn_716(arg_716: Any) -> int:
+    return 1
+def any_fn_717(arg_717: Any) -> int:
+    return 1
+def any_fn_718(arg_718: Any) -> int:
+    return 1
+def any_fn_719(arg_719: Any) -> int:
+    return 1
+def any_fn_720(arg_720: Any) -> int:
+    return 1
+def any_fn_721(arg_721: Any) -> int:
+    return 1
+def any_fn_722(arg_722: Any) -> int:
+    return 1
+def any_fn_723(arg_723: Any) -> int:
+    return 1
+def any_fn_724(arg_724: Any) -> int:
+    return 1
+def any_fn_725(arg_725: Any) -> int:
+    return 1
+def any_fn_726(arg_726: Any) -> int:
+    return 1
+def any_fn_727(arg_727: Any) -> int:
+    return 1
+def any_fn_728(arg_728: Any) -> int:
+    return 1
+def any_fn_729(arg_729: Any) -> int:
+    return 1
+def any_fn_730(arg_730: Any) -> int:
+    return 1
+def any_fn_731(arg_731: Any) -> int:
+    return 1
+def any_fn_732(arg_732: Any) -> int:
+    return 1
+def any_fn_733(arg_733: Any) -> int:
+    return 1
+def any_fn_734(arg_734: Any) -> int:
+    return 1
+def any_fn_735(arg_735: Any) -> int:
+    return 1
+def any_fn_736(arg_736: Any) -> int:
+    return 1
+def any_fn_737(arg_737: Any) -> int:
+    return 1
+def any_fn_738(arg_738: Any) -> int:
+    return 1
+def any_fn_739(arg_739: Any) -> int:
+    return 1
+def any_fn_740(arg_740: Any) -> int:
+    return 1
+def any_fn_741(arg_741: Any) -> int:
+    return 1
+def any_fn_742(arg_742: Any) -> int:
+    return 1
+def any_fn_743(arg_743: Any) -> int:
+    return 1
+def any_fn_744(arg_744: Any) -> int:
+    return 1
+def any_fn_745(arg_745: Any) -> int:
+    return 1
+def any_fn_746(arg_746: Any) -> int:
+    return 1
+def any_fn_747(arg_747: Any) -> int:
+    return 1
+def any_fn_748(arg_748: Any) -> int:
+    return 1
+def any_fn_749(arg_749: Any) -> int:
+    return 1
+def any_fn_750(arg_750: Any) -> int:
+    return 1
+def any_fn_751(arg_751: Any) -> int:
+    return 1
+def any_fn_752(arg_752: Any) -> int:
+    return 1
+def any_fn_753(arg_753: Any) -> int:
+    return 1
+def any_fn_754(arg_754: Any) -> int:
+    return 1
+def any_fn_755(arg_755: Any) -> int:
+    return 1
+def any_fn_756(arg_756: Any) -> int:
+    return 1
+def any_fn_757(arg_757: Any) -> int:
+    return 1
+def any_fn_758(arg_758: Any) -> int:
+    return 1
+def any_fn_759(arg_759: Any) -> int:
+    return 1
+def any_fn_760(arg_760: Any) -> int:
+    return 1
+def any_fn_761(arg_761: Any) -> int:
+    return 1
+def any_fn_762(arg_762: Any) -> int:
+    return 1
+def any_fn_763(arg_763: Any) -> int:
+    return 1
+def any_fn_764(arg_764: Any) -> int:
+    return 1
+def any_fn_765(arg_765: Any) -> int:
+    return 1
+def any_fn_766(arg_766: Any) -> int:
+    return 1
+def any_fn_767(arg_767: Any) -> int:
+    return 1
+def any_fn_768(arg_768: Any) -> int:
+    return 1
+def any_fn_769(arg_769: Any) -> int:
+    return 1
+def any_fn_770(arg_770: Any) -> int:
+    return 1
+def any_fn_771(arg_771: Any) -> int:
+    return 1
+def any_fn_772(arg_772: Any) -> int:
+    return 1
+def any_fn_773(arg_773: Any) -> int:
+    return 1
+def any_fn_774(arg_774: Any) -> int:
+    return 1
+def any_fn_775(arg_775: Any) -> int:
+    return 1
+def any_fn_776(arg_776: Any) -> int:
+    return 1
+def any_fn_777(arg_777: Any) -> int:
+    return 1
+def any_fn_778(arg_778: Any) -> int:
+    return 1
+def any_fn_779(arg_779: Any) -> int:
+    return 1
+def any_fn_780(arg_780: Any) -> int:
+    return 1
+def any_fn_781(arg_781: Any) -> int:
+    return 1
+def any_fn_782(arg_782: Any) -> int:
+    return 1
+def any_fn_783(arg_783: Any) -> int:
+    return 1
+def any_fn_784(arg_784: Any) -> int:
+    return 1
+def any_fn_785(arg_785: Any) -> int:
+    return 1
+def any_fn_786(arg_786: Any) -> int:
+    return 1
+def any_fn_787(arg_787: Any) -> int:
+    return 1
+def any_fn_788(arg_788: Any) -> int:
+    return 1
+def any_fn_789(arg_789: Any) -> int:
+    return 1
+def any_fn_790(arg_790: Any) -> int:
+    return 1
+def any_fn_791(arg_791: Any) -> int:
+    return 1
+def any_fn_792(arg_792: Any) -> int:
+    return 1
+def any_fn_793(arg_793: Any) -> int:
+    return 1
+def any_fn_794(arg_794: Any) -> int:
+    return 1
+def any_fn_795(arg_795: Any) -> int:
+    return 1
+def any_fn_796(arg_796: Any) -> int:
+    return 1
+def any_fn_797(arg_797: Any) -> int:
+    return 1
+def any_fn_798(arg_798: Any) -> int:
+    return 1
+def any_fn_799(arg_799: Any) -> int:
+    return 1
+def any_fn_800(arg_800: Any) -> int:
+    return 1
+def any_fn_801(arg_801: Any) -> int:
+    return 1
+def any_fn_802(arg_802: Any) -> int:
+    return 1
+def any_fn_803(arg_803: Any) -> int:
+    return 1
+def any_fn_804(arg_804: Any) -> int:
+    return 1
+def any_fn_805(arg_805: Any) -> int:
+    return 1
+def any_fn_806(arg_806: Any) -> int:
+    return 1
+def any_fn_807(arg_807: Any) -> int:
+    return 1
+def any_fn_808(arg_808: Any) -> int:
+    return 1
+def any_fn_809(arg_809: Any) -> int:
+    return 1
+def any_fn_810(arg_810: Any) -> int:
+    return 1
+def any_fn_811(arg_811: Any) -> int:
+    return 1
+def any_fn_812(arg_812: Any) -> int:
+    return 1
+def any_fn_813(arg_813: Any) -> int:
+    return 1
+def any_fn_814(arg_814: Any) -> int:
+    return 1
+def any_fn_815(arg_815: Any) -> int:
+    return 1
+def any_fn_816(arg_816: Any) -> int:
+    return 1
+def any_fn_817(arg_817: Any) -> int:
+    return 1
+def any_fn_818(arg_818: Any) -> int:
+    return 1
+def any_fn_819(arg_819: Any) -> int:
+    return 1
+def any_fn_820(arg_820: Any) -> int:
+    return 1
+def any_fn_821(arg_821: Any) -> int:
+    return 1
+def any_fn_822(arg_822: Any) -> int:
+    return 1
+def any_fn_823(arg_823: Any) -> int:
+    return 1
+def any_fn_824(arg_824: Any) -> int:
+    return 1
+def any_fn_825(arg_825: Any) -> int:
+    return 1
+def any_fn_826(arg_826: Any) -> int:
+    return 1
+def any_fn_827(arg_827: Any) -> int:
+    return 1
+def any_fn_828(arg_828: Any) -> int:
+    return 1
+def any_fn_829(arg_829: Any) -> int:
+    return 1
+def any_fn_830(arg_830: Any) -> int:
+    return 1
+def any_fn_831(arg_831: Any) -> int:
+    return 1
+def any_fn_832(arg_832: Any) -> int:
+    return 1
+def any_fn_833(arg_833: Any) -> int:
+    return 1
+def any_fn_834(arg_834: Any) -> int:
+    return 1
+def any_fn_835(arg_835: Any) -> int:
+    return 1
+def any_fn_836(arg_836: Any) -> int:
+    return 1
+def any_fn_837(arg_837: Any) -> int:
+    return 1
+def any_fn_838(arg_838: Any) -> int:
+    return 1
+def any_fn_839(arg_839: Any) -> int:
+    return 1
+def any_fn_840(arg_840: Any) -> int:
+    return 1
+def any_fn_841(arg_841: Any) -> int:
+    return 1
+def any_fn_842(arg_842: Any) -> int:
+    return 1
+def any_fn_843(arg_843: Any) -> int:
+    return 1
+def any_fn_844(arg_844: Any) -> int:
+    return 1
+def any_fn_845(arg_845: Any) -> int:
+    return 1
+def any_fn_846(arg_846: Any) -> int:
+    return 1
+def any_fn_847(arg_847: Any) -> int:
+    return 1
+def any_fn_848(arg_848: Any) -> int:
+    return 1
+def any_fn_849(arg_849: Any) -> int:
+    return 1
+def any_fn_850(arg_850: Any) -> int:
+    return 1
+def any_fn_851(arg_851: Any) -> int:
+    return 1
+def any_fn_852(arg_852: Any) -> int:
+    return 1
+def any_fn_853(arg_853: Any) -> int:
+    return 1
+def any_fn_854(arg_854: Any) -> int:
+    return 1
+def any_fn_855(arg_855: Any) -> int:
+    return 1
+def any_fn_856(arg_856: Any) -> int:
+    return 1
+def any_fn_857(arg_857: Any) -> int:
+    return 1
+def any_fn_858(arg_858: Any) -> int:
+    return 1
+def any_fn_859(arg_859: Any) -> int:
+    return 1
+def any_fn_860(arg_860: Any) -> int:
+    return 1
+def any_fn_861(arg_861: Any) -> int:
+    return 1
+def any_fn_862(arg_862: Any) -> int:
+    return 1
+def any_fn_863(arg_863: Any) -> int:
+    return 1
+def any_fn_864(arg_864: Any) -> int:
+    return 1
+def any_fn_865(arg_865: Any) -> int:
+    return 1
+def any_fn_866(arg_866: Any) -> int:
+    return 1
+def any_fn_867(arg_867: Any) -> int:
+    return 1
+def any_fn_868(arg_868: Any) -> int:
+    return 1
+def any_fn_869(arg_869: Any) -> int:
+    return 1
+def any_fn_870(arg_870: Any) -> int:
+    return 1
+def any_fn_871(arg_871: Any) -> int:
+    return 1
+def any_fn_872(arg_872: Any) -> int:
+    return 1
+def any_fn_873(arg_873: Any) -> int:
+    return 1
+def any_fn_874(arg_874: Any) -> int:
+    return 1
+def any_fn_875(arg_875: Any) -> int:
+    return 1
+def any_fn_876(arg_876: Any) -> int:
+    return 1
+def any_fn_877(arg_877: Any) -> int:
+    return 1
+def any_fn_878(arg_878: Any) -> int:
+    return 1
+def any_fn_879(arg_879: Any) -> int:
+    return 1
+def any_fn_880(arg_880: Any) -> int:
+    return 1
+def any_fn_881(arg_881: Any) -> int:
+    return 1
+def any_fn_882(arg_882: Any) -> int:
+    return 1
+def any_fn_883(arg_883: Any) -> int:
+    return 1
+def any_fn_884(arg_884: Any) -> int:
+    return 1
+def any_fn_885(arg_885: Any) -> int:
+    return 1
+def any_fn_886(arg_886: Any) -> int:
+    return 1
+def any_fn_887(arg_887: Any) -> int:
+    return 1
+def any_fn_888(arg_888: Any) -> int:
+    return 1
+def any_fn_889(arg_889: Any) -> int:
+    return 1
+def any_fn_890(arg_890: Any) -> int:
+    return 1
+def any_fn_891(arg_891: Any) -> int:
+    return 1
+def any_fn_892(arg_892: Any) -> int:
+    return 1
+def any_fn_893(arg_893: Any) -> int:
+    return 1
+def any_fn_894(arg_894: Any) -> int:
+    return 1
+def any_fn_895(arg_895: Any) -> int:
+    return 1
+def any_fn_896(arg_896: Any) -> int:
+    return 1
+def any_fn_897(arg_897: Any) -> int:
+    return 1
+def any_fn_898(arg_898: Any) -> int:
+    return 1
+def any_fn_899(arg_899: Any) -> int:
+    return 1
+def any_fn_900(arg_900: Any) -> int:
+    return 1
+def any_fn_901(arg_901: Any) -> int:
+    return 1
+def any_fn_902(arg_902: Any) -> int:
+    return 1
+def any_fn_903(arg_903: Any) -> int:
+    return 1
+def any_fn_904(arg_904: Any) -> int:
+    return 1
+def any_fn_905(arg_905: Any) -> int:
+    return 1
+def any_fn_906(arg_906: Any) -> int:
+    return 1
+def any_fn_907(arg_907: Any) -> int:
+    return 1
+def any_fn_908(arg_908: Any) -> int:
+    return 1
+def any_fn_909(arg_909: Any) -> int:
+    return 1
+def any_fn_910(arg_910: Any) -> int:
+    return 1
+def any_fn_911(arg_911: Any) -> int:
+    return 1
+def any_fn_912(arg_912: Any) -> int:
+    return 1
+def any_fn_913(arg_913: Any) -> int:
+    return 1
+def any_fn_914(arg_914: Any) -> int:
+    return 1
+def any_fn_915(arg_915: Any) -> int:
+    return 1
+def any_fn_916(arg_916: Any) -> int:
+    return 1
+def any_fn_917(arg_917: Any) -> int:
+    return 1
+def any_fn_918(arg_918: Any) -> int:
+    return 1
+def any_fn_919(arg_919: Any) -> int:
+    return 1
+def any_fn_920(arg_920: Any) -> int:
+    return 1
+def any_fn_921(arg_921: Any) -> int:
+    return 1
+def any_fn_922(arg_922: Any) -> int:
+    return 1
+def any_fn_923(arg_923: Any) -> int:
+    return 1
+def any_fn_924(arg_924: Any) -> int:
+    return 1
+def any_fn_925(arg_925: Any) -> int:
+    return 1
+def any_fn_926(arg_926: Any) -> int:
+    return 1
+def any_fn_927(arg_927: Any) -> int:
+    return 1
+def any_fn_928(arg_928: Any) -> int:
+    return 1
+def any_fn_929(arg_929: Any) -> int:
+    return 1
+def any_fn_930(arg_930: Any) -> int:
+    return 1
+def any_fn_931(arg_931: Any) -> int:
+    return 1
+def any_fn_932(arg_932: Any) -> int:
+    return 1
+def any_fn_933(arg_933: Any) -> int:
+    return 1
+def any_fn_934(arg_934: Any) -> int:
+    return 1
+def any_fn_935(arg_935: Any) -> int:
+    return 1
+def any_fn_936(arg_936: Any) -> int:
+    return 1
+def any_fn_937(arg_937: Any) -> int:
+    return 1
+def any_fn_938(arg_938: Any) -> int:
+    return 1
+def any_fn_939(arg_939: Any) -> int:
+    return 1
+def any_fn_940(arg_940: Any) -> int:
+    return 1
+def any_fn_941(arg_941: Any) -> int:
+    return 1
+def any_fn_942(arg_942: Any) -> int:
+    return 1
+def any_fn_943(arg_943: Any) -> int:
+    return 1
+def any_fn_944(arg_944: Any) -> int:
+    return 1
+def any_fn_945(arg_945: Any) -> int:
+    return 1
+def any_fn_946(arg_946: Any) -> int:
+    return 1
+def any_fn_947(arg_947: Any) -> int:
+    return 1
+def any_fn_948(arg_948: Any) -> int:
+    return 1
+def any_fn_949(arg_949: Any) -> int:
+    return 1
+def any_fn_950(arg_950: Any) -> int:
+    return 1
+def any_fn_951(arg_951: Any) -> int:
+    return 1
+def any_fn_952(arg_952: Any) -> int:
+    return 1
+def any_fn_953(arg_953: Any) -> int:
+    return 1
+def any_fn_954(arg_954: Any) -> int:
+    return 1
+def any_fn_955(arg_955: Any) -> int:
+    return 1
+def any_fn_956(arg_956: Any) -> int:
+    return 1
+def any_fn_957(arg_957: Any) -> int:
+    return 1
+def any_fn_958(arg_958: Any) -> int:
+    return 1
+def any_fn_959(arg_959: Any) -> int:
+    return 1
+def any_fn_960(arg_960: Any) -> int:
+    return 1
+def any_fn_961(arg_961: Any) -> int:
+    return 1
+def any_fn_962(arg_962: Any) -> int:
+    return 1
+def any_fn_963(arg_963: Any) -> int:
+    return 1
+def any_fn_964(arg_964: Any) -> int:
+    return 1
+def any_fn_965(arg_965: Any) -> int:
+    return 1
+def any_fn_966(arg_966: Any) -> int:
+    return 1
+def any_fn_967(arg_967: Any) -> int:
+    return 1
+def any_fn_968(arg_968: Any) -> int:
+    return 1
+def any_fn_969(arg_969: Any) -> int:
+    return 1
+def any_fn_970(arg_970: Any) -> int:
+    return 1
+def any_fn_971(arg_971: Any) -> int:
+    return 1
+def any_fn_972(arg_972: Any) -> int:
+    return 1
+def any_fn_973(arg_973: Any) -> int:
+    return 1
+def any_fn_974(arg_974: Any) -> int:
+    return 1
+def any_fn_975(arg_975: Any) -> int:
+    return 1
+def any_fn_976(arg_976: Any) -> int:
+    return 1
+def any_fn_977(arg_977: Any) -> int:
+    return 1
+def any_fn_978(arg_978: Any) -> int:
+    return 1
+def any_fn_979(arg_979: Any) -> int:
+    return 1
+def any_fn_980(arg_980: Any) -> int:
+    return 1
+def any_fn_981(arg_981: Any) -> int:
+    return 1
+def any_fn_982(arg_982: Any) -> int:
+    return 1
+def any_fn_983(arg_983: Any) -> int:
+    return 1
+def any_fn_984(arg_984: Any) -> int:
+    return 1
+def any_fn_985(arg_985: Any) -> int:
+    return 1
+def any_fn_986(arg_986: Any) -> int:
+    return 1
+def any_fn_987(arg_987: Any) -> int:
+    return 1
+def any_fn_988(arg_988: Any) -> int:
+    return 1
+def any_fn_989(arg_989: Any) -> int:
+    return 1
+def any_fn_990(arg_990: Any) -> int:
+    return 1
+def any_fn_991(arg_991: Any) -> int:
+    return 1
+def any_fn_992(arg_992: Any) -> int:
+    return 1
+def any_fn_993(arg_993: Any) -> int:
+    return 1
+def any_fn_994(arg_994: Any) -> int:
+    return 1
+def any_fn_995(arg_995: Any) -> int:
+    return 1
+def any_fn_996(arg_996: Any) -> int:
+    return 1
+def any_fn_997(arg_997: Any) -> int:
+    return 1
+def any_fn_998(arg_998: Any) -> int:
+    return 1
+def any_fn_999(arg_999: Any) -> int:
+    return 1
+def any_fn_1000(arg_1000: Any) -> int:
+    return 1
+def any_fn_1001(arg_1001: Any) -> int:
+    return 1
+def any_fn_1002(arg_1002: Any) -> int:
+    return 1
+def any_fn_1003(arg_1003: Any) -> int:
+    return 1
+def any_fn_1004(arg_1004: Any) -> int:
+    return 1
+def any_fn_1005(arg_1005: Any) -> int:
+    return 1
+def any_fn_1006(arg_1006: Any) -> int:
+    return 1
+def any_fn_1007(arg_1007: Any) -> int:
+    return 1
+def any_fn_1008(arg_1008: Any) -> int:
+    return 1
+def any_fn_1009(arg_1009: Any) -> int:
+    return 1
+def any_fn_1010(arg_1010: Any) -> int:
+    return 1
+def any_fn_1011(arg_1011: Any) -> int:
+    return 1
+def any_fn_1012(arg_1012: Any) -> int:
+    return 1
+def any_fn_1013(arg_1013: Any) -> int:
+    return 1
+def any_fn_1014(arg_1014: Any) -> int:
+    return 1
+def any_fn_1015(arg_1015: Any) -> int:
+    return 1
+def any_fn_1016(arg_1016: Any) -> int:
+    return 1
+def any_fn_1017(arg_1017: Any) -> int:
+    return 1
+def any_fn_1018(arg_1018: Any) -> int:
+    return 1
+def any_fn_1019(arg_1019: Any) -> int:
+    return 1
+def any_fn_1020(arg_1020: Any) -> int:
+    return 1
+def any_fn_1021(arg_1021: Any) -> int:
+    return 1
+def any_fn_1022(arg_1022: Any) -> int:
+    return 1
+def any_fn_1023(arg_1023: Any) -> int:
+    return 1
+def any_fn_1024(arg_1024: Any) -> int:
+    return 1
+def any_fn_1025(arg_1025: Any) -> int:
+    return 1
+def any_fn_1026(arg_1026: Any) -> int:
+    return 1
+def any_fn_1027(arg_1027: Any) -> int:
+    return 1
+def any_fn_1028(arg_1028: Any) -> int:
+    return 1
+def any_fn_1029(arg_1029: Any) -> int:
+    return 1
+def any_fn_1030(arg_1030: Any) -> int:
+    return 1
+def any_fn_1031(arg_1031: Any) -> int:
+    return 1
+def any_fn_1032(arg_1032: Any) -> int:
+    return 1
+def any_fn_1033(arg_1033: Any) -> int:
+    return 1
+def any_fn_1034(arg_1034: Any) -> int:
+    return 1
+def any_fn_1035(arg_1035: Any) -> int:
+    return 1
+def any_fn_1036(arg_1036: Any) -> int:
+    return 1
+def any_fn_1037(arg_1037: Any) -> int:
+    return 1
+def any_fn_1038(arg_1038: Any) -> int:
+    return 1
+def any_fn_1039(arg_1039: Any) -> int:
+    return 1
+def any_fn_1040(arg_1040: Any) -> int:
+    return 1
+def any_fn_1041(arg_1041: Any) -> int:
+    return 1
+def any_fn_1042(arg_1042: Any) -> int:
+    return 1
+def any_fn_1043(arg_1043: Any) -> int:
+    return 1
+def any_fn_1044(arg_1044: Any) -> int:
+    return 1
+def any_fn_1045(arg_1045: Any) -> int:
+    return 1
+def any_fn_1046(arg_1046: Any) -> int:
+    return 1
+def any_fn_1047(arg_1047: Any) -> int:
+    return 1
+def any_fn_1048(arg_1048: Any) -> int:
+    return 1
+def any_fn_1049(arg_1049: Any) -> int:
+    return 1
+def any_fn_1050(arg_1050: Any) -> int:
+    return 1
+def any_fn_1051(arg_1051: Any) -> int:
+    return 1
+def any_fn_1052(arg_1052: Any) -> int:
+    return 1
+def any_fn_1053(arg_1053: Any) -> int:
+    return 1
+def any_fn_1054(arg_1054: Any) -> int:
+    return 1
+def any_fn_1055(arg_1055: Any) -> int:
+    return 1
+def any_fn_1056(arg_1056: Any) -> int:
+    return 1
+def any_fn_1057(arg_1057: Any) -> int:
+    return 1
+def any_fn_1058(arg_1058: Any) -> int:
+    return 1
+def any_fn_1059(arg_1059: Any) -> int:
+    return 1
+def any_fn_1060(arg_1060: Any) -> int:
+    return 1
+def any_fn_1061(arg_1061: Any) -> int:
+    return 1
+def any_fn_1062(arg_1062: Any) -> int:
+    return 1
+def any_fn_1063(arg_1063: Any) -> int:
+    return 1
+def any_fn_1064(arg_1064: Any) -> int:
+    return 1
+def any_fn_1065(arg_1065: Any) -> int:
+    return 1
+def any_fn_1066(arg_1066: Any) -> int:
+    return 1
+def any_fn_1067(arg_1067: Any) -> int:
+    return 1
+def any_fn_1068(arg_1068: Any) -> int:
+    return 1
+def any_fn_1069(arg_1069: Any) -> int:
+    return 1
+def any_fn_1070(arg_1070: Any) -> int:
+    return 1
+def any_fn_1071(arg_1071: Any) -> int:
+    return 1
+def any_fn_1072(arg_1072: Any) -> int:
+    return 1
+def any_fn_1073(arg_1073: Any) -> int:
+    return 1
+def any_fn_1074(arg_1074: Any) -> int:
+    return 1
+def any_fn_1075(arg_1075: Any) -> int:
+    return 1
+def any_fn_1076(arg_1076: Any) -> int:
+    return 1
+def any_fn_1077(arg_1077: Any) -> int:
+    return 1
+def any_fn_1078(arg_1078: Any) -> int:
+    return 1
+def any_fn_1079(arg_1079: Any) -> int:
+    return 1
+def any_fn_1080(arg_1080: Any) -> int:
+    return 1
+def any_fn_1081(arg_1081: Any) -> int:
+    return 1
+def any_fn_1082(arg_1082: Any) -> int:
+    return 1
+def any_fn_1083(arg_1083: Any) -> int:
+    return 1
+def any_fn_1084(arg_1084: Any) -> int:
+    return 1
+def any_fn_1085(arg_1085: Any) -> int:
+    return 1
+def any_fn_1086(arg_1086: Any) -> int:
+    return 1
+def any_fn_1087(arg_1087: Any) -> int:
+    return 1
+def any_fn_1088(arg_1088: Any) -> int:
+    return 1
+def any_fn_1089(arg_1089: Any) -> int:
+    return 1
+def any_fn_1090(arg_1090: Any) -> int:
+    return 1
+def any_fn_1091(arg_1091: Any) -> int:
+    return 1
+def any_fn_1092(arg_1092: Any) -> int:
+    return 1
+def any_fn_1093(arg_1093: Any) -> int:
+    return 1
+def any_fn_1094(arg_1094: Any) -> int:
+    return 1
+def any_fn_1095(arg_1095: Any) -> int:
+    return 1
+def any_fn_1096(arg_1096: Any) -> int:
+    return 1
+def any_fn_1097(arg_1097: Any) -> int:
+    return 1
+def any_fn_1098(arg_1098: Any) -> int:
+    return 1
+def any_fn_1099(arg_1099: Any) -> int:
+    return 1
+def any_fn_1100(arg_1100: Any) -> int:
+    return 1
+def any_fn_1101(arg_1101: Any) -> int:
+    return 1
+def any_fn_1102(arg_1102: Any) -> int:
+    return 1
+def any_fn_1103(arg_1103: Any) -> int:
+    return 1
+def any_fn_1104(arg_1104: Any) -> int:
+    return 1
+def any_fn_1105(arg_1105: Any) -> int:
+    return 1
+def any_fn_1106(arg_1106: Any) -> int:
+    return 1
+def any_fn_1107(arg_1107: Any) -> int:
+    return 1
+def any_fn_1108(arg_1108: Any) -> int:
+    return 1
+def any_fn_1109(arg_1109: Any) -> int:
+    return 1
+def any_fn_1110(arg_1110: Any) -> int:
+    return 1
+def any_fn_1111(arg_1111: Any) -> int:
+    return 1
+def any_fn_1112(arg_1112: Any) -> int:
+    return 1
+def any_fn_1113(arg_1113: Any) -> int:
+    return 1
+def any_fn_1114(arg_1114: Any) -> int:
+    return 1
+def any_fn_1115(arg_1115: Any) -> int:
+    return 1
+def any_fn_1116(arg_1116: Any) -> int:
+    return 1
+def any_fn_1117(arg_1117: Any) -> int:
+    return 1
+def any_fn_1118(arg_1118: Any) -> int:
+    return 1
+def any_fn_1119(arg_1119: Any) -> int:
+    return 1
+def any_fn_1120(arg_1120: Any) -> int:
+    return 1
+def any_fn_1121(arg_1121: Any) -> int:
+    return 1
+def any_fn_1122(arg_1122: Any) -> int:
+    return 1
+def any_fn_1123(arg_1123: Any) -> int:
+    return 1
+def any_fn_1124(arg_1124: Any) -> int:
+    return 1
+def any_fn_1125(arg_1125: Any) -> int:
+    return 1
+def any_fn_1126(arg_1126: Any) -> int:
+    return 1
+def any_fn_1127(arg_1127: Any) -> int:
+    return 1
+def any_fn_1128(arg_1128: Any) -> int:
+    return 1
+def any_fn_1129(arg_1129: Any) -> int:
+    return 1
+def any_fn_1130(arg_1130: Any) -> int:
+    return 1
+def any_fn_1131(arg_1131: Any) -> int:
+    return 1
+def any_fn_1132(arg_1132: Any) -> int:
+    return 1
+def any_fn_1133(arg_1133: Any) -> int:
+    return 1
+def any_fn_1134(arg_1134: Any) -> int:
+    return 1
+def any_fn_1135(arg_1135: Any) -> int:
+    return 1
+def any_fn_1136(arg_1136: Any) -> int:
+    return 1
+def any_fn_1137(arg_1137: Any) -> int:
+    return 1
+def any_fn_1138(arg_1138: Any) -> int:
+    return 1
+def any_fn_1139(arg_1139: Any) -> int:
+    return 1
+def any_fn_1140(arg_1140: Any) -> int:
+    return 1
+def any_fn_1141(arg_1141: Any) -> int:
+    return 1
+def any_fn_1142(arg_1142: Any) -> int:
+    return 1
+def any_fn_1143(arg_1143: Any) -> int:
+    return 1
+def any_fn_1144(arg_1144: Any) -> int:
+    return 1
+def any_fn_1145(arg_1145: Any) -> int:
+    return 1
+def any_fn_1146(arg_1146: Any) -> int:
+    return 1
+def any_fn_1147(arg_1147: Any) -> int:
+    return 1
+def any_fn_1148(arg_1148: Any) -> int:
+    return 1
+def any_fn_1149(arg_1149: Any) -> int:
+    return 1
+def any_fn_1150(arg_1150: Any) -> int:
+    return 1
+def any_fn_1151(arg_1151: Any) -> int:
+    return 1
+def any_fn_1152(arg_1152: Any) -> int:
+    return 1
+def any_fn_1153(arg_1153: Any) -> int:
+    return 1
+def any_fn_1154(arg_1154: Any) -> int:
+    return 1
+def any_fn_1155(arg_1155: Any) -> int:
+    return 1
+def any_fn_1156(arg_1156: Any) -> int:
+    return 1
+def any_fn_1157(arg_1157: Any) -> int:
+    return 1
+def any_fn_1158(arg_1158: Any) -> int:
+    return 1
+def any_fn_1159(arg_1159: Any) -> int:
+    return 1
+def any_fn_1160(arg_1160: Any) -> int:
+    return 1
+def any_fn_1161(arg_1161: Any) -> int:
+    return 1
+def any_fn_1162(arg_1162: Any) -> int:
+    return 1
+def any_fn_1163(arg_1163: Any) -> int:
+    return 1
+def any_fn_1164(arg_1164: Any) -> int:
+    return 1
+def any_fn_1165(arg_1165: Any) -> int:
+    return 1
+def any_fn_1166(arg_1166: Any) -> int:
+    return 1
+def any_fn_1167(arg_1167: Any) -> int:
+    return 1
+def any_fn_1168(arg_1168: Any) -> int:
+    return 1
+def any_fn_1169(arg_1169: Any) -> int:
+    return 1
+def any_fn_1170(arg_1170: Any) -> int:
+    return 1
+def any_fn_1171(arg_1171: Any) -> int:
+    return 1
+def any_fn_1172(arg_1172: Any) -> int:
+    return 1
+def any_fn_1173(arg_1173: Any) -> int:
+    return 1
+def any_fn_1174(arg_1174: Any) -> int:
+    return 1
+def any_fn_1175(arg_1175: Any) -> int:
+    return 1
+def any_fn_1176(arg_1176: Any) -> int:
+    return 1
+def any_fn_1177(arg_1177: Any) -> int:
+    return 1
+def any_fn_1178(arg_1178: Any) -> int:
+    return 1
+def any_fn_1179(arg_1179: Any) -> int:
+    return 1
+def any_fn_1180(arg_1180: Any) -> int:
+    return 1
+def any_fn_1181(arg_1181: Any) -> int:
+    return 1
+def any_fn_1182(arg_1182: Any) -> int:
+    return 1
+def any_fn_1183(arg_1183: Any) -> int:
+    return 1
+def any_fn_1184(arg_1184: Any) -> int:
+    return 1
+def any_fn_1185(arg_1185: Any) -> int:
+    return 1
+def any_fn_1186(arg_1186: Any) -> int:
+    return 1
+def any_fn_1187(arg_1187: Any) -> int:
+    return 1
+def any_fn_1188(arg_1188: Any) -> int:
+    return 1
+def any_fn_1189(arg_1189: Any) -> int:
+    return 1
+def any_fn_1190(arg_1190: Any) -> int:
+    return 1
+def any_fn_1191(arg_1191: Any) -> int:
+    return 1
+def any_fn_1192(arg_1192: Any) -> int:
+    return 1
+def any_fn_1193(arg_1193: Any) -> int:
+    return 1
+def any_fn_1194(arg_1194: Any) -> int:
+    return 1
+def any_fn_1195(arg_1195: Any) -> int:
+    return 1
+def any_fn_1196(arg_1196: Any) -> int:
+    return 1
+def any_fn_1197(arg_1197: Any) -> int:
+    return 1
+def any_fn_1198(arg_1198: Any) -> int:
+    return 1
+def any_fn_1199(arg_1199: Any) -> int:
+    return 1
+def any_fn_1200(arg_1200: Any) -> int:
+    return 1
+def any_fn_1201(arg_1201: Any) -> int:
+    return 1
+def any_fn_1202(arg_1202: Any) -> int:
+    return 1
+def any_fn_1203(arg_1203: Any) -> int:
+    return 1
+def any_fn_1204(arg_1204: Any) -> int:
+    return 1
+def any_fn_1205(arg_1205: Any) -> int:
+    return 1
+def any_fn_1206(arg_1206: Any) -> int:
+    return 1
+def any_fn_1207(arg_1207: Any) -> int:
+    return 1
+def any_fn_1208(arg_1208: Any) -> int:
+    return 1
+def any_fn_1209(arg_1209: Any) -> int:
+    return 1
+def any_fn_1210(arg_1210: Any) -> int:
+    return 1
+def any_fn_1211(arg_1211: Any) -> int:
+    return 1
+def any_fn_1212(arg_1212: Any) -> int:
+    return 1
+def any_fn_1213(arg_1213: Any) -> int:
+    return 1
+def any_fn_1214(arg_1214: Any) -> int:
+    return 1
+def any_fn_1215(arg_1215: Any) -> int:
+    return 1
+def any_fn_1216(arg_1216: Any) -> int:
+    return 1
+def any_fn_1217(arg_1217: Any) -> int:
+    return 1
+def any_fn_1218(arg_1218: Any) -> int:
+    return 1
+def any_fn_1219(arg_1219: Any) -> int:
+    return 1
+def any_fn_1220(arg_1220: Any) -> int:
+    return 1
+def any_fn_1221(arg_1221: Any) -> int:
+    return 1
+def any_fn_1222(arg_1222: Any) -> int:
+    return 1
+def any_fn_1223(arg_1223: Any) -> int:
+    return 1
+def any_fn_1224(arg_1224: Any) -> int:
+    return 1
+def any_fn_1225(arg_1225: Any) -> int:
+    return 1
+def any_fn_1226(arg_1226: Any) -> int:
+    return 1
+def any_fn_1227(arg_1227: Any) -> int:
+    return 1
+def any_fn_1228(arg_1228: Any) -> int:
+    return 1
+def any_fn_1229(arg_1229: Any) -> int:
+    return 1
+def any_fn_1230(arg_1230: Any) -> int:
+    return 1
+def any_fn_1231(arg_1231: Any) -> int:
+    return 1
+def any_fn_1232(arg_1232: Any) -> int:
+    return 1
+def any_fn_1233(arg_1233: Any) -> int:
+    return 1
+def any_fn_1234(arg_1234: Any) -> int:
+    return 1
+def any_fn_1235(arg_1235: Any) -> int:
+    return 1
+def any_fn_1236(arg_1236: Any) -> int:
+    return 1
+def any_fn_1237(arg_1237: Any) -> int:
+    return 1
+def any_fn_1238(arg_1238: Any) -> int:
+    return 1
+def any_fn_1239(arg_1239: Any) -> int:
+    return 1
+def any_fn_1240(arg_1240: Any) -> int:
+    return 1
+def any_fn_1241(arg_1241: Any) -> int:
+    return 1
+def any_fn_1242(arg_1242: Any) -> int:
+    return 1
+def any_fn_1243(arg_1243: Any) -> int:
+    return 1
+def any_fn_1244(arg_1244: Any) -> int:
+    return 1
+def any_fn_1245(arg_1245: Any) -> int:
+    return 1
+def any_fn_1246(arg_1246: Any) -> int:
+    return 1
+def any_fn_1247(arg_1247: Any) -> int:
+    return 1
+def any_fn_1248(arg_1248: Any) -> int:
+    return 1
+def any_fn_1249(arg_1249: Any) -> int:
+    return 1
+def any_fn_1250(arg_1250: Any) -> int:
+    return 1
+def any_fn_1251(arg_1251: Any) -> int:
+    return 1
+def any_fn_1252(arg_1252: Any) -> int:
+    return 1
+def any_fn_1253(arg_1253: Any) -> int:
+    return 1
+def any_fn_1254(arg_1254: Any) -> int:
+    return 1
+def any_fn_1255(arg_1255: Any) -> int:
+    return 1
+def any_fn_1256(arg_1256: Any) -> int:
+    return 1
+def any_fn_1257(arg_1257: Any) -> int:
+    return 1
+def any_fn_1258(arg_1258: Any) -> int:
+    return 1
+def any_fn_1259(arg_1259: Any) -> int:
+    return 1
+def any_fn_1260(arg_1260: Any) -> int:
+    return 1
+def any_fn_1261(arg_1261: Any) -> int:
+    return 1
+def any_fn_1262(arg_1262: Any) -> int:
+    return 1
+def any_fn_1263(arg_1263: Any) -> int:
+    return 1
+def any_fn_1264(arg_1264: Any) -> int:
+    return 1
+def any_fn_1265(arg_1265: Any) -> int:
+    return 1
+def any_fn_1266(arg_1266: Any) -> int:
+    return 1
+def any_fn_1267(arg_1267: Any) -> int:
+    return 1
+def any_fn_1268(arg_1268: Any) -> int:
+    return 1
+def any_fn_1269(arg_1269: Any) -> int:
+    return 1
+def any_fn_1270(arg_1270: Any) -> int:
+    return 1
+def any_fn_1271(arg_1271: Any) -> int:
+    return 1
+def any_fn_1272(arg_1272: Any) -> int:
+    return 1
+def any_fn_1273(arg_1273: Any) -> int:
+    return 1
+def any_fn_1274(arg_1274: Any) -> int:
+    return 1
+def any_fn_1275(arg_1275: Any) -> int:
+    return 1
+def any_fn_1276(arg_1276: Any) -> int:
+    return 1
+def any_fn_1277(arg_1277: Any) -> int:
+    return 1
+def any_fn_1278(arg_1278: Any) -> int:
+    return 1
+def any_fn_1279(arg_1279: Any) -> int:
+    return 1
+def any_fn_1280(arg_1280: Any) -> int:
+    return 1
+def any_fn_1281(arg_1281: Any) -> int:
+    return 1
+def any_fn_1282(arg_1282: Any) -> int:
+    return 1
+def any_fn_1283(arg_1283: Any) -> int:
+    return 1
+def any_fn_1284(arg_1284: Any) -> int:
+    return 1
+def any_fn_1285(arg_1285: Any) -> int:
+    return 1
+def any_fn_1286(arg_1286: Any) -> int:
+    return 1
+def any_fn_1287(arg_1287: Any) -> int:
+    return 1
+def any_fn_1288(arg_1288: Any) -> int:
+    return 1
+def any_fn_1289(arg_1289: Any) -> int:
+    return 1
+def any_fn_1290(arg_1290: Any) -> int:
+    return 1
+def any_fn_1291(arg_1291: Any) -> int:
+    return 1
+def any_fn_1292(arg_1292: Any) -> int:
+    return 1
+def any_fn_1293(arg_1293: Any) -> int:
+    return 1
+def any_fn_1294(arg_1294: Any) -> int:
+    return 1
+def any_fn_1295(arg_1295: Any) -> int:
+    return 1
+def any_fn_1296(arg_1296: Any) -> int:
+    return 1
+def any_fn_1297(arg_1297: Any) -> int:
+    return 1
+def any_fn_1298(arg_1298: Any) -> int:
+    return 1
+def any_fn_1299(arg_1299: Any) -> int:
+    return 1
+def any_fn_1300(arg_1300: Any) -> int:
+    return 1
+def any_fn_1301(arg_1301: Any) -> int:
+    return 1
+def any_fn_1302(arg_1302: Any) -> int:
+    return 1
+def any_fn_1303(arg_1303: Any) -> int:
+    return 1
+def any_fn_1304(arg_1304: Any) -> int:
+    return 1
+def any_fn_1305(arg_1305: Any) -> int:
+    return 1
+def any_fn_1306(arg_1306: Any) -> int:
+    return 1
+def any_fn_1307(arg_1307: Any) -> int:
+    return 1
+def any_fn_1308(arg_1308: Any) -> int:
+    return 1
+def any_fn_1309(arg_1309: Any) -> int:
+    return 1
+def any_fn_1310(arg_1310: Any) -> int:
+    return 1
+def any_fn_1311(arg_1311: Any) -> int:
+    return 1
+def any_fn_1312(arg_1312: Any) -> int:
+    return 1
+def any_fn_1313(arg_1313: Any) -> int:
+    return 1
+def any_fn_1314(arg_1314: Any) -> int:
+    return 1
+def any_fn_1315(arg_1315: Any) -> int:
+    return 1
+def any_fn_1316(arg_1316: Any) -> int:
+    return 1
+def any_fn_1317(arg_1317: Any) -> int:
+    return 1
+def any_fn_1318(arg_1318: Any) -> int:
+    return 1
+def any_fn_1319(arg_1319: Any) -> int:
+    return 1
+def any_fn_1320(arg_1320: Any) -> int:
+    return 1
+def any_fn_1321(arg_1321: Any) -> int:
+    return 1
+def any_fn_1322(arg_1322: Any) -> int:
+    return 1
+def any_fn_1323(arg_1323: Any) -> int:
+    return 1
+def any_fn_1324(arg_1324: Any) -> int:
+    return 1
+def any_fn_1325(arg_1325: Any) -> int:
+    return 1
+def any_fn_1326(arg_1326: Any) -> int:
+    return 1
+def any_fn_1327(arg_1327: Any) -> int:
+    return 1
+def any_fn_1328(arg_1328: Any) -> int:
+    return 1
+def any_fn_1329(arg_1329: Any) -> int:
+    return 1
+def any_fn_1330(arg_1330: Any) -> int:
+    return 1
+def any_fn_1331(arg_1331: Any) -> int:
+    return 1
+def any_fn_1332(arg_1332: Any) -> int:
+    return 1
+def any_fn_1333(arg_1333: Any) -> int:
+    return 1
+def any_fn_1334(arg_1334: Any) -> int:
+    return 1
+def any_fn_1335(arg_1335: Any) -> int:
+    return 1
+def any_fn_1336(arg_1336: Any) -> int:
+    return 1
+def any_fn_1337(arg_1337: Any) -> int:
+    return 1
+def any_fn_1338(arg_1338: Any) -> int:
+    return 1
+def any_fn_1339(arg_1339: Any) -> int:
+    return 1
+def any_fn_1340(arg_1340: Any) -> int:
+    return 1
+def any_fn_1341(arg_1341: Any) -> int:
+    return 1
+def any_fn_1342(arg_1342: Any) -> int:
+    return 1
+def any_fn_1343(arg_1343: Any) -> int:
+    return 1
+def any_fn_1344(arg_1344: Any) -> int:
+    return 1
+def any_fn_1345(arg_1345: Any) -> int:
+    return 1
+def any_fn_1346(arg_1346: Any) -> int:
+    return 1
+def any_fn_1347(arg_1347: Any) -> int:
+    return 1
+def any_fn_1348(arg_1348: Any) -> int:
+    return 1
+def any_fn_1349(arg_1349: Any) -> int:
+    return 1
+def any_fn_1350(arg_1350: Any) -> int:
+    return 1
+def any_fn_1351(arg_1351: Any) -> int:
+    return 1
+def any_fn_1352(arg_1352: Any) -> int:
+    return 1
+def any_fn_1353(arg_1353: Any) -> int:
+    return 1
+def any_fn_1354(arg_1354: Any) -> int:
+    return 1
+def any_fn_1355(arg_1355: Any) -> int:
+    return 1
+def any_fn_1356(arg_1356: Any) -> int:
+    return 1
+def any_fn_1357(arg_1357: Any) -> int:
+    return 1
+def any_fn_1358(arg_1358: Any) -> int:
+    return 1
+def any_fn_1359(arg_1359: Any) -> int:
+    return 1
+def any_fn_1360(arg_1360: Any) -> int:
+    return 1
+def any_fn_1361(arg_1361: Any) -> int:
+    return 1
+def any_fn_1362(arg_1362: Any) -> int:
+    return 1
+def any_fn_1363(arg_1363: Any) -> int:
+    return 1
+def any_fn_1364(arg_1364: Any) -> int:
+    return 1
+def any_fn_1365(arg_1365: Any) -> int:
+    return 1
+def any_fn_1366(arg_1366: Any) -> int:
+    return 1
+def any_fn_1367(arg_1367: Any) -> int:
+    return 1
+def any_fn_1368(arg_1368: Any) -> int:
+    return 1
+def any_fn_1369(arg_1369: Any) -> int:
+    return 1
+def any_fn_1370(arg_1370: Any) -> int:
+    return 1
+def any_fn_1371(arg_1371: Any) -> int:
+    return 1
+def any_fn_1372(arg_1372: Any) -> int:
+    return 1
+def any_fn_1373(arg_1373: Any) -> int:
+    return 1
+def any_fn_1374(arg_1374: Any) -> int:
+    return 1
+def any_fn_1375(arg_1375: Any) -> int:
+    return 1
+def any_fn_1376(arg_1376: Any) -> int:
+    return 1
+def any_fn_1377(arg_1377: Any) -> int:
+    return 1
+def any_fn_1378(arg_1378: Any) -> int:
+    return 1
+def any_fn_1379(arg_1379: Any) -> int:
+    return 1
+def any_fn_1380(arg_1380: Any) -> int:
+    return 1
+def any_fn_1381(arg_1381: Any) -> int:
+    return 1
+def any_fn_1382(arg_1382: Any) -> int:
+    return 1
+def any_fn_1383(arg_1383: Any) -> int:
+    return 1
+def any_fn_1384(arg_1384: Any) -> int:
+    return 1
+def any_fn_1385(arg_1385: Any) -> int:
+    return 1
+def any_fn_1386(arg_1386: Any) -> int:
+    return 1
+def any_fn_1387(arg_1387: Any) -> int:
+    return 1
+def any_fn_1388(arg_1388: Any) -> int:
+    return 1
+def any_fn_1389(arg_1389: Any) -> int:
+    return 1
+def any_fn_1390(arg_1390: Any) -> int:
+    return 1
+def any_fn_1391(arg_1391: Any) -> int:
+    return 1
+def any_fn_1392(arg_1392: Any) -> int:
+    return 1
+def any_fn_1393(arg_1393: Any) -> int:
+    return 1
+def any_fn_1394(arg_1394: Any) -> int:
+    return 1
+def any_fn_1395(arg_1395: Any) -> int:
+    return 1
+def any_fn_1396(arg_1396: Any) -> int:
+    return 1
+def any_fn_1397(arg_1397: Any) -> int:
+    return 1
+def any_fn_1398(arg_1398: Any) -> int:
+    return 1
+def any_fn_1399(arg_1399: Any) -> int:
+    return 1
+def any_fn_1400(arg_1400: Any) -> int:
+    return 1
+def any_fn_1401(arg_1401: Any) -> int:
+    return 1
+def any_fn_1402(arg_1402: Any) -> int:
+    return 1
+def any_fn_1403(arg_1403: Any) -> int:
+    return 1
+def any_fn_1404(arg_1404: Any) -> int:
+    return 1
+def any_fn_1405(arg_1405: Any) -> int:
+    return 1
+def any_fn_1406(arg_1406: Any) -> int:
+    return 1
+def any_fn_1407(arg_1407: Any) -> int:
+    return 1
+def any_fn_1408(arg_1408: Any) -> int:
+    return 1
+def any_fn_1409(arg_1409: Any) -> int:
+    return 1
+def any_fn_1410(arg_1410: Any) -> int:
+    return 1
+def any_fn_1411(arg_1411: Any) -> int:
+    return 1
+def any_fn_1412(arg_1412: Any) -> int:
+    return 1
+def any_fn_1413(arg_1413: Any) -> int:
+    return 1
+def any_fn_1414(arg_1414: Any) -> int:
+    return 1
+def any_fn_1415(arg_1415: Any) -> int:
+    return 1
+def any_fn_1416(arg_1416: Any) -> int:
+    return 1
+def any_fn_1417(arg_1417: Any) -> int:
+    return 1
+def any_fn_1418(arg_1418: Any) -> int:
+    return 1
+def any_fn_1419(arg_1419: Any) -> int:
+    return 1
+def any_fn_1420(arg_1420: Any) -> int:
+    return 1
+def any_fn_1421(arg_1421: Any) -> int:
+    return 1
+def any_fn_1422(arg_1422: Any) -> int:
+    return 1
+def any_fn_1423(arg_1423: Any) -> int:
+    return 1
+def any_fn_1424(arg_1424: Any) -> int:
+    return 1
+def any_fn_1425(arg_1425: Any) -> int:
+    return 1
+def any_fn_1426(arg_1426: Any) -> int:
+    return 1
+def any_fn_1427(arg_1427: Any) -> int:
+    return 1
+def any_fn_1428(arg_1428: Any) -> int:
+    return 1
+def any_fn_1429(arg_1429: Any) -> int:
+    return 1
+def any_fn_1430(arg_1430: Any) -> int:
+    return 1
+def any_fn_1431(arg_1431: Any) -> int:
+    return 1
+def any_fn_1432(arg_1432: Any) -> int:
+    return 1
+def any_fn_1433(arg_1433: Any) -> int:
+    return 1
+def any_fn_1434(arg_1434: Any) -> int:
+    return 1
+def any_fn_1435(arg_1435: Any) -> int:
+    return 1
+def any_fn_1436(arg_1436: Any) -> int:
+    return 1
+def any_fn_1437(arg_1437: Any) -> int:
+    return 1
+def any_fn_1438(arg_1438: Any) -> int:
+    return 1
+def any_fn_1439(arg_1439: Any) -> int:
+    return 1
+def any_fn_1440(arg_1440: Any) -> int:
+    return 1
+def any_fn_1441(arg_1441: Any) -> int:
+    return 1
+def any_fn_1442(arg_1442: Any) -> int:
+    return 1
+def any_fn_1443(arg_1443: Any) -> int:
+    return 1
+def any_fn_1444(arg_1444: Any) -> int:
+    return 1
+def any_fn_1445(arg_1445: Any) -> int:
+    return 1
+def any_fn_1446(arg_1446: Any) -> int:
+    return 1
+def any_fn_1447(arg_1447: Any) -> int:
+    return 1
+def any_fn_1448(arg_1448: Any) -> int:
+    return 1
+def any_fn_1449(arg_1449: Any) -> int:
+    return 1
+def any_fn_1450(arg_1450: Any) -> int:
+    return 1
+def any_fn_1451(arg_1451: Any) -> int:
+    return 1
+def any_fn_1452(arg_1452: Any) -> int:
+    return 1
+def any_fn_1453(arg_1453: Any) -> int:
+    return 1
+def any_fn_1454(arg_1454: Any) -> int:
+    return 1
+def any_fn_1455(arg_1455: Any) -> int:
+    return 1
+def any_fn_1456(arg_1456: Any) -> int:
+    return 1
+def any_fn_1457(arg_1457: Any) -> int:
+    return 1
+def any_fn_1458(arg_1458: Any) -> int:
+    return 1
+def any_fn_1459(arg_1459: Any) -> int:
+    return 1
+def any_fn_1460(arg_1460: Any) -> int:
+    return 1
+def any_fn_1461(arg_1461: Any) -> int:
+    return 1
+def any_fn_1462(arg_1462: Any) -> int:
+    return 1
+def any_fn_1463(arg_1463: Any) -> int:
+    return 1
+def any_fn_1464(arg_1464: Any) -> int:
+    return 1
+def any_fn_1465(arg_1465: Any) -> int:
+    return 1
+def any_fn_1466(arg_1466: Any) -> int:
+    return 1
+def any_fn_1467(arg_1467: Any) -> int:
+    return 1
+def any_fn_1468(arg_1468: Any) -> int:
+    return 1
+def any_fn_1469(arg_1469: Any) -> int:
+    return 1
+def any_fn_1470(arg_1470: Any) -> int:
+    return 1
+def any_fn_1471(arg_1471: Any) -> int:
+    return 1
+def any_fn_1472(arg_1472: Any) -> int:
+    return 1
+def any_fn_1473(arg_1473: Any) -> int:
+    return 1
+def any_fn_1474(arg_1474: Any) -> int:
+    return 1
+def any_fn_1475(arg_1475: Any) -> int:
+    return 1
+def any_fn_1476(arg_1476: Any) -> int:
+    return 1
+def any_fn_1477(arg_1477: Any) -> int:
+    return 1
+def any_fn_1478(arg_1478: Any) -> int:
+    return 1
+def any_fn_1479(arg_1479: Any) -> int:
+    return 1
+def any_fn_1480(arg_1480: Any) -> int:
+    return 1
+def any_fn_1481(arg_1481: Any) -> int:
+    return 1
+def any_fn_1482(arg_1482: Any) -> int:
+    return 1
+def any_fn_1483(arg_1483: Any) -> int:
+    return 1
+def any_fn_1484(arg_1484: Any) -> int:
+    return 1
+def any_fn_1485(arg_1485: Any) -> int:
+    return 1
+def any_fn_1486(arg_1486: Any) -> int:
+    return 1
+def any_fn_1487(arg_1487: Any) -> int:
+    return 1
+def any_fn_1488(arg_1488: Any) -> int:
+    return 1
+def any_fn_1489(arg_1489: Any) -> int:
+    return 1
+def any_fn_1490(arg_1490: Any) -> int:
+    return 1
+def any_fn_1491(arg_1491: Any) -> int:
+    return 1
+def any_fn_1492(arg_1492: Any) -> int:
+    return 1
+def any_fn_1493(arg_1493: Any) -> int:
+    return 1
+def any_fn_1494(arg_1494: Any) -> int:
+    return 1
+def any_fn_1495(arg_1495: Any) -> int:
+    return 1
+def any_fn_1496(arg_1496: Any) -> int:
+    return 1
+def any_fn_1497(arg_1497: Any) -> int:
+    return 1
+def any_fn_1498(arg_1498: Any) -> int:
+    return 1
+def any_fn_1499(arg_1499: Any) -> int:
+    return 1
+def any_fn_1500(arg_1500: Any) -> int:
+    return 1
+def any_fn_1501(arg_1501: Any) -> int:
+    return 1
+def any_fn_1502(arg_1502: Any) -> int:
+    return 1
+def any_fn_1503(arg_1503: Any) -> int:
+    return 1
+def any_fn_1504(arg_1504: Any) -> int:
+    return 1
+def any_fn_1505(arg_1505: Any) -> int:
+    return 1
+def any_fn_1506(arg_1506: Any) -> int:
+    return 1
+def any_fn_1507(arg_1507: Any) -> int:
+    return 1
+def any_fn_1508(arg_1508: Any) -> int:
+    return 1
+def any_fn_1509(arg_1509: Any) -> int:
+    return 1
+def any_fn_1510(arg_1510: Any) -> int:
+    return 1
+def any_fn_1511(arg_1511: Any) -> int:
+    return 1
+def any_fn_1512(arg_1512: Any) -> int:
+    return 1
+def any_fn_1513(arg_1513: Any) -> int:
+    return 1
+def any_fn_1514(arg_1514: Any) -> int:
+    return 1
+def any_fn_1515(arg_1515: Any) -> int:
+    return 1
+def any_fn_1516(arg_1516: Any) -> int:
+    return 1
+def any_fn_1517(arg_1517: Any) -> int:
+    return 1
+def any_fn_1518(arg_1518: Any) -> int:
+    return 1
+def any_fn_1519(arg_1519: Any) -> int:
+    return 1
+def any_fn_1520(arg_1520: Any) -> int:
+    return 1
+def any_fn_1521(arg_1521: Any) -> int:
+    return 1
+def any_fn_1522(arg_1522: Any) -> int:
+    return 1
+def any_fn_1523(arg_1523: Any) -> int:
+    return 1
+def any_fn_1524(arg_1524: Any) -> int:
+    return 1
+def any_fn_1525(arg_1525: Any) -> int:
+    return 1
+def any_fn_1526(arg_1526: Any) -> int:
+    return 1
+def any_fn_1527(arg_1527: Any) -> int:
+    return 1
+def any_fn_1528(arg_1528: Any) -> int:
+    return 1
+def any_fn_1529(arg_1529: Any) -> int:
+    return 1
+def any_fn_1530(arg_1530: Any) -> int:
+    return 1
+def any_fn_1531(arg_1531: Any) -> int:
+    return 1
+def any_fn_1532(arg_1532: Any) -> int:
+    return 1
+def any_fn_1533(arg_1533: Any) -> int:
+    return 1
+def any_fn_1534(arg_1534: Any) -> int:
+    return 1
+def any_fn_1535(arg_1535: Any) -> int:
+    return 1
+def any_fn_1536(arg_1536: Any) -> int:
+    return 1
+def any_fn_1537(arg_1537: Any) -> int:
+    return 1
+def any_fn_1538(arg_1538: Any) -> int:
+    return 1
+def any_fn_1539(arg_1539: Any) -> int:
+    return 1
+def any_fn_1540(arg_1540: Any) -> int:
+    return 1
+def any_fn_1541(arg_1541: Any) -> int:
+    return 1
+def any_fn_1542(arg_1542: Any) -> int:
+    return 1
+def any_fn_1543(arg_1543: Any) -> int:
+    return 1
+def any_fn_1544(arg_1544: Any) -> int:
+    return 1
+def any_fn_1545(arg_1545: Any) -> int:
+    return 1
+def any_fn_1546(arg_1546: Any) -> int:
+    return 1
+def any_fn_1547(arg_1547: Any) -> int:
+    return 1
+def any_fn_1548(arg_1548: Any) -> int:
+    return 1
+def any_fn_1549(arg_1549: Any) -> int:
+    return 1
+def any_fn_1550(arg_1550: Any) -> int:
+    return 1
+def any_fn_1551(arg_1551: Any) -> int:
+    return 1
+def any_fn_1552(arg_1552: Any) -> int:
+    return 1
+def any_fn_1553(arg_1553: Any) -> int:
+    return 1
+def any_fn_1554(arg_1554: Any) -> int:
+    return 1
+def any_fn_1555(arg_1555: Any) -> int:
+    return 1
+def any_fn_1556(arg_1556: Any) -> int:
+    return 1
+def any_fn_1557(arg_1557: Any) -> int:
+    return 1
+def any_fn_1558(arg_1558: Any) -> int:
+    return 1
+def any_fn_1559(arg_1559: Any) -> int:
+    return 1
+def any_fn_1560(arg_1560: Any) -> int:
+    return 1
+def any_fn_1561(arg_1561: Any) -> int:
+    return 1
+def any_fn_1562(arg_1562: Any) -> int:
+    return 1
+def any_fn_1563(arg_1563: Any) -> int:
+    return 1
+def any_fn_1564(arg_1564: Any) -> int:
+    return 1
+def any_fn_1565(arg_1565: Any) -> int:
+    return 1
+def any_fn_1566(arg_1566: Any) -> int:
+    return 1
+def any_fn_1567(arg_1567: Any) -> int:
+    return 1
+def any_fn_1568(arg_1568: Any) -> int:
+    return 1
+def any_fn_1569(arg_1569: Any) -> int:
+    return 1
+def any_fn_1570(arg_1570: Any) -> int:
+    return 1
+def any_fn_1571(arg_1571: Any) -> int:
+    return 1
+def any_fn_1572(arg_1572: Any) -> int:
+    return 1
+def any_fn_1573(arg_1573: Any) -> int:
+    return 1
+def any_fn_1574(arg_1574: Any) -> int:
+    return 1
+def any_fn_1575(arg_1575: Any) -> int:
+    return 1
+def any_fn_1576(arg_1576: Any) -> int:
+    return 1
+def any_fn_1577(arg_1577: Any) -> int:
+    return 1
+def any_fn_1578(arg_1578: Any) -> int:
+    return 1
+def any_fn_1579(arg_1579: Any) -> int:
+    return 1
+def any_fn_1580(arg_1580: Any) -> int:
+    return 1
+def any_fn_1581(arg_1581: Any) -> int:
+    return 1
+def any_fn_1582(arg_1582: Any) -> int:
+    return 1
+def any_fn_1583(arg_1583: Any) -> int:
+    return 1
+def any_fn_1584(arg_1584: Any) -> int:
+    return 1
+def any_fn_1585(arg_1585: Any) -> int:
+    return 1
+def any_fn_1586(arg_1586: Any) -> int:
+    return 1
+def any_fn_1587(arg_1587: Any) -> int:
+    return 1
+def any_fn_1588(arg_1588: Any) -> int:
+    return 1
+def any_fn_1589(arg_1589: Any) -> int:
+    return 1
+def any_fn_1590(arg_1590: Any) -> int:
+    return 1
+def any_fn_1591(arg_1591: Any) -> int:
+    return 1
+def any_fn_1592(arg_1592: Any) -> int:
+    return 1
+def any_fn_1593(arg_1593: Any) -> int:
+    return 1
+def any_fn_1594(arg_1594: Any) -> int:
+    return 1
+def any_fn_1595(arg_1595: Any) -> int:
+    return 1
+def any_fn_1596(arg_1596: Any) -> int:
+    return 1
+def any_fn_1597(arg_1597: Any) -> int:
+    return 1
+def any_fn_1598(arg_1598: Any) -> int:
+    return 1
+def any_fn_1599(arg_1599: Any) -> int:
+    return 1
+def any_fn_1600(arg_1600: Any) -> int:
+    return 1
+def any_fn_1601(arg_1601: Any) -> int:
+    return 1
+def any_fn_1602(arg_1602: Any) -> int:
+    return 1
+def any_fn_1603(arg_1603: Any) -> int:
+    return 1
+def any_fn_1604(arg_1604: Any) -> int:
+    return 1
+def any_fn_1605(arg_1605: Any) -> int:
+    return 1
+def any_fn_1606(arg_1606: Any) -> int:
+    return 1
+def any_fn_1607(arg_1607: Any) -> int:
+    return 1
+def any_fn_1608(arg_1608: Any) -> int:
+    return 1
+def any_fn_1609(arg_1609: Any) -> int:
+    return 1
+def any_fn_1610(arg_1610: Any) -> int:
+    return 1
+def any_fn_1611(arg_1611: Any) -> int:
+    return 1
+def any_fn_1612(arg_1612: Any) -> int:
+    return 1
+def any_fn_1613(arg_1613: Any) -> int:
+    return 1
+def any_fn_1614(arg_1614: Any) -> int:
+    return 1
+def any_fn_1615(arg_1615: Any) -> int:
+    return 1
+def any_fn_1616(arg_1616: Any) -> int:
+    return 1
+def any_fn_1617(arg_1617: Any) -> int:
+    return 1
+def any_fn_1618(arg_1618: Any) -> int:
+    return 1
+def any_fn_1619(arg_1619: Any) -> int:
+    return 1
+def any_fn_1620(arg_1620: Any) -> int:
+    return 1
+def any_fn_1621(arg_1621: Any) -> int:
+    return 1
+def any_fn_1622(arg_1622: Any) -> int:
+    return 1
+def any_fn_1623(arg_1623: Any) -> int:
+    return 1
+def any_fn_1624(arg_1624: Any) -> int:
+    return 1
+def any_fn_1625(arg_1625: Any) -> int:
+    return 1
+def any_fn_1626(arg_1626: Any) -> int:
+    return 1
+def any_fn_1627(arg_1627: Any) -> int:
+    return 1
+def any_fn_1628(arg_1628: Any) -> int:
+    return 1
+def any_fn_1629(arg_1629: Any) -> int:
+    return 1
+def any_fn_1630(arg_1630: Any) -> int:
+    return 1
+def any_fn_1631(arg_1631: Any) -> int:
+    return 1
+def any_fn_1632(arg_1632: Any) -> int:
+    return 1
+def any_fn_1633(arg_1633: Any) -> int:
+    return 1
+def any_fn_1634(arg_1634: Any) -> int:
+    return 1
+def any_fn_1635(arg_1635: Any) -> int:
+    return 1
+def any_fn_1636(arg_1636: Any) -> int:
+    return 1
+def any_fn_1637(arg_1637: Any) -> int:
+    return 1
+def any_fn_1638(arg_1638: Any) -> int:
+    return 1
+def any_fn_1639(arg_1639: Any) -> int:
+    return 1
+def any_fn_1640(arg_1640: Any) -> int:
+    return 1
+def any_fn_1641(arg_1641: Any) -> int:
+    return 1
+def any_fn_1642(arg_1642: Any) -> int:
+    return 1
+def any_fn_1643(arg_1643: Any) -> int:
+    return 1
+def any_fn_1644(arg_1644: Any) -> int:
+    return 1
+def any_fn_1645(arg_1645: Any) -> int:
+    return 1
+def any_fn_1646(arg_1646: Any) -> int:
+    return 1
+def any_fn_1647(arg_1647: Any) -> int:
+    return 1
+def any_fn_1648(arg_1648: Any) -> int:
+    return 1
+def any_fn_1649(arg_1649: Any) -> int:
+    return 1
+def any_fn_1650(arg_1650: Any) -> int:
+    return 1
+def any_fn_1651(arg_1651: Any) -> int:
+    return 1
+def any_fn_1652(arg_1652: Any) -> int:
+    return 1
+def any_fn_1653(arg_1653: Any) -> int:
+    return 1
+def any_fn_1654(arg_1654: Any) -> int:
+    return 1
+def any_fn_1655(arg_1655: Any) -> int:
+    return 1
+def any_fn_1656(arg_1656: Any) -> int:
+    return 1
+def any_fn_1657(arg_1657: Any) -> int:
+    return 1
+def any_fn_1658(arg_1658: Any) -> int:
+    return 1
+def any_fn_1659(arg_1659: Any) -> int:
+    return 1
+def any_fn_1660(arg_1660: Any) -> int:
+    return 1
+def any_fn_1661(arg_1661: Any) -> int:
+    return 1
+def any_fn_1662(arg_1662: Any) -> int:
+    return 1
+def any_fn_1663(arg_1663: Any) -> int:
+    return 1
+def any_fn_1664(arg_1664: Any) -> int:
+    return 1
+def any_fn_1665(arg_1665: Any) -> int:
+    return 1
+def any_fn_1666(arg_1666: Any) -> int:
+    return 1
+def any_fn_1667(arg_1667: Any) -> int:
+    return 1
+def any_fn_1668(arg_1668: Any) -> int:
+    return 1
+def any_fn_1669(arg_1669: Any) -> int:
+    return 1
+def any_fn_1670(arg_1670: Any) -> int:
+    return 1
+def any_fn_1671(arg_1671: Any) -> int:
+    return 1
+def any_fn_1672(arg_1672: Any) -> int:
+    return 1
+def any_fn_1673(arg_1673: Any) -> int:
+    return 1
+def any_fn_1674(arg_1674: Any) -> int:
+    return 1
+def any_fn_1675(arg_1675: Any) -> int:
+    return 1
+def any_fn_1676(arg_1676: Any) -> int:
+    return 1
+def any_fn_1677(arg_1677: Any) -> int:
+    return 1
+def any_fn_1678(arg_1678: Any) -> int:
+    return 1
+def any_fn_1679(arg_1679: Any) -> int:
+    return 1
+def any_fn_1680(arg_1680: Any) -> int:
+    return 1
+def any_fn_1681(arg_1681: Any) -> int:
+    return 1
+def any_fn_1682(arg_1682: Any) -> int:
+    return 1
+def any_fn_1683(arg_1683: Any) -> int:
+    return 1
+def any_fn_1684(arg_1684: Any) -> int:
+    return 1
+def any_fn_1685(arg_1685: Any) -> int:
+    return 1
+def any_fn_1686(arg_1686: Any) -> int:
+    return 1
+def any_fn_1687(arg_1687: Any) -> int:
+    return 1
+def any_fn_1688(arg_1688: Any) -> int:
+    return 1
+def any_fn_1689(arg_1689: Any) -> int:
+    return 1
+def any_fn_1690(arg_1690: Any) -> int:
+    return 1
+def any_fn_1691(arg_1691: Any) -> int:
+    return 1
+def any_fn_1692(arg_1692: Any) -> int:
+    return 1
+def any_fn_1693(arg_1693: Any) -> int:
+    return 1
+def any_fn_1694(arg_1694: Any) -> int:
+    return 1
+def any_fn_1695(arg_1695: Any) -> int:
+    return 1
+def any_fn_1696(arg_1696: Any) -> int:
+    return 1
+def any_fn_1697(arg_1697: Any) -> int:
+    return 1
+def any_fn_1698(arg_1698: Any) -> int:
+    return 1
+def any_fn_1699(arg_1699: Any) -> int:
+    return 1
+def any_fn_1700(arg_1700: Any) -> int:
+    return 1
+def any_fn_1701(arg_1701: Any) -> int:
+    return 1
+def any_fn_1702(arg_1702: Any) -> int:
+    return 1
+def any_fn_1703(arg_1703: Any) -> int:
+    return 1
+def any_fn_1704(arg_1704: Any) -> int:
+    return 1
+def any_fn_1705(arg_1705: Any) -> int:
+    return 1
+def any_fn_1706(arg_1706: Any) -> int:
+    return 1
+def any_fn_1707(arg_1707: Any) -> int:
+    return 1
+def any_fn_1708(arg_1708: Any) -> int:
+    return 1
+def any_fn_1709(arg_1709: Any) -> int:
+    return 1
+def any_fn_1710(arg_1710: Any) -> int:
+    return 1
+def any_fn_1711(arg_1711: Any) -> int:
+    return 1
+def any_fn_1712(arg_1712: Any) -> int:
+    return 1
+def any_fn_1713(arg_1713: Any) -> int:
+    return 1
+def any_fn_1714(arg_1714: Any) -> int:
+    return 1
+def any_fn_1715(arg_1715: Any) -> int:
+    return 1
+def any_fn_1716(arg_1716: Any) -> int:
+    return 1
+def any_fn_1717(arg_1717: Any) -> int:
+    return 1
+def any_fn_1718(arg_1718: Any) -> int:
+    return 1
+def any_fn_1719(arg_1719: Any) -> int:
+    return 1
+def any_fn_1720(arg_1720: Any) -> int:
+    return 1
+def any_fn_1721(arg_1721: Any) -> int:
+    return 1
+def any_fn_1722(arg_1722: Any) -> int:
+    return 1
+def any_fn_1723(arg_1723: Any) -> int:
+    return 1
+def any_fn_1724(arg_1724: Any) -> int:
+    return 1
+def any_fn_1725(arg_1725: Any) -> int:
+    return 1
+def any_fn_1726(arg_1726: Any) -> int:
+    return 1
+def any_fn_1727(arg_1727: Any) -> int:
+    return 1
+def any_fn_1728(arg_1728: Any) -> int:
+    return 1
+def any_fn_1729(arg_1729: Any) -> int:
+    return 1
+def any_fn_1730(arg_1730: Any) -> int:
+    return 1
+def any_fn_1731(arg_1731: Any) -> int:
+    return 1
+def any_fn_1732(arg_1732: Any) -> int:
+    return 1
+def any_fn_1733(arg_1733: Any) -> int:
+    return 1
+def any_fn_1734(arg_1734: Any) -> int:
+    return 1
+def any_fn_1735(arg_1735: Any) -> int:
+    return 1
+def any_fn_1736(arg_1736: Any) -> int:
+    return 1
+def any_fn_1737(arg_1737: Any) -> int:
+    return 1
+def any_fn_1738(arg_1738: Any) -> int:
+    return 1
+def any_fn_1739(arg_1739: Any) -> int:
+    return 1
+def any_fn_1740(arg_1740: Any) -> int:
+    return 1
+def any_fn_1741(arg_1741: Any) -> int:
+    return 1
+def any_fn_1742(arg_1742: Any) -> int:
+    return 1
+def any_fn_1743(arg_1743: Any) -> int:
+    return 1
+def any_fn_1744(arg_1744: Any) -> int:
+    return 1
+def any_fn_1745(arg_1745: Any) -> int:
+    return 1
+def any_fn_1746(arg_1746: Any) -> int:
+    return 1
+def any_fn_1747(arg_1747: Any) -> int:
+    return 1
+def any_fn_1748(arg_1748: Any) -> int:
+    return 1
+def any_fn_1749(arg_1749: Any) -> int:
+    return 1
+def any_fn_1750(arg_1750: Any) -> int:
+    return 1
+def any_fn_1751(arg_1751: Any) -> int:
+    return 1
+def any_fn_1752(arg_1752: Any) -> int:
+    return 1
+def any_fn_1753(arg_1753: Any) -> int:
+    return 1
+def any_fn_1754(arg_1754: Any) -> int:
+    return 1
+def any_fn_1755(arg_1755: Any) -> int:
+    return 1
+def any_fn_1756(arg_1756: Any) -> int:
+    return 1
+def any_fn_1757(arg_1757: Any) -> int:
+    return 1
+def any_fn_1758(arg_1758: Any) -> int:
+    return 1
+def any_fn_1759(arg_1759: Any) -> int:
+    return 1
+def any_fn_1760(arg_1760: Any) -> int:
+    return 1
+def any_fn_1761(arg_1761: Any) -> int:
+    return 1
+def any_fn_1762(arg_1762: Any) -> int:
+    return 1
+def any_fn_1763(arg_1763: Any) -> int:
+    return 1
+def any_fn_1764(arg_1764: Any) -> int:
+    return 1
+def any_fn_1765(arg_1765: Any) -> int:
+    return 1
+def any_fn_1766(arg_1766: Any) -> int:
+    return 1
+def any_fn_1767(arg_1767: Any) -> int:
+    return 1
+def any_fn_1768(arg_1768: Any) -> int:
+    return 1
+def any_fn_1769(arg_1769: Any) -> int:
+    return 1
+def any_fn_1770(arg_1770: Any) -> int:
+    return 1
+def any_fn_1771(arg_1771: Any) -> int:
+    return 1
+def any_fn_1772(arg_1772: Any) -> int:
+    return 1
+def any_fn_1773(arg_1773: Any) -> int:
+    return 1
+def any_fn_1774(arg_1774: Any) -> int:
+    return 1
+def any_fn_1775(arg_1775: Any) -> int:
+    return 1
+def any_fn_1776(arg_1776: Any) -> int:
+    return 1
+def any_fn_1777(arg_1777: Any) -> int:
+    return 1
+def any_fn_1778(arg_1778: Any) -> int:
+    return 1
+def any_fn_1779(arg_1779: Any) -> int:
+    return 1
+def any_fn_1780(arg_1780: Any) -> int:
+    return 1
+def any_fn_1781(arg_1781: Any) -> int:
+    return 1
+def any_fn_1782(arg_1782: Any) -> int:
+    return 1
+def any_fn_1783(arg_1783: Any) -> int:
+    return 1
+def any_fn_1784(arg_1784: Any) -> int:
+    return 1
+def any_fn_1785(arg_1785: Any) -> int:
+    return 1
+def any_fn_1786(arg_1786: Any) -> int:
+    return 1
+def any_fn_1787(arg_1787: Any) -> int:
+    return 1
+def any_fn_1788(arg_1788: Any) -> int:
+    return 1
+def any_fn_1789(arg_1789: Any) -> int:
+    return 1
+def any_fn_1790(arg_1790: Any) -> int:
+    return 1
+def any_fn_1791(arg_1791: Any) -> int:
+    return 1
+def any_fn_1792(arg_1792: Any) -> int:
+    return 1
+def any_fn_1793(arg_1793: Any) -> int:
+    return 1
+def any_fn_1794(arg_1794: Any) -> int:
+    return 1
+def any_fn_1795(arg_1795: Any) -> int:
+    return 1
+def any_fn_1796(arg_1796: Any) -> int:
+    return 1
+def any_fn_1797(arg_1797: Any) -> int:
+    return 1
+def any_fn_1798(arg_1798: Any) -> int:
+    return 1
+def any_fn_1799(arg_1799: Any) -> int:
+    return 1
+def any_fn_1800(arg_1800: Any) -> int:
+    return 1
+def any_fn_1801(arg_1801: Any) -> int:
+    return 1
+def any_fn_1802(arg_1802: Any) -> int:
+    return 1
+def any_fn_1803(arg_1803: Any) -> int:
+    return 1
+def any_fn_1804(arg_1804: Any) -> int:
+    return 1
+def any_fn_1805(arg_1805: Any) -> int:
+    return 1
+def any_fn_1806(arg_1806: Any) -> int:
+    return 1
+def any_fn_1807(arg_1807: Any) -> int:
+    return 1
+def any_fn_1808(arg_1808: Any) -> int:
+    return 1
+def any_fn_1809(arg_1809: Any) -> int:
+    return 1
+def any_fn_1810(arg_1810: Any) -> int:
+    return 1
+def any_fn_1811(arg_1811: Any) -> int:
+    return 1
+def any_fn_1812(arg_1812: Any) -> int:
+    return 1
+def any_fn_1813(arg_1813: Any) -> int:
+    return 1
+def any_fn_1814(arg_1814: Any) -> int:
+    return 1
+def any_fn_1815(arg_1815: Any) -> int:
+    return 1
+def any_fn_1816(arg_1816: Any) -> int:
+    return 1
+def any_fn_1817(arg_1817: Any) -> int:
+    return 1
+def any_fn_1818(arg_1818: Any) -> int:
+    return 1
+def any_fn_1819(arg_1819: Any) -> int:
+    return 1
+def any_fn_1820(arg_1820: Any) -> int:
+    return 1
+def any_fn_1821(arg_1821: Any) -> int:
+    return 1
+def any_fn_1822(arg_1822: Any) -> int:
+    return 1
+def any_fn_1823(arg_1823: Any) -> int:
+    return 1
+def any_fn_1824(arg_1824: Any) -> int:
+    return 1
+def any_fn_1825(arg_1825: Any) -> int:
+    return 1
+def any_fn_1826(arg_1826: Any) -> int:
+    return 1
+def any_fn_1827(arg_1827: Any) -> int:
+    return 1
+def any_fn_1828(arg_1828: Any) -> int:
+    return 1
+def any_fn_1829(arg_1829: Any) -> int:
+    return 1
+def any_fn_1830(arg_1830: Any) -> int:
+    return 1
+def any_fn_1831(arg_1831: Any) -> int:
+    return 1
+def any_fn_1832(arg_1832: Any) -> int:
+    return 1
+def any_fn_1833(arg_1833: Any) -> int:
+    return 1
+def any_fn_1834(arg_1834: Any) -> int:
+    return 1
+def any_fn_1835(arg_1835: Any) -> int:
+    return 1
+def any_fn_1836(arg_1836: Any) -> int:
+    return 1
+def any_fn_1837(arg_1837: Any) -> int:
+    return 1
+def any_fn_1838(arg_1838: Any) -> int:
+    return 1
+def any_fn_1839(arg_1839: Any) -> int:
+    return 1
+def any_fn_1840(arg_1840: Any) -> int:
+    return 1
+def any_fn_1841(arg_1841: Any) -> int:
+    return 1
+def any_fn_1842(arg_1842: Any) -> int:
+    return 1
+def any_fn_1843(arg_1843: Any) -> int:
+    return 1
+def any_fn_1844(arg_1844: Any) -> int:
+    return 1
+def any_fn_1845(arg_1845: Any) -> int:
+    return 1
+def any_fn_1846(arg_1846: Any) -> int:
+    return 1
+def any_fn_1847(arg_1847: Any) -> int:
+    return 1
+def any_fn_1848(arg_1848: Any) -> int:
+    return 1
+def any_fn_1849(arg_1849: Any) -> int:
+    return 1
+def any_fn_1850(arg_1850: Any) -> int:
+    return 1
+def any_fn_1851(arg_1851: Any) -> int:
+    return 1
+def any_fn_1852(arg_1852: Any) -> int:
+    return 1
+def any_fn_1853(arg_1853: Any) -> int:
+    return 1
+def any_fn_1854(arg_1854: Any) -> int:
+    return 1
+def any_fn_1855(arg_1855: Any) -> int:
+    return 1
+def any_fn_1856(arg_1856: Any) -> int:
+    return 1
+def any_fn_1857(arg_1857: Any) -> int:
+    return 1
+def any_fn_1858(arg_1858: Any) -> int:
+    return 1
+def any_fn_1859(arg_1859: Any) -> int:
+    return 1
+def any_fn_1860(arg_1860: Any) -> int:
+    return 1
+def any_fn_1861(arg_1861: Any) -> int:
+    return 1
+def any_fn_1862(arg_1862: Any) -> int:
+    return 1
+def any_fn_1863(arg_1863: Any) -> int:
+    return 1
+def any_fn_1864(arg_1864: Any) -> int:
+    return 1
+def any_fn_1865(arg_1865: Any) -> int:
+    return 1
+def any_fn_1866(arg_1866: Any) -> int:
+    return 1
+def any_fn_1867(arg_1867: Any) -> int:
+    return 1
+def any_fn_1868(arg_1868: Any) -> int:
+    return 1
+def any_fn_1869(arg_1869: Any) -> int:
+    return 1
+def any_fn_1870(arg_1870: Any) -> int:
+    return 1
+def any_fn_1871(arg_1871: Any) -> int:
+    return 1
+def any_fn_1872(arg_1872: Any) -> int:
+    return 1
+def any_fn_1873(arg_1873: Any) -> int:
+    return 1
+def any_fn_1874(arg_1874: Any) -> int:
+    return 1
+def any_fn_1875(arg_1875: Any) -> int:
+    return 1
+def any_fn_1876(arg_1876: Any) -> int:
+    return 1
+def any_fn_1877(arg_1877: Any) -> int:
+    return 1
+def any_fn_1878(arg_1878: Any) -> int:
+    return 1
+def any_fn_1879(arg_1879: Any) -> int:
+    return 1
+def any_fn_1880(arg_1880: Any) -> int:
+    return 1
+def any_fn_1881(arg_1881: Any) -> int:
+    return 1
+def any_fn_1882(arg_1882: Any) -> int:
+    return 1
+def any_fn_1883(arg_1883: Any) -> int:
+    return 1
+def any_fn_1884(arg_1884: Any) -> int:
+    return 1
+def any_fn_1885(arg_1885: Any) -> int:
+    return 1
+def any_fn_1886(arg_1886: Any) -> int:
+    return 1
+def any_fn_1887(arg_1887: Any) -> int:
+    return 1
+def any_fn_1888(arg_1888: Any) -> int:
+    return 1
+def any_fn_1889(arg_1889: Any) -> int:
+    return 1
+def any_fn_1890(arg_1890: Any) -> int:
+    return 1
+def any_fn_1891(arg_1891: Any) -> int:
+    return 1
+def any_fn_1892(arg_1892: Any) -> int:
+    return 1
+def any_fn_1893(arg_1893: Any) -> int:
+    return 1
+def any_fn_1894(arg_1894: Any) -> int:
+    return 1
+def any_fn_1895(arg_1895: Any) -> int:
+    return 1
+def any_fn_1896(arg_1896: Any) -> int:
+    return 1
+def any_fn_1897(arg_1897: Any) -> int:
+    return 1
+def any_fn_1898(arg_1898: Any) -> int:
+    return 1
+def any_fn_1899(arg_1899: Any) -> int:
+    return 1
+def any_fn_1900(arg_1900: Any) -> int:
+    return 1
+def any_fn_1901(arg_1901: Any) -> int:
+    return 1
+def any_fn_1902(arg_1902: Any) -> int:
+    return 1
+def any_fn_1903(arg_1903: Any) -> int:
+    return 1
+def any_fn_1904(arg_1904: Any) -> int:
+    return 1
+def any_fn_1905(arg_1905: Any) -> int:
+    return 1
+def any_fn_1906(arg_1906: Any) -> int:
+    return 1
+def any_fn_1907(arg_1907: Any) -> int:
+    return 1
+def any_fn_1908(arg_1908: Any) -> int:
+    return 1
+def any_fn_1909(arg_1909: Any) -> int:
+    return 1
+def any_fn_1910(arg_1910: Any) -> int:
+    return 1
+def any_fn_1911(arg_1911: Any) -> int:
+    return 1
+def any_fn_1912(arg_1912: Any) -> int:
+    return 1
+def any_fn_1913(arg_1913: Any) -> int:
+    return 1
+def any_fn_1914(arg_1914: Any) -> int:
+    return 1
+def any_fn_1915(arg_1915: Any) -> int:
+    return 1
+def any_fn_1916(arg_1916: Any) -> int:
+    return 1
+def any_fn_1917(arg_1917: Any) -> int:
+    return 1
+def any_fn_1918(arg_1918: Any) -> int:
+    return 1
+def any_fn_1919(arg_1919: Any) -> int:
+    return 1
+def any_fn_1920(arg_1920: Any) -> int:
+    return 1
+def any_fn_1921(arg_1921: Any) -> int:
+    return 1
+def any_fn_1922(arg_1922: Any) -> int:
+    return 1
+def any_fn_1923(arg_1923: Any) -> int:
+    return 1
+def any_fn_1924(arg_1924: Any) -> int:
+    return 1
+def any_fn_1925(arg_1925: Any) -> int:
+    return 1
+def any_fn_1926(arg_1926: Any) -> int:
+    return 1
+def any_fn_1927(arg_1927: Any) -> int:
+    return 1
+def any_fn_1928(arg_1928: Any) -> int:
+    return 1
+def any_fn_1929(arg_1929: Any) -> int:
+    return 1
+def any_fn_1930(arg_1930: Any) -> int:
+    return 1
+def any_fn_1931(arg_1931: Any) -> int:
+    return 1
+def any_fn_1932(arg_1932: Any) -> int:
+    return 1
+def any_fn_1933(arg_1933: Any) -> int:
+    return 1
+def any_fn_1934(arg_1934: Any) -> int:
+    return 1
+def any_fn_1935(arg_1935: Any) -> int:
+    return 1
+def any_fn_1936(arg_1936: Any) -> int:
+    return 1
+def any_fn_1937(arg_1937: Any) -> int:
+    return 1
+def any_fn_1938(arg_1938: Any) -> int:
+    return 1
+def any_fn_1939(arg_1939: Any) -> int:
+    return 1
+def any_fn_1940(arg_1940: Any) -> int:
+    return 1
+def any_fn_1941(arg_1941: Any) -> int:
+    return 1
+def any_fn_1942(arg_1942: Any) -> int:
+    return 1
+def any_fn_1943(arg_1943: Any) -> int:
+    return 1
+def any_fn_1944(arg_1944: Any) -> int:
+    return 1
+def any_fn_1945(arg_1945: Any) -> int:
+    return 1
+def any_fn_1946(arg_1946: Any) -> int:
+    return 1
+def any_fn_1947(arg_1947: Any) -> int:
+    return 1
+def any_fn_1948(arg_1948: Any) -> int:
+    return 1
+def any_fn_1949(arg_1949: Any) -> int:
+    return 1
+def any_fn_1950(arg_1950: Any) -> int:
+    return 1
+def any_fn_1951(arg_1951: Any) -> int:
+    return 1
+def any_fn_1952(arg_1952: Any) -> int:
+    return 1
+def any_fn_1953(arg_1953: Any) -> int:
+    return 1
+def any_fn_1954(arg_1954: Any) -> int:
+    return 1
+def any_fn_1955(arg_1955: Any) -> int:
+    return 1
+def any_fn_1956(arg_1956: Any) -> int:
+    return 1
+def any_fn_1957(arg_1957: Any) -> int:
+    return 1
+def any_fn_1958(arg_1958: Any) -> int:
+    return 1
+def any_fn_1959(arg_1959: Any) -> int:
+    return 1
+def any_fn_1960(arg_1960: Any) -> int:
+    return 1
+def any_fn_1961(arg_1961: Any) -> int:
+    return 1
+def any_fn_1962(arg_1962: Any) -> int:
+    return 1
+def any_fn_1963(arg_1963: Any) -> int:
+    return 1
+def any_fn_1964(arg_1964: Any) -> int:
+    return 1
+def any_fn_1965(arg_1965: Any) -> int:
+    return 1
+def any_fn_1966(arg_1966: Any) -> int:
+    return 1
+def any_fn_1967(arg_1967: Any) -> int:
+    return 1
+def any_fn_1968(arg_1968: Any) -> int:
+    return 1
+def any_fn_1969(arg_1969: Any) -> int:
+    return 1
+def any_fn_1970(arg_1970: Any) -> int:
+    return 1
+def any_fn_1971(arg_1971: Any) -> int:
+    return 1
+def any_fn_1972(arg_1972: Any) -> int:
+    return 1
+def any_fn_1973(arg_1973: Any) -> int:
+    return 1
+def any_fn_1974(arg_1974: Any) -> int:
+    return 1
+def any_fn_1975(arg_1975: Any) -> int:
+    return 1
+def any_fn_1976(arg_1976: Any) -> int:
+    return 1
+def any_fn_1977(arg_1977: Any) -> int:
+    return 1
+def any_fn_1978(arg_1978: Any) -> int:
+    return 1
+def any_fn_1979(arg_1979: Any) -> int:
+    return 1
+def any_fn_1980(arg_1980: Any) -> int:
+    return 1
+def any_fn_1981(arg_1981: Any) -> int:
+    return 1
+def any_fn_1982(arg_1982: Any) -> int:
+    return 1
+def any_fn_1983(arg_1983: Any) -> int:
+    return 1
+def any_fn_1984(arg_1984: Any) -> int:
+    return 1
+def any_fn_1985(arg_1985: Any) -> int:
+    return 1
+def any_fn_1986(arg_1986: Any) -> int:
+    return 1
+def any_fn_1987(arg_1987: Any) -> int:
+    return 1
+def any_fn_1988(arg_1988: Any) -> int:
+    return 1
+def any_fn_1989(arg_1989: Any) -> int:
+    return 1
+def any_fn_1990(arg_1990: Any) -> int:
+    return 1
+def any_fn_1991(arg_1991: Any) -> int:
+    return 1
+def any_fn_1992(arg_1992: Any) -> int:
+    return 1
+def any_fn_1993(arg_1993: Any) -> int:
+    return 1
+def any_fn_1994(arg_1994: Any) -> int:
+    return 1
+def any_fn_1995(arg_1995: Any) -> int:
+    return 1
+def any_fn_1996(arg_1996: Any) -> int:
+    return 1
+def any_fn_1997(arg_1997: Any) -> int:
+    return 1
+def any_fn_1998(arg_1998: Any) -> int:
+    return 1
+def any_fn_1999(arg_1999: Any) -> int:
+    return 1
+def any_fn_2000(arg_2000: Any) -> int:
+    return 1

--- a/benchmarks/fixtures/e0018_undefined_name.py
+++ b/benchmarks/fixtures/e0018_undefined_name.py
@@ -1,0 +1,4000 @@
+def undef_fn_1() -> int:
+    return undefined_symbol_1
+def undef_fn_2() -> int:
+    return undefined_symbol_2
+def undef_fn_3() -> int:
+    return undefined_symbol_3
+def undef_fn_4() -> int:
+    return undefined_symbol_4
+def undef_fn_5() -> int:
+    return undefined_symbol_5
+def undef_fn_6() -> int:
+    return undefined_symbol_6
+def undef_fn_7() -> int:
+    return undefined_symbol_7
+def undef_fn_8() -> int:
+    return undefined_symbol_8
+def undef_fn_9() -> int:
+    return undefined_symbol_9
+def undef_fn_10() -> int:
+    return undefined_symbol_10
+def undef_fn_11() -> int:
+    return undefined_symbol_11
+def undef_fn_12() -> int:
+    return undefined_symbol_12
+def undef_fn_13() -> int:
+    return undefined_symbol_13
+def undef_fn_14() -> int:
+    return undefined_symbol_14
+def undef_fn_15() -> int:
+    return undefined_symbol_15
+def undef_fn_16() -> int:
+    return undefined_symbol_16
+def undef_fn_17() -> int:
+    return undefined_symbol_17
+def undef_fn_18() -> int:
+    return undefined_symbol_18
+def undef_fn_19() -> int:
+    return undefined_symbol_19
+def undef_fn_20() -> int:
+    return undefined_symbol_20
+def undef_fn_21() -> int:
+    return undefined_symbol_21
+def undef_fn_22() -> int:
+    return undefined_symbol_22
+def undef_fn_23() -> int:
+    return undefined_symbol_23
+def undef_fn_24() -> int:
+    return undefined_symbol_24
+def undef_fn_25() -> int:
+    return undefined_symbol_25
+def undef_fn_26() -> int:
+    return undefined_symbol_26
+def undef_fn_27() -> int:
+    return undefined_symbol_27
+def undef_fn_28() -> int:
+    return undefined_symbol_28
+def undef_fn_29() -> int:
+    return undefined_symbol_29
+def undef_fn_30() -> int:
+    return undefined_symbol_30
+def undef_fn_31() -> int:
+    return undefined_symbol_31
+def undef_fn_32() -> int:
+    return undefined_symbol_32
+def undef_fn_33() -> int:
+    return undefined_symbol_33
+def undef_fn_34() -> int:
+    return undefined_symbol_34
+def undef_fn_35() -> int:
+    return undefined_symbol_35
+def undef_fn_36() -> int:
+    return undefined_symbol_36
+def undef_fn_37() -> int:
+    return undefined_symbol_37
+def undef_fn_38() -> int:
+    return undefined_symbol_38
+def undef_fn_39() -> int:
+    return undefined_symbol_39
+def undef_fn_40() -> int:
+    return undefined_symbol_40
+def undef_fn_41() -> int:
+    return undefined_symbol_41
+def undef_fn_42() -> int:
+    return undefined_symbol_42
+def undef_fn_43() -> int:
+    return undefined_symbol_43
+def undef_fn_44() -> int:
+    return undefined_symbol_44
+def undef_fn_45() -> int:
+    return undefined_symbol_45
+def undef_fn_46() -> int:
+    return undefined_symbol_46
+def undef_fn_47() -> int:
+    return undefined_symbol_47
+def undef_fn_48() -> int:
+    return undefined_symbol_48
+def undef_fn_49() -> int:
+    return undefined_symbol_49
+def undef_fn_50() -> int:
+    return undefined_symbol_50
+def undef_fn_51() -> int:
+    return undefined_symbol_51
+def undef_fn_52() -> int:
+    return undefined_symbol_52
+def undef_fn_53() -> int:
+    return undefined_symbol_53
+def undef_fn_54() -> int:
+    return undefined_symbol_54
+def undef_fn_55() -> int:
+    return undefined_symbol_55
+def undef_fn_56() -> int:
+    return undefined_symbol_56
+def undef_fn_57() -> int:
+    return undefined_symbol_57
+def undef_fn_58() -> int:
+    return undefined_symbol_58
+def undef_fn_59() -> int:
+    return undefined_symbol_59
+def undef_fn_60() -> int:
+    return undefined_symbol_60
+def undef_fn_61() -> int:
+    return undefined_symbol_61
+def undef_fn_62() -> int:
+    return undefined_symbol_62
+def undef_fn_63() -> int:
+    return undefined_symbol_63
+def undef_fn_64() -> int:
+    return undefined_symbol_64
+def undef_fn_65() -> int:
+    return undefined_symbol_65
+def undef_fn_66() -> int:
+    return undefined_symbol_66
+def undef_fn_67() -> int:
+    return undefined_symbol_67
+def undef_fn_68() -> int:
+    return undefined_symbol_68
+def undef_fn_69() -> int:
+    return undefined_symbol_69
+def undef_fn_70() -> int:
+    return undefined_symbol_70
+def undef_fn_71() -> int:
+    return undefined_symbol_71
+def undef_fn_72() -> int:
+    return undefined_symbol_72
+def undef_fn_73() -> int:
+    return undefined_symbol_73
+def undef_fn_74() -> int:
+    return undefined_symbol_74
+def undef_fn_75() -> int:
+    return undefined_symbol_75
+def undef_fn_76() -> int:
+    return undefined_symbol_76
+def undef_fn_77() -> int:
+    return undefined_symbol_77
+def undef_fn_78() -> int:
+    return undefined_symbol_78
+def undef_fn_79() -> int:
+    return undefined_symbol_79
+def undef_fn_80() -> int:
+    return undefined_symbol_80
+def undef_fn_81() -> int:
+    return undefined_symbol_81
+def undef_fn_82() -> int:
+    return undefined_symbol_82
+def undef_fn_83() -> int:
+    return undefined_symbol_83
+def undef_fn_84() -> int:
+    return undefined_symbol_84
+def undef_fn_85() -> int:
+    return undefined_symbol_85
+def undef_fn_86() -> int:
+    return undefined_symbol_86
+def undef_fn_87() -> int:
+    return undefined_symbol_87
+def undef_fn_88() -> int:
+    return undefined_symbol_88
+def undef_fn_89() -> int:
+    return undefined_symbol_89
+def undef_fn_90() -> int:
+    return undefined_symbol_90
+def undef_fn_91() -> int:
+    return undefined_symbol_91
+def undef_fn_92() -> int:
+    return undefined_symbol_92
+def undef_fn_93() -> int:
+    return undefined_symbol_93
+def undef_fn_94() -> int:
+    return undefined_symbol_94
+def undef_fn_95() -> int:
+    return undefined_symbol_95
+def undef_fn_96() -> int:
+    return undefined_symbol_96
+def undef_fn_97() -> int:
+    return undefined_symbol_97
+def undef_fn_98() -> int:
+    return undefined_symbol_98
+def undef_fn_99() -> int:
+    return undefined_symbol_99
+def undef_fn_100() -> int:
+    return undefined_symbol_100
+def undef_fn_101() -> int:
+    return undefined_symbol_101
+def undef_fn_102() -> int:
+    return undefined_symbol_102
+def undef_fn_103() -> int:
+    return undefined_symbol_103
+def undef_fn_104() -> int:
+    return undefined_symbol_104
+def undef_fn_105() -> int:
+    return undefined_symbol_105
+def undef_fn_106() -> int:
+    return undefined_symbol_106
+def undef_fn_107() -> int:
+    return undefined_symbol_107
+def undef_fn_108() -> int:
+    return undefined_symbol_108
+def undef_fn_109() -> int:
+    return undefined_symbol_109
+def undef_fn_110() -> int:
+    return undefined_symbol_110
+def undef_fn_111() -> int:
+    return undefined_symbol_111
+def undef_fn_112() -> int:
+    return undefined_symbol_112
+def undef_fn_113() -> int:
+    return undefined_symbol_113
+def undef_fn_114() -> int:
+    return undefined_symbol_114
+def undef_fn_115() -> int:
+    return undefined_symbol_115
+def undef_fn_116() -> int:
+    return undefined_symbol_116
+def undef_fn_117() -> int:
+    return undefined_symbol_117
+def undef_fn_118() -> int:
+    return undefined_symbol_118
+def undef_fn_119() -> int:
+    return undefined_symbol_119
+def undef_fn_120() -> int:
+    return undefined_symbol_120
+def undef_fn_121() -> int:
+    return undefined_symbol_121
+def undef_fn_122() -> int:
+    return undefined_symbol_122
+def undef_fn_123() -> int:
+    return undefined_symbol_123
+def undef_fn_124() -> int:
+    return undefined_symbol_124
+def undef_fn_125() -> int:
+    return undefined_symbol_125
+def undef_fn_126() -> int:
+    return undefined_symbol_126
+def undef_fn_127() -> int:
+    return undefined_symbol_127
+def undef_fn_128() -> int:
+    return undefined_symbol_128
+def undef_fn_129() -> int:
+    return undefined_symbol_129
+def undef_fn_130() -> int:
+    return undefined_symbol_130
+def undef_fn_131() -> int:
+    return undefined_symbol_131
+def undef_fn_132() -> int:
+    return undefined_symbol_132
+def undef_fn_133() -> int:
+    return undefined_symbol_133
+def undef_fn_134() -> int:
+    return undefined_symbol_134
+def undef_fn_135() -> int:
+    return undefined_symbol_135
+def undef_fn_136() -> int:
+    return undefined_symbol_136
+def undef_fn_137() -> int:
+    return undefined_symbol_137
+def undef_fn_138() -> int:
+    return undefined_symbol_138
+def undef_fn_139() -> int:
+    return undefined_symbol_139
+def undef_fn_140() -> int:
+    return undefined_symbol_140
+def undef_fn_141() -> int:
+    return undefined_symbol_141
+def undef_fn_142() -> int:
+    return undefined_symbol_142
+def undef_fn_143() -> int:
+    return undefined_symbol_143
+def undef_fn_144() -> int:
+    return undefined_symbol_144
+def undef_fn_145() -> int:
+    return undefined_symbol_145
+def undef_fn_146() -> int:
+    return undefined_symbol_146
+def undef_fn_147() -> int:
+    return undefined_symbol_147
+def undef_fn_148() -> int:
+    return undefined_symbol_148
+def undef_fn_149() -> int:
+    return undefined_symbol_149
+def undef_fn_150() -> int:
+    return undefined_symbol_150
+def undef_fn_151() -> int:
+    return undefined_symbol_151
+def undef_fn_152() -> int:
+    return undefined_symbol_152
+def undef_fn_153() -> int:
+    return undefined_symbol_153
+def undef_fn_154() -> int:
+    return undefined_symbol_154
+def undef_fn_155() -> int:
+    return undefined_symbol_155
+def undef_fn_156() -> int:
+    return undefined_symbol_156
+def undef_fn_157() -> int:
+    return undefined_symbol_157
+def undef_fn_158() -> int:
+    return undefined_symbol_158
+def undef_fn_159() -> int:
+    return undefined_symbol_159
+def undef_fn_160() -> int:
+    return undefined_symbol_160
+def undef_fn_161() -> int:
+    return undefined_symbol_161
+def undef_fn_162() -> int:
+    return undefined_symbol_162
+def undef_fn_163() -> int:
+    return undefined_symbol_163
+def undef_fn_164() -> int:
+    return undefined_symbol_164
+def undef_fn_165() -> int:
+    return undefined_symbol_165
+def undef_fn_166() -> int:
+    return undefined_symbol_166
+def undef_fn_167() -> int:
+    return undefined_symbol_167
+def undef_fn_168() -> int:
+    return undefined_symbol_168
+def undef_fn_169() -> int:
+    return undefined_symbol_169
+def undef_fn_170() -> int:
+    return undefined_symbol_170
+def undef_fn_171() -> int:
+    return undefined_symbol_171
+def undef_fn_172() -> int:
+    return undefined_symbol_172
+def undef_fn_173() -> int:
+    return undefined_symbol_173
+def undef_fn_174() -> int:
+    return undefined_symbol_174
+def undef_fn_175() -> int:
+    return undefined_symbol_175
+def undef_fn_176() -> int:
+    return undefined_symbol_176
+def undef_fn_177() -> int:
+    return undefined_symbol_177
+def undef_fn_178() -> int:
+    return undefined_symbol_178
+def undef_fn_179() -> int:
+    return undefined_symbol_179
+def undef_fn_180() -> int:
+    return undefined_symbol_180
+def undef_fn_181() -> int:
+    return undefined_symbol_181
+def undef_fn_182() -> int:
+    return undefined_symbol_182
+def undef_fn_183() -> int:
+    return undefined_symbol_183
+def undef_fn_184() -> int:
+    return undefined_symbol_184
+def undef_fn_185() -> int:
+    return undefined_symbol_185
+def undef_fn_186() -> int:
+    return undefined_symbol_186
+def undef_fn_187() -> int:
+    return undefined_symbol_187
+def undef_fn_188() -> int:
+    return undefined_symbol_188
+def undef_fn_189() -> int:
+    return undefined_symbol_189
+def undef_fn_190() -> int:
+    return undefined_symbol_190
+def undef_fn_191() -> int:
+    return undefined_symbol_191
+def undef_fn_192() -> int:
+    return undefined_symbol_192
+def undef_fn_193() -> int:
+    return undefined_symbol_193
+def undef_fn_194() -> int:
+    return undefined_symbol_194
+def undef_fn_195() -> int:
+    return undefined_symbol_195
+def undef_fn_196() -> int:
+    return undefined_symbol_196
+def undef_fn_197() -> int:
+    return undefined_symbol_197
+def undef_fn_198() -> int:
+    return undefined_symbol_198
+def undef_fn_199() -> int:
+    return undefined_symbol_199
+def undef_fn_200() -> int:
+    return undefined_symbol_200
+def undef_fn_201() -> int:
+    return undefined_symbol_201
+def undef_fn_202() -> int:
+    return undefined_symbol_202
+def undef_fn_203() -> int:
+    return undefined_symbol_203
+def undef_fn_204() -> int:
+    return undefined_symbol_204
+def undef_fn_205() -> int:
+    return undefined_symbol_205
+def undef_fn_206() -> int:
+    return undefined_symbol_206
+def undef_fn_207() -> int:
+    return undefined_symbol_207
+def undef_fn_208() -> int:
+    return undefined_symbol_208
+def undef_fn_209() -> int:
+    return undefined_symbol_209
+def undef_fn_210() -> int:
+    return undefined_symbol_210
+def undef_fn_211() -> int:
+    return undefined_symbol_211
+def undef_fn_212() -> int:
+    return undefined_symbol_212
+def undef_fn_213() -> int:
+    return undefined_symbol_213
+def undef_fn_214() -> int:
+    return undefined_symbol_214
+def undef_fn_215() -> int:
+    return undefined_symbol_215
+def undef_fn_216() -> int:
+    return undefined_symbol_216
+def undef_fn_217() -> int:
+    return undefined_symbol_217
+def undef_fn_218() -> int:
+    return undefined_symbol_218
+def undef_fn_219() -> int:
+    return undefined_symbol_219
+def undef_fn_220() -> int:
+    return undefined_symbol_220
+def undef_fn_221() -> int:
+    return undefined_symbol_221
+def undef_fn_222() -> int:
+    return undefined_symbol_222
+def undef_fn_223() -> int:
+    return undefined_symbol_223
+def undef_fn_224() -> int:
+    return undefined_symbol_224
+def undef_fn_225() -> int:
+    return undefined_symbol_225
+def undef_fn_226() -> int:
+    return undefined_symbol_226
+def undef_fn_227() -> int:
+    return undefined_symbol_227
+def undef_fn_228() -> int:
+    return undefined_symbol_228
+def undef_fn_229() -> int:
+    return undefined_symbol_229
+def undef_fn_230() -> int:
+    return undefined_symbol_230
+def undef_fn_231() -> int:
+    return undefined_symbol_231
+def undef_fn_232() -> int:
+    return undefined_symbol_232
+def undef_fn_233() -> int:
+    return undefined_symbol_233
+def undef_fn_234() -> int:
+    return undefined_symbol_234
+def undef_fn_235() -> int:
+    return undefined_symbol_235
+def undef_fn_236() -> int:
+    return undefined_symbol_236
+def undef_fn_237() -> int:
+    return undefined_symbol_237
+def undef_fn_238() -> int:
+    return undefined_symbol_238
+def undef_fn_239() -> int:
+    return undefined_symbol_239
+def undef_fn_240() -> int:
+    return undefined_symbol_240
+def undef_fn_241() -> int:
+    return undefined_symbol_241
+def undef_fn_242() -> int:
+    return undefined_symbol_242
+def undef_fn_243() -> int:
+    return undefined_symbol_243
+def undef_fn_244() -> int:
+    return undefined_symbol_244
+def undef_fn_245() -> int:
+    return undefined_symbol_245
+def undef_fn_246() -> int:
+    return undefined_symbol_246
+def undef_fn_247() -> int:
+    return undefined_symbol_247
+def undef_fn_248() -> int:
+    return undefined_symbol_248
+def undef_fn_249() -> int:
+    return undefined_symbol_249
+def undef_fn_250() -> int:
+    return undefined_symbol_250
+def undef_fn_251() -> int:
+    return undefined_symbol_251
+def undef_fn_252() -> int:
+    return undefined_symbol_252
+def undef_fn_253() -> int:
+    return undefined_symbol_253
+def undef_fn_254() -> int:
+    return undefined_symbol_254
+def undef_fn_255() -> int:
+    return undefined_symbol_255
+def undef_fn_256() -> int:
+    return undefined_symbol_256
+def undef_fn_257() -> int:
+    return undefined_symbol_257
+def undef_fn_258() -> int:
+    return undefined_symbol_258
+def undef_fn_259() -> int:
+    return undefined_symbol_259
+def undef_fn_260() -> int:
+    return undefined_symbol_260
+def undef_fn_261() -> int:
+    return undefined_symbol_261
+def undef_fn_262() -> int:
+    return undefined_symbol_262
+def undef_fn_263() -> int:
+    return undefined_symbol_263
+def undef_fn_264() -> int:
+    return undefined_symbol_264
+def undef_fn_265() -> int:
+    return undefined_symbol_265
+def undef_fn_266() -> int:
+    return undefined_symbol_266
+def undef_fn_267() -> int:
+    return undefined_symbol_267
+def undef_fn_268() -> int:
+    return undefined_symbol_268
+def undef_fn_269() -> int:
+    return undefined_symbol_269
+def undef_fn_270() -> int:
+    return undefined_symbol_270
+def undef_fn_271() -> int:
+    return undefined_symbol_271
+def undef_fn_272() -> int:
+    return undefined_symbol_272
+def undef_fn_273() -> int:
+    return undefined_symbol_273
+def undef_fn_274() -> int:
+    return undefined_symbol_274
+def undef_fn_275() -> int:
+    return undefined_symbol_275
+def undef_fn_276() -> int:
+    return undefined_symbol_276
+def undef_fn_277() -> int:
+    return undefined_symbol_277
+def undef_fn_278() -> int:
+    return undefined_symbol_278
+def undef_fn_279() -> int:
+    return undefined_symbol_279
+def undef_fn_280() -> int:
+    return undefined_symbol_280
+def undef_fn_281() -> int:
+    return undefined_symbol_281
+def undef_fn_282() -> int:
+    return undefined_symbol_282
+def undef_fn_283() -> int:
+    return undefined_symbol_283
+def undef_fn_284() -> int:
+    return undefined_symbol_284
+def undef_fn_285() -> int:
+    return undefined_symbol_285
+def undef_fn_286() -> int:
+    return undefined_symbol_286
+def undef_fn_287() -> int:
+    return undefined_symbol_287
+def undef_fn_288() -> int:
+    return undefined_symbol_288
+def undef_fn_289() -> int:
+    return undefined_symbol_289
+def undef_fn_290() -> int:
+    return undefined_symbol_290
+def undef_fn_291() -> int:
+    return undefined_symbol_291
+def undef_fn_292() -> int:
+    return undefined_symbol_292
+def undef_fn_293() -> int:
+    return undefined_symbol_293
+def undef_fn_294() -> int:
+    return undefined_symbol_294
+def undef_fn_295() -> int:
+    return undefined_symbol_295
+def undef_fn_296() -> int:
+    return undefined_symbol_296
+def undef_fn_297() -> int:
+    return undefined_symbol_297
+def undef_fn_298() -> int:
+    return undefined_symbol_298
+def undef_fn_299() -> int:
+    return undefined_symbol_299
+def undef_fn_300() -> int:
+    return undefined_symbol_300
+def undef_fn_301() -> int:
+    return undefined_symbol_301
+def undef_fn_302() -> int:
+    return undefined_symbol_302
+def undef_fn_303() -> int:
+    return undefined_symbol_303
+def undef_fn_304() -> int:
+    return undefined_symbol_304
+def undef_fn_305() -> int:
+    return undefined_symbol_305
+def undef_fn_306() -> int:
+    return undefined_symbol_306
+def undef_fn_307() -> int:
+    return undefined_symbol_307
+def undef_fn_308() -> int:
+    return undefined_symbol_308
+def undef_fn_309() -> int:
+    return undefined_symbol_309
+def undef_fn_310() -> int:
+    return undefined_symbol_310
+def undef_fn_311() -> int:
+    return undefined_symbol_311
+def undef_fn_312() -> int:
+    return undefined_symbol_312
+def undef_fn_313() -> int:
+    return undefined_symbol_313
+def undef_fn_314() -> int:
+    return undefined_symbol_314
+def undef_fn_315() -> int:
+    return undefined_symbol_315
+def undef_fn_316() -> int:
+    return undefined_symbol_316
+def undef_fn_317() -> int:
+    return undefined_symbol_317
+def undef_fn_318() -> int:
+    return undefined_symbol_318
+def undef_fn_319() -> int:
+    return undefined_symbol_319
+def undef_fn_320() -> int:
+    return undefined_symbol_320
+def undef_fn_321() -> int:
+    return undefined_symbol_321
+def undef_fn_322() -> int:
+    return undefined_symbol_322
+def undef_fn_323() -> int:
+    return undefined_symbol_323
+def undef_fn_324() -> int:
+    return undefined_symbol_324
+def undef_fn_325() -> int:
+    return undefined_symbol_325
+def undef_fn_326() -> int:
+    return undefined_symbol_326
+def undef_fn_327() -> int:
+    return undefined_symbol_327
+def undef_fn_328() -> int:
+    return undefined_symbol_328
+def undef_fn_329() -> int:
+    return undefined_symbol_329
+def undef_fn_330() -> int:
+    return undefined_symbol_330
+def undef_fn_331() -> int:
+    return undefined_symbol_331
+def undef_fn_332() -> int:
+    return undefined_symbol_332
+def undef_fn_333() -> int:
+    return undefined_symbol_333
+def undef_fn_334() -> int:
+    return undefined_symbol_334
+def undef_fn_335() -> int:
+    return undefined_symbol_335
+def undef_fn_336() -> int:
+    return undefined_symbol_336
+def undef_fn_337() -> int:
+    return undefined_symbol_337
+def undef_fn_338() -> int:
+    return undefined_symbol_338
+def undef_fn_339() -> int:
+    return undefined_symbol_339
+def undef_fn_340() -> int:
+    return undefined_symbol_340
+def undef_fn_341() -> int:
+    return undefined_symbol_341
+def undef_fn_342() -> int:
+    return undefined_symbol_342
+def undef_fn_343() -> int:
+    return undefined_symbol_343
+def undef_fn_344() -> int:
+    return undefined_symbol_344
+def undef_fn_345() -> int:
+    return undefined_symbol_345
+def undef_fn_346() -> int:
+    return undefined_symbol_346
+def undef_fn_347() -> int:
+    return undefined_symbol_347
+def undef_fn_348() -> int:
+    return undefined_symbol_348
+def undef_fn_349() -> int:
+    return undefined_symbol_349
+def undef_fn_350() -> int:
+    return undefined_symbol_350
+def undef_fn_351() -> int:
+    return undefined_symbol_351
+def undef_fn_352() -> int:
+    return undefined_symbol_352
+def undef_fn_353() -> int:
+    return undefined_symbol_353
+def undef_fn_354() -> int:
+    return undefined_symbol_354
+def undef_fn_355() -> int:
+    return undefined_symbol_355
+def undef_fn_356() -> int:
+    return undefined_symbol_356
+def undef_fn_357() -> int:
+    return undefined_symbol_357
+def undef_fn_358() -> int:
+    return undefined_symbol_358
+def undef_fn_359() -> int:
+    return undefined_symbol_359
+def undef_fn_360() -> int:
+    return undefined_symbol_360
+def undef_fn_361() -> int:
+    return undefined_symbol_361
+def undef_fn_362() -> int:
+    return undefined_symbol_362
+def undef_fn_363() -> int:
+    return undefined_symbol_363
+def undef_fn_364() -> int:
+    return undefined_symbol_364
+def undef_fn_365() -> int:
+    return undefined_symbol_365
+def undef_fn_366() -> int:
+    return undefined_symbol_366
+def undef_fn_367() -> int:
+    return undefined_symbol_367
+def undef_fn_368() -> int:
+    return undefined_symbol_368
+def undef_fn_369() -> int:
+    return undefined_symbol_369
+def undef_fn_370() -> int:
+    return undefined_symbol_370
+def undef_fn_371() -> int:
+    return undefined_symbol_371
+def undef_fn_372() -> int:
+    return undefined_symbol_372
+def undef_fn_373() -> int:
+    return undefined_symbol_373
+def undef_fn_374() -> int:
+    return undefined_symbol_374
+def undef_fn_375() -> int:
+    return undefined_symbol_375
+def undef_fn_376() -> int:
+    return undefined_symbol_376
+def undef_fn_377() -> int:
+    return undefined_symbol_377
+def undef_fn_378() -> int:
+    return undefined_symbol_378
+def undef_fn_379() -> int:
+    return undefined_symbol_379
+def undef_fn_380() -> int:
+    return undefined_symbol_380
+def undef_fn_381() -> int:
+    return undefined_symbol_381
+def undef_fn_382() -> int:
+    return undefined_symbol_382
+def undef_fn_383() -> int:
+    return undefined_symbol_383
+def undef_fn_384() -> int:
+    return undefined_symbol_384
+def undef_fn_385() -> int:
+    return undefined_symbol_385
+def undef_fn_386() -> int:
+    return undefined_symbol_386
+def undef_fn_387() -> int:
+    return undefined_symbol_387
+def undef_fn_388() -> int:
+    return undefined_symbol_388
+def undef_fn_389() -> int:
+    return undefined_symbol_389
+def undef_fn_390() -> int:
+    return undefined_symbol_390
+def undef_fn_391() -> int:
+    return undefined_symbol_391
+def undef_fn_392() -> int:
+    return undefined_symbol_392
+def undef_fn_393() -> int:
+    return undefined_symbol_393
+def undef_fn_394() -> int:
+    return undefined_symbol_394
+def undef_fn_395() -> int:
+    return undefined_symbol_395
+def undef_fn_396() -> int:
+    return undefined_symbol_396
+def undef_fn_397() -> int:
+    return undefined_symbol_397
+def undef_fn_398() -> int:
+    return undefined_symbol_398
+def undef_fn_399() -> int:
+    return undefined_symbol_399
+def undef_fn_400() -> int:
+    return undefined_symbol_400
+def undef_fn_401() -> int:
+    return undefined_symbol_401
+def undef_fn_402() -> int:
+    return undefined_symbol_402
+def undef_fn_403() -> int:
+    return undefined_symbol_403
+def undef_fn_404() -> int:
+    return undefined_symbol_404
+def undef_fn_405() -> int:
+    return undefined_symbol_405
+def undef_fn_406() -> int:
+    return undefined_symbol_406
+def undef_fn_407() -> int:
+    return undefined_symbol_407
+def undef_fn_408() -> int:
+    return undefined_symbol_408
+def undef_fn_409() -> int:
+    return undefined_symbol_409
+def undef_fn_410() -> int:
+    return undefined_symbol_410
+def undef_fn_411() -> int:
+    return undefined_symbol_411
+def undef_fn_412() -> int:
+    return undefined_symbol_412
+def undef_fn_413() -> int:
+    return undefined_symbol_413
+def undef_fn_414() -> int:
+    return undefined_symbol_414
+def undef_fn_415() -> int:
+    return undefined_symbol_415
+def undef_fn_416() -> int:
+    return undefined_symbol_416
+def undef_fn_417() -> int:
+    return undefined_symbol_417
+def undef_fn_418() -> int:
+    return undefined_symbol_418
+def undef_fn_419() -> int:
+    return undefined_symbol_419
+def undef_fn_420() -> int:
+    return undefined_symbol_420
+def undef_fn_421() -> int:
+    return undefined_symbol_421
+def undef_fn_422() -> int:
+    return undefined_symbol_422
+def undef_fn_423() -> int:
+    return undefined_symbol_423
+def undef_fn_424() -> int:
+    return undefined_symbol_424
+def undef_fn_425() -> int:
+    return undefined_symbol_425
+def undef_fn_426() -> int:
+    return undefined_symbol_426
+def undef_fn_427() -> int:
+    return undefined_symbol_427
+def undef_fn_428() -> int:
+    return undefined_symbol_428
+def undef_fn_429() -> int:
+    return undefined_symbol_429
+def undef_fn_430() -> int:
+    return undefined_symbol_430
+def undef_fn_431() -> int:
+    return undefined_symbol_431
+def undef_fn_432() -> int:
+    return undefined_symbol_432
+def undef_fn_433() -> int:
+    return undefined_symbol_433
+def undef_fn_434() -> int:
+    return undefined_symbol_434
+def undef_fn_435() -> int:
+    return undefined_symbol_435
+def undef_fn_436() -> int:
+    return undefined_symbol_436
+def undef_fn_437() -> int:
+    return undefined_symbol_437
+def undef_fn_438() -> int:
+    return undefined_symbol_438
+def undef_fn_439() -> int:
+    return undefined_symbol_439
+def undef_fn_440() -> int:
+    return undefined_symbol_440
+def undef_fn_441() -> int:
+    return undefined_symbol_441
+def undef_fn_442() -> int:
+    return undefined_symbol_442
+def undef_fn_443() -> int:
+    return undefined_symbol_443
+def undef_fn_444() -> int:
+    return undefined_symbol_444
+def undef_fn_445() -> int:
+    return undefined_symbol_445
+def undef_fn_446() -> int:
+    return undefined_symbol_446
+def undef_fn_447() -> int:
+    return undefined_symbol_447
+def undef_fn_448() -> int:
+    return undefined_symbol_448
+def undef_fn_449() -> int:
+    return undefined_symbol_449
+def undef_fn_450() -> int:
+    return undefined_symbol_450
+def undef_fn_451() -> int:
+    return undefined_symbol_451
+def undef_fn_452() -> int:
+    return undefined_symbol_452
+def undef_fn_453() -> int:
+    return undefined_symbol_453
+def undef_fn_454() -> int:
+    return undefined_symbol_454
+def undef_fn_455() -> int:
+    return undefined_symbol_455
+def undef_fn_456() -> int:
+    return undefined_symbol_456
+def undef_fn_457() -> int:
+    return undefined_symbol_457
+def undef_fn_458() -> int:
+    return undefined_symbol_458
+def undef_fn_459() -> int:
+    return undefined_symbol_459
+def undef_fn_460() -> int:
+    return undefined_symbol_460
+def undef_fn_461() -> int:
+    return undefined_symbol_461
+def undef_fn_462() -> int:
+    return undefined_symbol_462
+def undef_fn_463() -> int:
+    return undefined_symbol_463
+def undef_fn_464() -> int:
+    return undefined_symbol_464
+def undef_fn_465() -> int:
+    return undefined_symbol_465
+def undef_fn_466() -> int:
+    return undefined_symbol_466
+def undef_fn_467() -> int:
+    return undefined_symbol_467
+def undef_fn_468() -> int:
+    return undefined_symbol_468
+def undef_fn_469() -> int:
+    return undefined_symbol_469
+def undef_fn_470() -> int:
+    return undefined_symbol_470
+def undef_fn_471() -> int:
+    return undefined_symbol_471
+def undef_fn_472() -> int:
+    return undefined_symbol_472
+def undef_fn_473() -> int:
+    return undefined_symbol_473
+def undef_fn_474() -> int:
+    return undefined_symbol_474
+def undef_fn_475() -> int:
+    return undefined_symbol_475
+def undef_fn_476() -> int:
+    return undefined_symbol_476
+def undef_fn_477() -> int:
+    return undefined_symbol_477
+def undef_fn_478() -> int:
+    return undefined_symbol_478
+def undef_fn_479() -> int:
+    return undefined_symbol_479
+def undef_fn_480() -> int:
+    return undefined_symbol_480
+def undef_fn_481() -> int:
+    return undefined_symbol_481
+def undef_fn_482() -> int:
+    return undefined_symbol_482
+def undef_fn_483() -> int:
+    return undefined_symbol_483
+def undef_fn_484() -> int:
+    return undefined_symbol_484
+def undef_fn_485() -> int:
+    return undefined_symbol_485
+def undef_fn_486() -> int:
+    return undefined_symbol_486
+def undef_fn_487() -> int:
+    return undefined_symbol_487
+def undef_fn_488() -> int:
+    return undefined_symbol_488
+def undef_fn_489() -> int:
+    return undefined_symbol_489
+def undef_fn_490() -> int:
+    return undefined_symbol_490
+def undef_fn_491() -> int:
+    return undefined_symbol_491
+def undef_fn_492() -> int:
+    return undefined_symbol_492
+def undef_fn_493() -> int:
+    return undefined_symbol_493
+def undef_fn_494() -> int:
+    return undefined_symbol_494
+def undef_fn_495() -> int:
+    return undefined_symbol_495
+def undef_fn_496() -> int:
+    return undefined_symbol_496
+def undef_fn_497() -> int:
+    return undefined_symbol_497
+def undef_fn_498() -> int:
+    return undefined_symbol_498
+def undef_fn_499() -> int:
+    return undefined_symbol_499
+def undef_fn_500() -> int:
+    return undefined_symbol_500
+def undef_fn_501() -> int:
+    return undefined_symbol_501
+def undef_fn_502() -> int:
+    return undefined_symbol_502
+def undef_fn_503() -> int:
+    return undefined_symbol_503
+def undef_fn_504() -> int:
+    return undefined_symbol_504
+def undef_fn_505() -> int:
+    return undefined_symbol_505
+def undef_fn_506() -> int:
+    return undefined_symbol_506
+def undef_fn_507() -> int:
+    return undefined_symbol_507
+def undef_fn_508() -> int:
+    return undefined_symbol_508
+def undef_fn_509() -> int:
+    return undefined_symbol_509
+def undef_fn_510() -> int:
+    return undefined_symbol_510
+def undef_fn_511() -> int:
+    return undefined_symbol_511
+def undef_fn_512() -> int:
+    return undefined_symbol_512
+def undef_fn_513() -> int:
+    return undefined_symbol_513
+def undef_fn_514() -> int:
+    return undefined_symbol_514
+def undef_fn_515() -> int:
+    return undefined_symbol_515
+def undef_fn_516() -> int:
+    return undefined_symbol_516
+def undef_fn_517() -> int:
+    return undefined_symbol_517
+def undef_fn_518() -> int:
+    return undefined_symbol_518
+def undef_fn_519() -> int:
+    return undefined_symbol_519
+def undef_fn_520() -> int:
+    return undefined_symbol_520
+def undef_fn_521() -> int:
+    return undefined_symbol_521
+def undef_fn_522() -> int:
+    return undefined_symbol_522
+def undef_fn_523() -> int:
+    return undefined_symbol_523
+def undef_fn_524() -> int:
+    return undefined_symbol_524
+def undef_fn_525() -> int:
+    return undefined_symbol_525
+def undef_fn_526() -> int:
+    return undefined_symbol_526
+def undef_fn_527() -> int:
+    return undefined_symbol_527
+def undef_fn_528() -> int:
+    return undefined_symbol_528
+def undef_fn_529() -> int:
+    return undefined_symbol_529
+def undef_fn_530() -> int:
+    return undefined_symbol_530
+def undef_fn_531() -> int:
+    return undefined_symbol_531
+def undef_fn_532() -> int:
+    return undefined_symbol_532
+def undef_fn_533() -> int:
+    return undefined_symbol_533
+def undef_fn_534() -> int:
+    return undefined_symbol_534
+def undef_fn_535() -> int:
+    return undefined_symbol_535
+def undef_fn_536() -> int:
+    return undefined_symbol_536
+def undef_fn_537() -> int:
+    return undefined_symbol_537
+def undef_fn_538() -> int:
+    return undefined_symbol_538
+def undef_fn_539() -> int:
+    return undefined_symbol_539
+def undef_fn_540() -> int:
+    return undefined_symbol_540
+def undef_fn_541() -> int:
+    return undefined_symbol_541
+def undef_fn_542() -> int:
+    return undefined_symbol_542
+def undef_fn_543() -> int:
+    return undefined_symbol_543
+def undef_fn_544() -> int:
+    return undefined_symbol_544
+def undef_fn_545() -> int:
+    return undefined_symbol_545
+def undef_fn_546() -> int:
+    return undefined_symbol_546
+def undef_fn_547() -> int:
+    return undefined_symbol_547
+def undef_fn_548() -> int:
+    return undefined_symbol_548
+def undef_fn_549() -> int:
+    return undefined_symbol_549
+def undef_fn_550() -> int:
+    return undefined_symbol_550
+def undef_fn_551() -> int:
+    return undefined_symbol_551
+def undef_fn_552() -> int:
+    return undefined_symbol_552
+def undef_fn_553() -> int:
+    return undefined_symbol_553
+def undef_fn_554() -> int:
+    return undefined_symbol_554
+def undef_fn_555() -> int:
+    return undefined_symbol_555
+def undef_fn_556() -> int:
+    return undefined_symbol_556
+def undef_fn_557() -> int:
+    return undefined_symbol_557
+def undef_fn_558() -> int:
+    return undefined_symbol_558
+def undef_fn_559() -> int:
+    return undefined_symbol_559
+def undef_fn_560() -> int:
+    return undefined_symbol_560
+def undef_fn_561() -> int:
+    return undefined_symbol_561
+def undef_fn_562() -> int:
+    return undefined_symbol_562
+def undef_fn_563() -> int:
+    return undefined_symbol_563
+def undef_fn_564() -> int:
+    return undefined_symbol_564
+def undef_fn_565() -> int:
+    return undefined_symbol_565
+def undef_fn_566() -> int:
+    return undefined_symbol_566
+def undef_fn_567() -> int:
+    return undefined_symbol_567
+def undef_fn_568() -> int:
+    return undefined_symbol_568
+def undef_fn_569() -> int:
+    return undefined_symbol_569
+def undef_fn_570() -> int:
+    return undefined_symbol_570
+def undef_fn_571() -> int:
+    return undefined_symbol_571
+def undef_fn_572() -> int:
+    return undefined_symbol_572
+def undef_fn_573() -> int:
+    return undefined_symbol_573
+def undef_fn_574() -> int:
+    return undefined_symbol_574
+def undef_fn_575() -> int:
+    return undefined_symbol_575
+def undef_fn_576() -> int:
+    return undefined_symbol_576
+def undef_fn_577() -> int:
+    return undefined_symbol_577
+def undef_fn_578() -> int:
+    return undefined_symbol_578
+def undef_fn_579() -> int:
+    return undefined_symbol_579
+def undef_fn_580() -> int:
+    return undefined_symbol_580
+def undef_fn_581() -> int:
+    return undefined_symbol_581
+def undef_fn_582() -> int:
+    return undefined_symbol_582
+def undef_fn_583() -> int:
+    return undefined_symbol_583
+def undef_fn_584() -> int:
+    return undefined_symbol_584
+def undef_fn_585() -> int:
+    return undefined_symbol_585
+def undef_fn_586() -> int:
+    return undefined_symbol_586
+def undef_fn_587() -> int:
+    return undefined_symbol_587
+def undef_fn_588() -> int:
+    return undefined_symbol_588
+def undef_fn_589() -> int:
+    return undefined_symbol_589
+def undef_fn_590() -> int:
+    return undefined_symbol_590
+def undef_fn_591() -> int:
+    return undefined_symbol_591
+def undef_fn_592() -> int:
+    return undefined_symbol_592
+def undef_fn_593() -> int:
+    return undefined_symbol_593
+def undef_fn_594() -> int:
+    return undefined_symbol_594
+def undef_fn_595() -> int:
+    return undefined_symbol_595
+def undef_fn_596() -> int:
+    return undefined_symbol_596
+def undef_fn_597() -> int:
+    return undefined_symbol_597
+def undef_fn_598() -> int:
+    return undefined_symbol_598
+def undef_fn_599() -> int:
+    return undefined_symbol_599
+def undef_fn_600() -> int:
+    return undefined_symbol_600
+def undef_fn_601() -> int:
+    return undefined_symbol_601
+def undef_fn_602() -> int:
+    return undefined_symbol_602
+def undef_fn_603() -> int:
+    return undefined_symbol_603
+def undef_fn_604() -> int:
+    return undefined_symbol_604
+def undef_fn_605() -> int:
+    return undefined_symbol_605
+def undef_fn_606() -> int:
+    return undefined_symbol_606
+def undef_fn_607() -> int:
+    return undefined_symbol_607
+def undef_fn_608() -> int:
+    return undefined_symbol_608
+def undef_fn_609() -> int:
+    return undefined_symbol_609
+def undef_fn_610() -> int:
+    return undefined_symbol_610
+def undef_fn_611() -> int:
+    return undefined_symbol_611
+def undef_fn_612() -> int:
+    return undefined_symbol_612
+def undef_fn_613() -> int:
+    return undefined_symbol_613
+def undef_fn_614() -> int:
+    return undefined_symbol_614
+def undef_fn_615() -> int:
+    return undefined_symbol_615
+def undef_fn_616() -> int:
+    return undefined_symbol_616
+def undef_fn_617() -> int:
+    return undefined_symbol_617
+def undef_fn_618() -> int:
+    return undefined_symbol_618
+def undef_fn_619() -> int:
+    return undefined_symbol_619
+def undef_fn_620() -> int:
+    return undefined_symbol_620
+def undef_fn_621() -> int:
+    return undefined_symbol_621
+def undef_fn_622() -> int:
+    return undefined_symbol_622
+def undef_fn_623() -> int:
+    return undefined_symbol_623
+def undef_fn_624() -> int:
+    return undefined_symbol_624
+def undef_fn_625() -> int:
+    return undefined_symbol_625
+def undef_fn_626() -> int:
+    return undefined_symbol_626
+def undef_fn_627() -> int:
+    return undefined_symbol_627
+def undef_fn_628() -> int:
+    return undefined_symbol_628
+def undef_fn_629() -> int:
+    return undefined_symbol_629
+def undef_fn_630() -> int:
+    return undefined_symbol_630
+def undef_fn_631() -> int:
+    return undefined_symbol_631
+def undef_fn_632() -> int:
+    return undefined_symbol_632
+def undef_fn_633() -> int:
+    return undefined_symbol_633
+def undef_fn_634() -> int:
+    return undefined_symbol_634
+def undef_fn_635() -> int:
+    return undefined_symbol_635
+def undef_fn_636() -> int:
+    return undefined_symbol_636
+def undef_fn_637() -> int:
+    return undefined_symbol_637
+def undef_fn_638() -> int:
+    return undefined_symbol_638
+def undef_fn_639() -> int:
+    return undefined_symbol_639
+def undef_fn_640() -> int:
+    return undefined_symbol_640
+def undef_fn_641() -> int:
+    return undefined_symbol_641
+def undef_fn_642() -> int:
+    return undefined_symbol_642
+def undef_fn_643() -> int:
+    return undefined_symbol_643
+def undef_fn_644() -> int:
+    return undefined_symbol_644
+def undef_fn_645() -> int:
+    return undefined_symbol_645
+def undef_fn_646() -> int:
+    return undefined_symbol_646
+def undef_fn_647() -> int:
+    return undefined_symbol_647
+def undef_fn_648() -> int:
+    return undefined_symbol_648
+def undef_fn_649() -> int:
+    return undefined_symbol_649
+def undef_fn_650() -> int:
+    return undefined_symbol_650
+def undef_fn_651() -> int:
+    return undefined_symbol_651
+def undef_fn_652() -> int:
+    return undefined_symbol_652
+def undef_fn_653() -> int:
+    return undefined_symbol_653
+def undef_fn_654() -> int:
+    return undefined_symbol_654
+def undef_fn_655() -> int:
+    return undefined_symbol_655
+def undef_fn_656() -> int:
+    return undefined_symbol_656
+def undef_fn_657() -> int:
+    return undefined_symbol_657
+def undef_fn_658() -> int:
+    return undefined_symbol_658
+def undef_fn_659() -> int:
+    return undefined_symbol_659
+def undef_fn_660() -> int:
+    return undefined_symbol_660
+def undef_fn_661() -> int:
+    return undefined_symbol_661
+def undef_fn_662() -> int:
+    return undefined_symbol_662
+def undef_fn_663() -> int:
+    return undefined_symbol_663
+def undef_fn_664() -> int:
+    return undefined_symbol_664
+def undef_fn_665() -> int:
+    return undefined_symbol_665
+def undef_fn_666() -> int:
+    return undefined_symbol_666
+def undef_fn_667() -> int:
+    return undefined_symbol_667
+def undef_fn_668() -> int:
+    return undefined_symbol_668
+def undef_fn_669() -> int:
+    return undefined_symbol_669
+def undef_fn_670() -> int:
+    return undefined_symbol_670
+def undef_fn_671() -> int:
+    return undefined_symbol_671
+def undef_fn_672() -> int:
+    return undefined_symbol_672
+def undef_fn_673() -> int:
+    return undefined_symbol_673
+def undef_fn_674() -> int:
+    return undefined_symbol_674
+def undef_fn_675() -> int:
+    return undefined_symbol_675
+def undef_fn_676() -> int:
+    return undefined_symbol_676
+def undef_fn_677() -> int:
+    return undefined_symbol_677
+def undef_fn_678() -> int:
+    return undefined_symbol_678
+def undef_fn_679() -> int:
+    return undefined_symbol_679
+def undef_fn_680() -> int:
+    return undefined_symbol_680
+def undef_fn_681() -> int:
+    return undefined_symbol_681
+def undef_fn_682() -> int:
+    return undefined_symbol_682
+def undef_fn_683() -> int:
+    return undefined_symbol_683
+def undef_fn_684() -> int:
+    return undefined_symbol_684
+def undef_fn_685() -> int:
+    return undefined_symbol_685
+def undef_fn_686() -> int:
+    return undefined_symbol_686
+def undef_fn_687() -> int:
+    return undefined_symbol_687
+def undef_fn_688() -> int:
+    return undefined_symbol_688
+def undef_fn_689() -> int:
+    return undefined_symbol_689
+def undef_fn_690() -> int:
+    return undefined_symbol_690
+def undef_fn_691() -> int:
+    return undefined_symbol_691
+def undef_fn_692() -> int:
+    return undefined_symbol_692
+def undef_fn_693() -> int:
+    return undefined_symbol_693
+def undef_fn_694() -> int:
+    return undefined_symbol_694
+def undef_fn_695() -> int:
+    return undefined_symbol_695
+def undef_fn_696() -> int:
+    return undefined_symbol_696
+def undef_fn_697() -> int:
+    return undefined_symbol_697
+def undef_fn_698() -> int:
+    return undefined_symbol_698
+def undef_fn_699() -> int:
+    return undefined_symbol_699
+def undef_fn_700() -> int:
+    return undefined_symbol_700
+def undef_fn_701() -> int:
+    return undefined_symbol_701
+def undef_fn_702() -> int:
+    return undefined_symbol_702
+def undef_fn_703() -> int:
+    return undefined_symbol_703
+def undef_fn_704() -> int:
+    return undefined_symbol_704
+def undef_fn_705() -> int:
+    return undefined_symbol_705
+def undef_fn_706() -> int:
+    return undefined_symbol_706
+def undef_fn_707() -> int:
+    return undefined_symbol_707
+def undef_fn_708() -> int:
+    return undefined_symbol_708
+def undef_fn_709() -> int:
+    return undefined_symbol_709
+def undef_fn_710() -> int:
+    return undefined_symbol_710
+def undef_fn_711() -> int:
+    return undefined_symbol_711
+def undef_fn_712() -> int:
+    return undefined_symbol_712
+def undef_fn_713() -> int:
+    return undefined_symbol_713
+def undef_fn_714() -> int:
+    return undefined_symbol_714
+def undef_fn_715() -> int:
+    return undefined_symbol_715
+def undef_fn_716() -> int:
+    return undefined_symbol_716
+def undef_fn_717() -> int:
+    return undefined_symbol_717
+def undef_fn_718() -> int:
+    return undefined_symbol_718
+def undef_fn_719() -> int:
+    return undefined_symbol_719
+def undef_fn_720() -> int:
+    return undefined_symbol_720
+def undef_fn_721() -> int:
+    return undefined_symbol_721
+def undef_fn_722() -> int:
+    return undefined_symbol_722
+def undef_fn_723() -> int:
+    return undefined_symbol_723
+def undef_fn_724() -> int:
+    return undefined_symbol_724
+def undef_fn_725() -> int:
+    return undefined_symbol_725
+def undef_fn_726() -> int:
+    return undefined_symbol_726
+def undef_fn_727() -> int:
+    return undefined_symbol_727
+def undef_fn_728() -> int:
+    return undefined_symbol_728
+def undef_fn_729() -> int:
+    return undefined_symbol_729
+def undef_fn_730() -> int:
+    return undefined_symbol_730
+def undef_fn_731() -> int:
+    return undefined_symbol_731
+def undef_fn_732() -> int:
+    return undefined_symbol_732
+def undef_fn_733() -> int:
+    return undefined_symbol_733
+def undef_fn_734() -> int:
+    return undefined_symbol_734
+def undef_fn_735() -> int:
+    return undefined_symbol_735
+def undef_fn_736() -> int:
+    return undefined_symbol_736
+def undef_fn_737() -> int:
+    return undefined_symbol_737
+def undef_fn_738() -> int:
+    return undefined_symbol_738
+def undef_fn_739() -> int:
+    return undefined_symbol_739
+def undef_fn_740() -> int:
+    return undefined_symbol_740
+def undef_fn_741() -> int:
+    return undefined_symbol_741
+def undef_fn_742() -> int:
+    return undefined_symbol_742
+def undef_fn_743() -> int:
+    return undefined_symbol_743
+def undef_fn_744() -> int:
+    return undefined_symbol_744
+def undef_fn_745() -> int:
+    return undefined_symbol_745
+def undef_fn_746() -> int:
+    return undefined_symbol_746
+def undef_fn_747() -> int:
+    return undefined_symbol_747
+def undef_fn_748() -> int:
+    return undefined_symbol_748
+def undef_fn_749() -> int:
+    return undefined_symbol_749
+def undef_fn_750() -> int:
+    return undefined_symbol_750
+def undef_fn_751() -> int:
+    return undefined_symbol_751
+def undef_fn_752() -> int:
+    return undefined_symbol_752
+def undef_fn_753() -> int:
+    return undefined_symbol_753
+def undef_fn_754() -> int:
+    return undefined_symbol_754
+def undef_fn_755() -> int:
+    return undefined_symbol_755
+def undef_fn_756() -> int:
+    return undefined_symbol_756
+def undef_fn_757() -> int:
+    return undefined_symbol_757
+def undef_fn_758() -> int:
+    return undefined_symbol_758
+def undef_fn_759() -> int:
+    return undefined_symbol_759
+def undef_fn_760() -> int:
+    return undefined_symbol_760
+def undef_fn_761() -> int:
+    return undefined_symbol_761
+def undef_fn_762() -> int:
+    return undefined_symbol_762
+def undef_fn_763() -> int:
+    return undefined_symbol_763
+def undef_fn_764() -> int:
+    return undefined_symbol_764
+def undef_fn_765() -> int:
+    return undefined_symbol_765
+def undef_fn_766() -> int:
+    return undefined_symbol_766
+def undef_fn_767() -> int:
+    return undefined_symbol_767
+def undef_fn_768() -> int:
+    return undefined_symbol_768
+def undef_fn_769() -> int:
+    return undefined_symbol_769
+def undef_fn_770() -> int:
+    return undefined_symbol_770
+def undef_fn_771() -> int:
+    return undefined_symbol_771
+def undef_fn_772() -> int:
+    return undefined_symbol_772
+def undef_fn_773() -> int:
+    return undefined_symbol_773
+def undef_fn_774() -> int:
+    return undefined_symbol_774
+def undef_fn_775() -> int:
+    return undefined_symbol_775
+def undef_fn_776() -> int:
+    return undefined_symbol_776
+def undef_fn_777() -> int:
+    return undefined_symbol_777
+def undef_fn_778() -> int:
+    return undefined_symbol_778
+def undef_fn_779() -> int:
+    return undefined_symbol_779
+def undef_fn_780() -> int:
+    return undefined_symbol_780
+def undef_fn_781() -> int:
+    return undefined_symbol_781
+def undef_fn_782() -> int:
+    return undefined_symbol_782
+def undef_fn_783() -> int:
+    return undefined_symbol_783
+def undef_fn_784() -> int:
+    return undefined_symbol_784
+def undef_fn_785() -> int:
+    return undefined_symbol_785
+def undef_fn_786() -> int:
+    return undefined_symbol_786
+def undef_fn_787() -> int:
+    return undefined_symbol_787
+def undef_fn_788() -> int:
+    return undefined_symbol_788
+def undef_fn_789() -> int:
+    return undefined_symbol_789
+def undef_fn_790() -> int:
+    return undefined_symbol_790
+def undef_fn_791() -> int:
+    return undefined_symbol_791
+def undef_fn_792() -> int:
+    return undefined_symbol_792
+def undef_fn_793() -> int:
+    return undefined_symbol_793
+def undef_fn_794() -> int:
+    return undefined_symbol_794
+def undef_fn_795() -> int:
+    return undefined_symbol_795
+def undef_fn_796() -> int:
+    return undefined_symbol_796
+def undef_fn_797() -> int:
+    return undefined_symbol_797
+def undef_fn_798() -> int:
+    return undefined_symbol_798
+def undef_fn_799() -> int:
+    return undefined_symbol_799
+def undef_fn_800() -> int:
+    return undefined_symbol_800
+def undef_fn_801() -> int:
+    return undefined_symbol_801
+def undef_fn_802() -> int:
+    return undefined_symbol_802
+def undef_fn_803() -> int:
+    return undefined_symbol_803
+def undef_fn_804() -> int:
+    return undefined_symbol_804
+def undef_fn_805() -> int:
+    return undefined_symbol_805
+def undef_fn_806() -> int:
+    return undefined_symbol_806
+def undef_fn_807() -> int:
+    return undefined_symbol_807
+def undef_fn_808() -> int:
+    return undefined_symbol_808
+def undef_fn_809() -> int:
+    return undefined_symbol_809
+def undef_fn_810() -> int:
+    return undefined_symbol_810
+def undef_fn_811() -> int:
+    return undefined_symbol_811
+def undef_fn_812() -> int:
+    return undefined_symbol_812
+def undef_fn_813() -> int:
+    return undefined_symbol_813
+def undef_fn_814() -> int:
+    return undefined_symbol_814
+def undef_fn_815() -> int:
+    return undefined_symbol_815
+def undef_fn_816() -> int:
+    return undefined_symbol_816
+def undef_fn_817() -> int:
+    return undefined_symbol_817
+def undef_fn_818() -> int:
+    return undefined_symbol_818
+def undef_fn_819() -> int:
+    return undefined_symbol_819
+def undef_fn_820() -> int:
+    return undefined_symbol_820
+def undef_fn_821() -> int:
+    return undefined_symbol_821
+def undef_fn_822() -> int:
+    return undefined_symbol_822
+def undef_fn_823() -> int:
+    return undefined_symbol_823
+def undef_fn_824() -> int:
+    return undefined_symbol_824
+def undef_fn_825() -> int:
+    return undefined_symbol_825
+def undef_fn_826() -> int:
+    return undefined_symbol_826
+def undef_fn_827() -> int:
+    return undefined_symbol_827
+def undef_fn_828() -> int:
+    return undefined_symbol_828
+def undef_fn_829() -> int:
+    return undefined_symbol_829
+def undef_fn_830() -> int:
+    return undefined_symbol_830
+def undef_fn_831() -> int:
+    return undefined_symbol_831
+def undef_fn_832() -> int:
+    return undefined_symbol_832
+def undef_fn_833() -> int:
+    return undefined_symbol_833
+def undef_fn_834() -> int:
+    return undefined_symbol_834
+def undef_fn_835() -> int:
+    return undefined_symbol_835
+def undef_fn_836() -> int:
+    return undefined_symbol_836
+def undef_fn_837() -> int:
+    return undefined_symbol_837
+def undef_fn_838() -> int:
+    return undefined_symbol_838
+def undef_fn_839() -> int:
+    return undefined_symbol_839
+def undef_fn_840() -> int:
+    return undefined_symbol_840
+def undef_fn_841() -> int:
+    return undefined_symbol_841
+def undef_fn_842() -> int:
+    return undefined_symbol_842
+def undef_fn_843() -> int:
+    return undefined_symbol_843
+def undef_fn_844() -> int:
+    return undefined_symbol_844
+def undef_fn_845() -> int:
+    return undefined_symbol_845
+def undef_fn_846() -> int:
+    return undefined_symbol_846
+def undef_fn_847() -> int:
+    return undefined_symbol_847
+def undef_fn_848() -> int:
+    return undefined_symbol_848
+def undef_fn_849() -> int:
+    return undefined_symbol_849
+def undef_fn_850() -> int:
+    return undefined_symbol_850
+def undef_fn_851() -> int:
+    return undefined_symbol_851
+def undef_fn_852() -> int:
+    return undefined_symbol_852
+def undef_fn_853() -> int:
+    return undefined_symbol_853
+def undef_fn_854() -> int:
+    return undefined_symbol_854
+def undef_fn_855() -> int:
+    return undefined_symbol_855
+def undef_fn_856() -> int:
+    return undefined_symbol_856
+def undef_fn_857() -> int:
+    return undefined_symbol_857
+def undef_fn_858() -> int:
+    return undefined_symbol_858
+def undef_fn_859() -> int:
+    return undefined_symbol_859
+def undef_fn_860() -> int:
+    return undefined_symbol_860
+def undef_fn_861() -> int:
+    return undefined_symbol_861
+def undef_fn_862() -> int:
+    return undefined_symbol_862
+def undef_fn_863() -> int:
+    return undefined_symbol_863
+def undef_fn_864() -> int:
+    return undefined_symbol_864
+def undef_fn_865() -> int:
+    return undefined_symbol_865
+def undef_fn_866() -> int:
+    return undefined_symbol_866
+def undef_fn_867() -> int:
+    return undefined_symbol_867
+def undef_fn_868() -> int:
+    return undefined_symbol_868
+def undef_fn_869() -> int:
+    return undefined_symbol_869
+def undef_fn_870() -> int:
+    return undefined_symbol_870
+def undef_fn_871() -> int:
+    return undefined_symbol_871
+def undef_fn_872() -> int:
+    return undefined_symbol_872
+def undef_fn_873() -> int:
+    return undefined_symbol_873
+def undef_fn_874() -> int:
+    return undefined_symbol_874
+def undef_fn_875() -> int:
+    return undefined_symbol_875
+def undef_fn_876() -> int:
+    return undefined_symbol_876
+def undef_fn_877() -> int:
+    return undefined_symbol_877
+def undef_fn_878() -> int:
+    return undefined_symbol_878
+def undef_fn_879() -> int:
+    return undefined_symbol_879
+def undef_fn_880() -> int:
+    return undefined_symbol_880
+def undef_fn_881() -> int:
+    return undefined_symbol_881
+def undef_fn_882() -> int:
+    return undefined_symbol_882
+def undef_fn_883() -> int:
+    return undefined_symbol_883
+def undef_fn_884() -> int:
+    return undefined_symbol_884
+def undef_fn_885() -> int:
+    return undefined_symbol_885
+def undef_fn_886() -> int:
+    return undefined_symbol_886
+def undef_fn_887() -> int:
+    return undefined_symbol_887
+def undef_fn_888() -> int:
+    return undefined_symbol_888
+def undef_fn_889() -> int:
+    return undefined_symbol_889
+def undef_fn_890() -> int:
+    return undefined_symbol_890
+def undef_fn_891() -> int:
+    return undefined_symbol_891
+def undef_fn_892() -> int:
+    return undefined_symbol_892
+def undef_fn_893() -> int:
+    return undefined_symbol_893
+def undef_fn_894() -> int:
+    return undefined_symbol_894
+def undef_fn_895() -> int:
+    return undefined_symbol_895
+def undef_fn_896() -> int:
+    return undefined_symbol_896
+def undef_fn_897() -> int:
+    return undefined_symbol_897
+def undef_fn_898() -> int:
+    return undefined_symbol_898
+def undef_fn_899() -> int:
+    return undefined_symbol_899
+def undef_fn_900() -> int:
+    return undefined_symbol_900
+def undef_fn_901() -> int:
+    return undefined_symbol_901
+def undef_fn_902() -> int:
+    return undefined_symbol_902
+def undef_fn_903() -> int:
+    return undefined_symbol_903
+def undef_fn_904() -> int:
+    return undefined_symbol_904
+def undef_fn_905() -> int:
+    return undefined_symbol_905
+def undef_fn_906() -> int:
+    return undefined_symbol_906
+def undef_fn_907() -> int:
+    return undefined_symbol_907
+def undef_fn_908() -> int:
+    return undefined_symbol_908
+def undef_fn_909() -> int:
+    return undefined_symbol_909
+def undef_fn_910() -> int:
+    return undefined_symbol_910
+def undef_fn_911() -> int:
+    return undefined_symbol_911
+def undef_fn_912() -> int:
+    return undefined_symbol_912
+def undef_fn_913() -> int:
+    return undefined_symbol_913
+def undef_fn_914() -> int:
+    return undefined_symbol_914
+def undef_fn_915() -> int:
+    return undefined_symbol_915
+def undef_fn_916() -> int:
+    return undefined_symbol_916
+def undef_fn_917() -> int:
+    return undefined_symbol_917
+def undef_fn_918() -> int:
+    return undefined_symbol_918
+def undef_fn_919() -> int:
+    return undefined_symbol_919
+def undef_fn_920() -> int:
+    return undefined_symbol_920
+def undef_fn_921() -> int:
+    return undefined_symbol_921
+def undef_fn_922() -> int:
+    return undefined_symbol_922
+def undef_fn_923() -> int:
+    return undefined_symbol_923
+def undef_fn_924() -> int:
+    return undefined_symbol_924
+def undef_fn_925() -> int:
+    return undefined_symbol_925
+def undef_fn_926() -> int:
+    return undefined_symbol_926
+def undef_fn_927() -> int:
+    return undefined_symbol_927
+def undef_fn_928() -> int:
+    return undefined_symbol_928
+def undef_fn_929() -> int:
+    return undefined_symbol_929
+def undef_fn_930() -> int:
+    return undefined_symbol_930
+def undef_fn_931() -> int:
+    return undefined_symbol_931
+def undef_fn_932() -> int:
+    return undefined_symbol_932
+def undef_fn_933() -> int:
+    return undefined_symbol_933
+def undef_fn_934() -> int:
+    return undefined_symbol_934
+def undef_fn_935() -> int:
+    return undefined_symbol_935
+def undef_fn_936() -> int:
+    return undefined_symbol_936
+def undef_fn_937() -> int:
+    return undefined_symbol_937
+def undef_fn_938() -> int:
+    return undefined_symbol_938
+def undef_fn_939() -> int:
+    return undefined_symbol_939
+def undef_fn_940() -> int:
+    return undefined_symbol_940
+def undef_fn_941() -> int:
+    return undefined_symbol_941
+def undef_fn_942() -> int:
+    return undefined_symbol_942
+def undef_fn_943() -> int:
+    return undefined_symbol_943
+def undef_fn_944() -> int:
+    return undefined_symbol_944
+def undef_fn_945() -> int:
+    return undefined_symbol_945
+def undef_fn_946() -> int:
+    return undefined_symbol_946
+def undef_fn_947() -> int:
+    return undefined_symbol_947
+def undef_fn_948() -> int:
+    return undefined_symbol_948
+def undef_fn_949() -> int:
+    return undefined_symbol_949
+def undef_fn_950() -> int:
+    return undefined_symbol_950
+def undef_fn_951() -> int:
+    return undefined_symbol_951
+def undef_fn_952() -> int:
+    return undefined_symbol_952
+def undef_fn_953() -> int:
+    return undefined_symbol_953
+def undef_fn_954() -> int:
+    return undefined_symbol_954
+def undef_fn_955() -> int:
+    return undefined_symbol_955
+def undef_fn_956() -> int:
+    return undefined_symbol_956
+def undef_fn_957() -> int:
+    return undefined_symbol_957
+def undef_fn_958() -> int:
+    return undefined_symbol_958
+def undef_fn_959() -> int:
+    return undefined_symbol_959
+def undef_fn_960() -> int:
+    return undefined_symbol_960
+def undef_fn_961() -> int:
+    return undefined_symbol_961
+def undef_fn_962() -> int:
+    return undefined_symbol_962
+def undef_fn_963() -> int:
+    return undefined_symbol_963
+def undef_fn_964() -> int:
+    return undefined_symbol_964
+def undef_fn_965() -> int:
+    return undefined_symbol_965
+def undef_fn_966() -> int:
+    return undefined_symbol_966
+def undef_fn_967() -> int:
+    return undefined_symbol_967
+def undef_fn_968() -> int:
+    return undefined_symbol_968
+def undef_fn_969() -> int:
+    return undefined_symbol_969
+def undef_fn_970() -> int:
+    return undefined_symbol_970
+def undef_fn_971() -> int:
+    return undefined_symbol_971
+def undef_fn_972() -> int:
+    return undefined_symbol_972
+def undef_fn_973() -> int:
+    return undefined_symbol_973
+def undef_fn_974() -> int:
+    return undefined_symbol_974
+def undef_fn_975() -> int:
+    return undefined_symbol_975
+def undef_fn_976() -> int:
+    return undefined_symbol_976
+def undef_fn_977() -> int:
+    return undefined_symbol_977
+def undef_fn_978() -> int:
+    return undefined_symbol_978
+def undef_fn_979() -> int:
+    return undefined_symbol_979
+def undef_fn_980() -> int:
+    return undefined_symbol_980
+def undef_fn_981() -> int:
+    return undefined_symbol_981
+def undef_fn_982() -> int:
+    return undefined_symbol_982
+def undef_fn_983() -> int:
+    return undefined_symbol_983
+def undef_fn_984() -> int:
+    return undefined_symbol_984
+def undef_fn_985() -> int:
+    return undefined_symbol_985
+def undef_fn_986() -> int:
+    return undefined_symbol_986
+def undef_fn_987() -> int:
+    return undefined_symbol_987
+def undef_fn_988() -> int:
+    return undefined_symbol_988
+def undef_fn_989() -> int:
+    return undefined_symbol_989
+def undef_fn_990() -> int:
+    return undefined_symbol_990
+def undef_fn_991() -> int:
+    return undefined_symbol_991
+def undef_fn_992() -> int:
+    return undefined_symbol_992
+def undef_fn_993() -> int:
+    return undefined_symbol_993
+def undef_fn_994() -> int:
+    return undefined_symbol_994
+def undef_fn_995() -> int:
+    return undefined_symbol_995
+def undef_fn_996() -> int:
+    return undefined_symbol_996
+def undef_fn_997() -> int:
+    return undefined_symbol_997
+def undef_fn_998() -> int:
+    return undefined_symbol_998
+def undef_fn_999() -> int:
+    return undefined_symbol_999
+def undef_fn_1000() -> int:
+    return undefined_symbol_1000
+def undef_fn_1001() -> int:
+    return undefined_symbol_1001
+def undef_fn_1002() -> int:
+    return undefined_symbol_1002
+def undef_fn_1003() -> int:
+    return undefined_symbol_1003
+def undef_fn_1004() -> int:
+    return undefined_symbol_1004
+def undef_fn_1005() -> int:
+    return undefined_symbol_1005
+def undef_fn_1006() -> int:
+    return undefined_symbol_1006
+def undef_fn_1007() -> int:
+    return undefined_symbol_1007
+def undef_fn_1008() -> int:
+    return undefined_symbol_1008
+def undef_fn_1009() -> int:
+    return undefined_symbol_1009
+def undef_fn_1010() -> int:
+    return undefined_symbol_1010
+def undef_fn_1011() -> int:
+    return undefined_symbol_1011
+def undef_fn_1012() -> int:
+    return undefined_symbol_1012
+def undef_fn_1013() -> int:
+    return undefined_symbol_1013
+def undef_fn_1014() -> int:
+    return undefined_symbol_1014
+def undef_fn_1015() -> int:
+    return undefined_symbol_1015
+def undef_fn_1016() -> int:
+    return undefined_symbol_1016
+def undef_fn_1017() -> int:
+    return undefined_symbol_1017
+def undef_fn_1018() -> int:
+    return undefined_symbol_1018
+def undef_fn_1019() -> int:
+    return undefined_symbol_1019
+def undef_fn_1020() -> int:
+    return undefined_symbol_1020
+def undef_fn_1021() -> int:
+    return undefined_symbol_1021
+def undef_fn_1022() -> int:
+    return undefined_symbol_1022
+def undef_fn_1023() -> int:
+    return undefined_symbol_1023
+def undef_fn_1024() -> int:
+    return undefined_symbol_1024
+def undef_fn_1025() -> int:
+    return undefined_symbol_1025
+def undef_fn_1026() -> int:
+    return undefined_symbol_1026
+def undef_fn_1027() -> int:
+    return undefined_symbol_1027
+def undef_fn_1028() -> int:
+    return undefined_symbol_1028
+def undef_fn_1029() -> int:
+    return undefined_symbol_1029
+def undef_fn_1030() -> int:
+    return undefined_symbol_1030
+def undef_fn_1031() -> int:
+    return undefined_symbol_1031
+def undef_fn_1032() -> int:
+    return undefined_symbol_1032
+def undef_fn_1033() -> int:
+    return undefined_symbol_1033
+def undef_fn_1034() -> int:
+    return undefined_symbol_1034
+def undef_fn_1035() -> int:
+    return undefined_symbol_1035
+def undef_fn_1036() -> int:
+    return undefined_symbol_1036
+def undef_fn_1037() -> int:
+    return undefined_symbol_1037
+def undef_fn_1038() -> int:
+    return undefined_symbol_1038
+def undef_fn_1039() -> int:
+    return undefined_symbol_1039
+def undef_fn_1040() -> int:
+    return undefined_symbol_1040
+def undef_fn_1041() -> int:
+    return undefined_symbol_1041
+def undef_fn_1042() -> int:
+    return undefined_symbol_1042
+def undef_fn_1043() -> int:
+    return undefined_symbol_1043
+def undef_fn_1044() -> int:
+    return undefined_symbol_1044
+def undef_fn_1045() -> int:
+    return undefined_symbol_1045
+def undef_fn_1046() -> int:
+    return undefined_symbol_1046
+def undef_fn_1047() -> int:
+    return undefined_symbol_1047
+def undef_fn_1048() -> int:
+    return undefined_symbol_1048
+def undef_fn_1049() -> int:
+    return undefined_symbol_1049
+def undef_fn_1050() -> int:
+    return undefined_symbol_1050
+def undef_fn_1051() -> int:
+    return undefined_symbol_1051
+def undef_fn_1052() -> int:
+    return undefined_symbol_1052
+def undef_fn_1053() -> int:
+    return undefined_symbol_1053
+def undef_fn_1054() -> int:
+    return undefined_symbol_1054
+def undef_fn_1055() -> int:
+    return undefined_symbol_1055
+def undef_fn_1056() -> int:
+    return undefined_symbol_1056
+def undef_fn_1057() -> int:
+    return undefined_symbol_1057
+def undef_fn_1058() -> int:
+    return undefined_symbol_1058
+def undef_fn_1059() -> int:
+    return undefined_symbol_1059
+def undef_fn_1060() -> int:
+    return undefined_symbol_1060
+def undef_fn_1061() -> int:
+    return undefined_symbol_1061
+def undef_fn_1062() -> int:
+    return undefined_symbol_1062
+def undef_fn_1063() -> int:
+    return undefined_symbol_1063
+def undef_fn_1064() -> int:
+    return undefined_symbol_1064
+def undef_fn_1065() -> int:
+    return undefined_symbol_1065
+def undef_fn_1066() -> int:
+    return undefined_symbol_1066
+def undef_fn_1067() -> int:
+    return undefined_symbol_1067
+def undef_fn_1068() -> int:
+    return undefined_symbol_1068
+def undef_fn_1069() -> int:
+    return undefined_symbol_1069
+def undef_fn_1070() -> int:
+    return undefined_symbol_1070
+def undef_fn_1071() -> int:
+    return undefined_symbol_1071
+def undef_fn_1072() -> int:
+    return undefined_symbol_1072
+def undef_fn_1073() -> int:
+    return undefined_symbol_1073
+def undef_fn_1074() -> int:
+    return undefined_symbol_1074
+def undef_fn_1075() -> int:
+    return undefined_symbol_1075
+def undef_fn_1076() -> int:
+    return undefined_symbol_1076
+def undef_fn_1077() -> int:
+    return undefined_symbol_1077
+def undef_fn_1078() -> int:
+    return undefined_symbol_1078
+def undef_fn_1079() -> int:
+    return undefined_symbol_1079
+def undef_fn_1080() -> int:
+    return undefined_symbol_1080
+def undef_fn_1081() -> int:
+    return undefined_symbol_1081
+def undef_fn_1082() -> int:
+    return undefined_symbol_1082
+def undef_fn_1083() -> int:
+    return undefined_symbol_1083
+def undef_fn_1084() -> int:
+    return undefined_symbol_1084
+def undef_fn_1085() -> int:
+    return undefined_symbol_1085
+def undef_fn_1086() -> int:
+    return undefined_symbol_1086
+def undef_fn_1087() -> int:
+    return undefined_symbol_1087
+def undef_fn_1088() -> int:
+    return undefined_symbol_1088
+def undef_fn_1089() -> int:
+    return undefined_symbol_1089
+def undef_fn_1090() -> int:
+    return undefined_symbol_1090
+def undef_fn_1091() -> int:
+    return undefined_symbol_1091
+def undef_fn_1092() -> int:
+    return undefined_symbol_1092
+def undef_fn_1093() -> int:
+    return undefined_symbol_1093
+def undef_fn_1094() -> int:
+    return undefined_symbol_1094
+def undef_fn_1095() -> int:
+    return undefined_symbol_1095
+def undef_fn_1096() -> int:
+    return undefined_symbol_1096
+def undef_fn_1097() -> int:
+    return undefined_symbol_1097
+def undef_fn_1098() -> int:
+    return undefined_symbol_1098
+def undef_fn_1099() -> int:
+    return undefined_symbol_1099
+def undef_fn_1100() -> int:
+    return undefined_symbol_1100
+def undef_fn_1101() -> int:
+    return undefined_symbol_1101
+def undef_fn_1102() -> int:
+    return undefined_symbol_1102
+def undef_fn_1103() -> int:
+    return undefined_symbol_1103
+def undef_fn_1104() -> int:
+    return undefined_symbol_1104
+def undef_fn_1105() -> int:
+    return undefined_symbol_1105
+def undef_fn_1106() -> int:
+    return undefined_symbol_1106
+def undef_fn_1107() -> int:
+    return undefined_symbol_1107
+def undef_fn_1108() -> int:
+    return undefined_symbol_1108
+def undef_fn_1109() -> int:
+    return undefined_symbol_1109
+def undef_fn_1110() -> int:
+    return undefined_symbol_1110
+def undef_fn_1111() -> int:
+    return undefined_symbol_1111
+def undef_fn_1112() -> int:
+    return undefined_symbol_1112
+def undef_fn_1113() -> int:
+    return undefined_symbol_1113
+def undef_fn_1114() -> int:
+    return undefined_symbol_1114
+def undef_fn_1115() -> int:
+    return undefined_symbol_1115
+def undef_fn_1116() -> int:
+    return undefined_symbol_1116
+def undef_fn_1117() -> int:
+    return undefined_symbol_1117
+def undef_fn_1118() -> int:
+    return undefined_symbol_1118
+def undef_fn_1119() -> int:
+    return undefined_symbol_1119
+def undef_fn_1120() -> int:
+    return undefined_symbol_1120
+def undef_fn_1121() -> int:
+    return undefined_symbol_1121
+def undef_fn_1122() -> int:
+    return undefined_symbol_1122
+def undef_fn_1123() -> int:
+    return undefined_symbol_1123
+def undef_fn_1124() -> int:
+    return undefined_symbol_1124
+def undef_fn_1125() -> int:
+    return undefined_symbol_1125
+def undef_fn_1126() -> int:
+    return undefined_symbol_1126
+def undef_fn_1127() -> int:
+    return undefined_symbol_1127
+def undef_fn_1128() -> int:
+    return undefined_symbol_1128
+def undef_fn_1129() -> int:
+    return undefined_symbol_1129
+def undef_fn_1130() -> int:
+    return undefined_symbol_1130
+def undef_fn_1131() -> int:
+    return undefined_symbol_1131
+def undef_fn_1132() -> int:
+    return undefined_symbol_1132
+def undef_fn_1133() -> int:
+    return undefined_symbol_1133
+def undef_fn_1134() -> int:
+    return undefined_symbol_1134
+def undef_fn_1135() -> int:
+    return undefined_symbol_1135
+def undef_fn_1136() -> int:
+    return undefined_symbol_1136
+def undef_fn_1137() -> int:
+    return undefined_symbol_1137
+def undef_fn_1138() -> int:
+    return undefined_symbol_1138
+def undef_fn_1139() -> int:
+    return undefined_symbol_1139
+def undef_fn_1140() -> int:
+    return undefined_symbol_1140
+def undef_fn_1141() -> int:
+    return undefined_symbol_1141
+def undef_fn_1142() -> int:
+    return undefined_symbol_1142
+def undef_fn_1143() -> int:
+    return undefined_symbol_1143
+def undef_fn_1144() -> int:
+    return undefined_symbol_1144
+def undef_fn_1145() -> int:
+    return undefined_symbol_1145
+def undef_fn_1146() -> int:
+    return undefined_symbol_1146
+def undef_fn_1147() -> int:
+    return undefined_symbol_1147
+def undef_fn_1148() -> int:
+    return undefined_symbol_1148
+def undef_fn_1149() -> int:
+    return undefined_symbol_1149
+def undef_fn_1150() -> int:
+    return undefined_symbol_1150
+def undef_fn_1151() -> int:
+    return undefined_symbol_1151
+def undef_fn_1152() -> int:
+    return undefined_symbol_1152
+def undef_fn_1153() -> int:
+    return undefined_symbol_1153
+def undef_fn_1154() -> int:
+    return undefined_symbol_1154
+def undef_fn_1155() -> int:
+    return undefined_symbol_1155
+def undef_fn_1156() -> int:
+    return undefined_symbol_1156
+def undef_fn_1157() -> int:
+    return undefined_symbol_1157
+def undef_fn_1158() -> int:
+    return undefined_symbol_1158
+def undef_fn_1159() -> int:
+    return undefined_symbol_1159
+def undef_fn_1160() -> int:
+    return undefined_symbol_1160
+def undef_fn_1161() -> int:
+    return undefined_symbol_1161
+def undef_fn_1162() -> int:
+    return undefined_symbol_1162
+def undef_fn_1163() -> int:
+    return undefined_symbol_1163
+def undef_fn_1164() -> int:
+    return undefined_symbol_1164
+def undef_fn_1165() -> int:
+    return undefined_symbol_1165
+def undef_fn_1166() -> int:
+    return undefined_symbol_1166
+def undef_fn_1167() -> int:
+    return undefined_symbol_1167
+def undef_fn_1168() -> int:
+    return undefined_symbol_1168
+def undef_fn_1169() -> int:
+    return undefined_symbol_1169
+def undef_fn_1170() -> int:
+    return undefined_symbol_1170
+def undef_fn_1171() -> int:
+    return undefined_symbol_1171
+def undef_fn_1172() -> int:
+    return undefined_symbol_1172
+def undef_fn_1173() -> int:
+    return undefined_symbol_1173
+def undef_fn_1174() -> int:
+    return undefined_symbol_1174
+def undef_fn_1175() -> int:
+    return undefined_symbol_1175
+def undef_fn_1176() -> int:
+    return undefined_symbol_1176
+def undef_fn_1177() -> int:
+    return undefined_symbol_1177
+def undef_fn_1178() -> int:
+    return undefined_symbol_1178
+def undef_fn_1179() -> int:
+    return undefined_symbol_1179
+def undef_fn_1180() -> int:
+    return undefined_symbol_1180
+def undef_fn_1181() -> int:
+    return undefined_symbol_1181
+def undef_fn_1182() -> int:
+    return undefined_symbol_1182
+def undef_fn_1183() -> int:
+    return undefined_symbol_1183
+def undef_fn_1184() -> int:
+    return undefined_symbol_1184
+def undef_fn_1185() -> int:
+    return undefined_symbol_1185
+def undef_fn_1186() -> int:
+    return undefined_symbol_1186
+def undef_fn_1187() -> int:
+    return undefined_symbol_1187
+def undef_fn_1188() -> int:
+    return undefined_symbol_1188
+def undef_fn_1189() -> int:
+    return undefined_symbol_1189
+def undef_fn_1190() -> int:
+    return undefined_symbol_1190
+def undef_fn_1191() -> int:
+    return undefined_symbol_1191
+def undef_fn_1192() -> int:
+    return undefined_symbol_1192
+def undef_fn_1193() -> int:
+    return undefined_symbol_1193
+def undef_fn_1194() -> int:
+    return undefined_symbol_1194
+def undef_fn_1195() -> int:
+    return undefined_symbol_1195
+def undef_fn_1196() -> int:
+    return undefined_symbol_1196
+def undef_fn_1197() -> int:
+    return undefined_symbol_1197
+def undef_fn_1198() -> int:
+    return undefined_symbol_1198
+def undef_fn_1199() -> int:
+    return undefined_symbol_1199
+def undef_fn_1200() -> int:
+    return undefined_symbol_1200
+def undef_fn_1201() -> int:
+    return undefined_symbol_1201
+def undef_fn_1202() -> int:
+    return undefined_symbol_1202
+def undef_fn_1203() -> int:
+    return undefined_symbol_1203
+def undef_fn_1204() -> int:
+    return undefined_symbol_1204
+def undef_fn_1205() -> int:
+    return undefined_symbol_1205
+def undef_fn_1206() -> int:
+    return undefined_symbol_1206
+def undef_fn_1207() -> int:
+    return undefined_symbol_1207
+def undef_fn_1208() -> int:
+    return undefined_symbol_1208
+def undef_fn_1209() -> int:
+    return undefined_symbol_1209
+def undef_fn_1210() -> int:
+    return undefined_symbol_1210
+def undef_fn_1211() -> int:
+    return undefined_symbol_1211
+def undef_fn_1212() -> int:
+    return undefined_symbol_1212
+def undef_fn_1213() -> int:
+    return undefined_symbol_1213
+def undef_fn_1214() -> int:
+    return undefined_symbol_1214
+def undef_fn_1215() -> int:
+    return undefined_symbol_1215
+def undef_fn_1216() -> int:
+    return undefined_symbol_1216
+def undef_fn_1217() -> int:
+    return undefined_symbol_1217
+def undef_fn_1218() -> int:
+    return undefined_symbol_1218
+def undef_fn_1219() -> int:
+    return undefined_symbol_1219
+def undef_fn_1220() -> int:
+    return undefined_symbol_1220
+def undef_fn_1221() -> int:
+    return undefined_symbol_1221
+def undef_fn_1222() -> int:
+    return undefined_symbol_1222
+def undef_fn_1223() -> int:
+    return undefined_symbol_1223
+def undef_fn_1224() -> int:
+    return undefined_symbol_1224
+def undef_fn_1225() -> int:
+    return undefined_symbol_1225
+def undef_fn_1226() -> int:
+    return undefined_symbol_1226
+def undef_fn_1227() -> int:
+    return undefined_symbol_1227
+def undef_fn_1228() -> int:
+    return undefined_symbol_1228
+def undef_fn_1229() -> int:
+    return undefined_symbol_1229
+def undef_fn_1230() -> int:
+    return undefined_symbol_1230
+def undef_fn_1231() -> int:
+    return undefined_symbol_1231
+def undef_fn_1232() -> int:
+    return undefined_symbol_1232
+def undef_fn_1233() -> int:
+    return undefined_symbol_1233
+def undef_fn_1234() -> int:
+    return undefined_symbol_1234
+def undef_fn_1235() -> int:
+    return undefined_symbol_1235
+def undef_fn_1236() -> int:
+    return undefined_symbol_1236
+def undef_fn_1237() -> int:
+    return undefined_symbol_1237
+def undef_fn_1238() -> int:
+    return undefined_symbol_1238
+def undef_fn_1239() -> int:
+    return undefined_symbol_1239
+def undef_fn_1240() -> int:
+    return undefined_symbol_1240
+def undef_fn_1241() -> int:
+    return undefined_symbol_1241
+def undef_fn_1242() -> int:
+    return undefined_symbol_1242
+def undef_fn_1243() -> int:
+    return undefined_symbol_1243
+def undef_fn_1244() -> int:
+    return undefined_symbol_1244
+def undef_fn_1245() -> int:
+    return undefined_symbol_1245
+def undef_fn_1246() -> int:
+    return undefined_symbol_1246
+def undef_fn_1247() -> int:
+    return undefined_symbol_1247
+def undef_fn_1248() -> int:
+    return undefined_symbol_1248
+def undef_fn_1249() -> int:
+    return undefined_symbol_1249
+def undef_fn_1250() -> int:
+    return undefined_symbol_1250
+def undef_fn_1251() -> int:
+    return undefined_symbol_1251
+def undef_fn_1252() -> int:
+    return undefined_symbol_1252
+def undef_fn_1253() -> int:
+    return undefined_symbol_1253
+def undef_fn_1254() -> int:
+    return undefined_symbol_1254
+def undef_fn_1255() -> int:
+    return undefined_symbol_1255
+def undef_fn_1256() -> int:
+    return undefined_symbol_1256
+def undef_fn_1257() -> int:
+    return undefined_symbol_1257
+def undef_fn_1258() -> int:
+    return undefined_symbol_1258
+def undef_fn_1259() -> int:
+    return undefined_symbol_1259
+def undef_fn_1260() -> int:
+    return undefined_symbol_1260
+def undef_fn_1261() -> int:
+    return undefined_symbol_1261
+def undef_fn_1262() -> int:
+    return undefined_symbol_1262
+def undef_fn_1263() -> int:
+    return undefined_symbol_1263
+def undef_fn_1264() -> int:
+    return undefined_symbol_1264
+def undef_fn_1265() -> int:
+    return undefined_symbol_1265
+def undef_fn_1266() -> int:
+    return undefined_symbol_1266
+def undef_fn_1267() -> int:
+    return undefined_symbol_1267
+def undef_fn_1268() -> int:
+    return undefined_symbol_1268
+def undef_fn_1269() -> int:
+    return undefined_symbol_1269
+def undef_fn_1270() -> int:
+    return undefined_symbol_1270
+def undef_fn_1271() -> int:
+    return undefined_symbol_1271
+def undef_fn_1272() -> int:
+    return undefined_symbol_1272
+def undef_fn_1273() -> int:
+    return undefined_symbol_1273
+def undef_fn_1274() -> int:
+    return undefined_symbol_1274
+def undef_fn_1275() -> int:
+    return undefined_symbol_1275
+def undef_fn_1276() -> int:
+    return undefined_symbol_1276
+def undef_fn_1277() -> int:
+    return undefined_symbol_1277
+def undef_fn_1278() -> int:
+    return undefined_symbol_1278
+def undef_fn_1279() -> int:
+    return undefined_symbol_1279
+def undef_fn_1280() -> int:
+    return undefined_symbol_1280
+def undef_fn_1281() -> int:
+    return undefined_symbol_1281
+def undef_fn_1282() -> int:
+    return undefined_symbol_1282
+def undef_fn_1283() -> int:
+    return undefined_symbol_1283
+def undef_fn_1284() -> int:
+    return undefined_symbol_1284
+def undef_fn_1285() -> int:
+    return undefined_symbol_1285
+def undef_fn_1286() -> int:
+    return undefined_symbol_1286
+def undef_fn_1287() -> int:
+    return undefined_symbol_1287
+def undef_fn_1288() -> int:
+    return undefined_symbol_1288
+def undef_fn_1289() -> int:
+    return undefined_symbol_1289
+def undef_fn_1290() -> int:
+    return undefined_symbol_1290
+def undef_fn_1291() -> int:
+    return undefined_symbol_1291
+def undef_fn_1292() -> int:
+    return undefined_symbol_1292
+def undef_fn_1293() -> int:
+    return undefined_symbol_1293
+def undef_fn_1294() -> int:
+    return undefined_symbol_1294
+def undef_fn_1295() -> int:
+    return undefined_symbol_1295
+def undef_fn_1296() -> int:
+    return undefined_symbol_1296
+def undef_fn_1297() -> int:
+    return undefined_symbol_1297
+def undef_fn_1298() -> int:
+    return undefined_symbol_1298
+def undef_fn_1299() -> int:
+    return undefined_symbol_1299
+def undef_fn_1300() -> int:
+    return undefined_symbol_1300
+def undef_fn_1301() -> int:
+    return undefined_symbol_1301
+def undef_fn_1302() -> int:
+    return undefined_symbol_1302
+def undef_fn_1303() -> int:
+    return undefined_symbol_1303
+def undef_fn_1304() -> int:
+    return undefined_symbol_1304
+def undef_fn_1305() -> int:
+    return undefined_symbol_1305
+def undef_fn_1306() -> int:
+    return undefined_symbol_1306
+def undef_fn_1307() -> int:
+    return undefined_symbol_1307
+def undef_fn_1308() -> int:
+    return undefined_symbol_1308
+def undef_fn_1309() -> int:
+    return undefined_symbol_1309
+def undef_fn_1310() -> int:
+    return undefined_symbol_1310
+def undef_fn_1311() -> int:
+    return undefined_symbol_1311
+def undef_fn_1312() -> int:
+    return undefined_symbol_1312
+def undef_fn_1313() -> int:
+    return undefined_symbol_1313
+def undef_fn_1314() -> int:
+    return undefined_symbol_1314
+def undef_fn_1315() -> int:
+    return undefined_symbol_1315
+def undef_fn_1316() -> int:
+    return undefined_symbol_1316
+def undef_fn_1317() -> int:
+    return undefined_symbol_1317
+def undef_fn_1318() -> int:
+    return undefined_symbol_1318
+def undef_fn_1319() -> int:
+    return undefined_symbol_1319
+def undef_fn_1320() -> int:
+    return undefined_symbol_1320
+def undef_fn_1321() -> int:
+    return undefined_symbol_1321
+def undef_fn_1322() -> int:
+    return undefined_symbol_1322
+def undef_fn_1323() -> int:
+    return undefined_symbol_1323
+def undef_fn_1324() -> int:
+    return undefined_symbol_1324
+def undef_fn_1325() -> int:
+    return undefined_symbol_1325
+def undef_fn_1326() -> int:
+    return undefined_symbol_1326
+def undef_fn_1327() -> int:
+    return undefined_symbol_1327
+def undef_fn_1328() -> int:
+    return undefined_symbol_1328
+def undef_fn_1329() -> int:
+    return undefined_symbol_1329
+def undef_fn_1330() -> int:
+    return undefined_symbol_1330
+def undef_fn_1331() -> int:
+    return undefined_symbol_1331
+def undef_fn_1332() -> int:
+    return undefined_symbol_1332
+def undef_fn_1333() -> int:
+    return undefined_symbol_1333
+def undef_fn_1334() -> int:
+    return undefined_symbol_1334
+def undef_fn_1335() -> int:
+    return undefined_symbol_1335
+def undef_fn_1336() -> int:
+    return undefined_symbol_1336
+def undef_fn_1337() -> int:
+    return undefined_symbol_1337
+def undef_fn_1338() -> int:
+    return undefined_symbol_1338
+def undef_fn_1339() -> int:
+    return undefined_symbol_1339
+def undef_fn_1340() -> int:
+    return undefined_symbol_1340
+def undef_fn_1341() -> int:
+    return undefined_symbol_1341
+def undef_fn_1342() -> int:
+    return undefined_symbol_1342
+def undef_fn_1343() -> int:
+    return undefined_symbol_1343
+def undef_fn_1344() -> int:
+    return undefined_symbol_1344
+def undef_fn_1345() -> int:
+    return undefined_symbol_1345
+def undef_fn_1346() -> int:
+    return undefined_symbol_1346
+def undef_fn_1347() -> int:
+    return undefined_symbol_1347
+def undef_fn_1348() -> int:
+    return undefined_symbol_1348
+def undef_fn_1349() -> int:
+    return undefined_symbol_1349
+def undef_fn_1350() -> int:
+    return undefined_symbol_1350
+def undef_fn_1351() -> int:
+    return undefined_symbol_1351
+def undef_fn_1352() -> int:
+    return undefined_symbol_1352
+def undef_fn_1353() -> int:
+    return undefined_symbol_1353
+def undef_fn_1354() -> int:
+    return undefined_symbol_1354
+def undef_fn_1355() -> int:
+    return undefined_symbol_1355
+def undef_fn_1356() -> int:
+    return undefined_symbol_1356
+def undef_fn_1357() -> int:
+    return undefined_symbol_1357
+def undef_fn_1358() -> int:
+    return undefined_symbol_1358
+def undef_fn_1359() -> int:
+    return undefined_symbol_1359
+def undef_fn_1360() -> int:
+    return undefined_symbol_1360
+def undef_fn_1361() -> int:
+    return undefined_symbol_1361
+def undef_fn_1362() -> int:
+    return undefined_symbol_1362
+def undef_fn_1363() -> int:
+    return undefined_symbol_1363
+def undef_fn_1364() -> int:
+    return undefined_symbol_1364
+def undef_fn_1365() -> int:
+    return undefined_symbol_1365
+def undef_fn_1366() -> int:
+    return undefined_symbol_1366
+def undef_fn_1367() -> int:
+    return undefined_symbol_1367
+def undef_fn_1368() -> int:
+    return undefined_symbol_1368
+def undef_fn_1369() -> int:
+    return undefined_symbol_1369
+def undef_fn_1370() -> int:
+    return undefined_symbol_1370
+def undef_fn_1371() -> int:
+    return undefined_symbol_1371
+def undef_fn_1372() -> int:
+    return undefined_symbol_1372
+def undef_fn_1373() -> int:
+    return undefined_symbol_1373
+def undef_fn_1374() -> int:
+    return undefined_symbol_1374
+def undef_fn_1375() -> int:
+    return undefined_symbol_1375
+def undef_fn_1376() -> int:
+    return undefined_symbol_1376
+def undef_fn_1377() -> int:
+    return undefined_symbol_1377
+def undef_fn_1378() -> int:
+    return undefined_symbol_1378
+def undef_fn_1379() -> int:
+    return undefined_symbol_1379
+def undef_fn_1380() -> int:
+    return undefined_symbol_1380
+def undef_fn_1381() -> int:
+    return undefined_symbol_1381
+def undef_fn_1382() -> int:
+    return undefined_symbol_1382
+def undef_fn_1383() -> int:
+    return undefined_symbol_1383
+def undef_fn_1384() -> int:
+    return undefined_symbol_1384
+def undef_fn_1385() -> int:
+    return undefined_symbol_1385
+def undef_fn_1386() -> int:
+    return undefined_symbol_1386
+def undef_fn_1387() -> int:
+    return undefined_symbol_1387
+def undef_fn_1388() -> int:
+    return undefined_symbol_1388
+def undef_fn_1389() -> int:
+    return undefined_symbol_1389
+def undef_fn_1390() -> int:
+    return undefined_symbol_1390
+def undef_fn_1391() -> int:
+    return undefined_symbol_1391
+def undef_fn_1392() -> int:
+    return undefined_symbol_1392
+def undef_fn_1393() -> int:
+    return undefined_symbol_1393
+def undef_fn_1394() -> int:
+    return undefined_symbol_1394
+def undef_fn_1395() -> int:
+    return undefined_symbol_1395
+def undef_fn_1396() -> int:
+    return undefined_symbol_1396
+def undef_fn_1397() -> int:
+    return undefined_symbol_1397
+def undef_fn_1398() -> int:
+    return undefined_symbol_1398
+def undef_fn_1399() -> int:
+    return undefined_symbol_1399
+def undef_fn_1400() -> int:
+    return undefined_symbol_1400
+def undef_fn_1401() -> int:
+    return undefined_symbol_1401
+def undef_fn_1402() -> int:
+    return undefined_symbol_1402
+def undef_fn_1403() -> int:
+    return undefined_symbol_1403
+def undef_fn_1404() -> int:
+    return undefined_symbol_1404
+def undef_fn_1405() -> int:
+    return undefined_symbol_1405
+def undef_fn_1406() -> int:
+    return undefined_symbol_1406
+def undef_fn_1407() -> int:
+    return undefined_symbol_1407
+def undef_fn_1408() -> int:
+    return undefined_symbol_1408
+def undef_fn_1409() -> int:
+    return undefined_symbol_1409
+def undef_fn_1410() -> int:
+    return undefined_symbol_1410
+def undef_fn_1411() -> int:
+    return undefined_symbol_1411
+def undef_fn_1412() -> int:
+    return undefined_symbol_1412
+def undef_fn_1413() -> int:
+    return undefined_symbol_1413
+def undef_fn_1414() -> int:
+    return undefined_symbol_1414
+def undef_fn_1415() -> int:
+    return undefined_symbol_1415
+def undef_fn_1416() -> int:
+    return undefined_symbol_1416
+def undef_fn_1417() -> int:
+    return undefined_symbol_1417
+def undef_fn_1418() -> int:
+    return undefined_symbol_1418
+def undef_fn_1419() -> int:
+    return undefined_symbol_1419
+def undef_fn_1420() -> int:
+    return undefined_symbol_1420
+def undef_fn_1421() -> int:
+    return undefined_symbol_1421
+def undef_fn_1422() -> int:
+    return undefined_symbol_1422
+def undef_fn_1423() -> int:
+    return undefined_symbol_1423
+def undef_fn_1424() -> int:
+    return undefined_symbol_1424
+def undef_fn_1425() -> int:
+    return undefined_symbol_1425
+def undef_fn_1426() -> int:
+    return undefined_symbol_1426
+def undef_fn_1427() -> int:
+    return undefined_symbol_1427
+def undef_fn_1428() -> int:
+    return undefined_symbol_1428
+def undef_fn_1429() -> int:
+    return undefined_symbol_1429
+def undef_fn_1430() -> int:
+    return undefined_symbol_1430
+def undef_fn_1431() -> int:
+    return undefined_symbol_1431
+def undef_fn_1432() -> int:
+    return undefined_symbol_1432
+def undef_fn_1433() -> int:
+    return undefined_symbol_1433
+def undef_fn_1434() -> int:
+    return undefined_symbol_1434
+def undef_fn_1435() -> int:
+    return undefined_symbol_1435
+def undef_fn_1436() -> int:
+    return undefined_symbol_1436
+def undef_fn_1437() -> int:
+    return undefined_symbol_1437
+def undef_fn_1438() -> int:
+    return undefined_symbol_1438
+def undef_fn_1439() -> int:
+    return undefined_symbol_1439
+def undef_fn_1440() -> int:
+    return undefined_symbol_1440
+def undef_fn_1441() -> int:
+    return undefined_symbol_1441
+def undef_fn_1442() -> int:
+    return undefined_symbol_1442
+def undef_fn_1443() -> int:
+    return undefined_symbol_1443
+def undef_fn_1444() -> int:
+    return undefined_symbol_1444
+def undef_fn_1445() -> int:
+    return undefined_symbol_1445
+def undef_fn_1446() -> int:
+    return undefined_symbol_1446
+def undef_fn_1447() -> int:
+    return undefined_symbol_1447
+def undef_fn_1448() -> int:
+    return undefined_symbol_1448
+def undef_fn_1449() -> int:
+    return undefined_symbol_1449
+def undef_fn_1450() -> int:
+    return undefined_symbol_1450
+def undef_fn_1451() -> int:
+    return undefined_symbol_1451
+def undef_fn_1452() -> int:
+    return undefined_symbol_1452
+def undef_fn_1453() -> int:
+    return undefined_symbol_1453
+def undef_fn_1454() -> int:
+    return undefined_symbol_1454
+def undef_fn_1455() -> int:
+    return undefined_symbol_1455
+def undef_fn_1456() -> int:
+    return undefined_symbol_1456
+def undef_fn_1457() -> int:
+    return undefined_symbol_1457
+def undef_fn_1458() -> int:
+    return undefined_symbol_1458
+def undef_fn_1459() -> int:
+    return undefined_symbol_1459
+def undef_fn_1460() -> int:
+    return undefined_symbol_1460
+def undef_fn_1461() -> int:
+    return undefined_symbol_1461
+def undef_fn_1462() -> int:
+    return undefined_symbol_1462
+def undef_fn_1463() -> int:
+    return undefined_symbol_1463
+def undef_fn_1464() -> int:
+    return undefined_symbol_1464
+def undef_fn_1465() -> int:
+    return undefined_symbol_1465
+def undef_fn_1466() -> int:
+    return undefined_symbol_1466
+def undef_fn_1467() -> int:
+    return undefined_symbol_1467
+def undef_fn_1468() -> int:
+    return undefined_symbol_1468
+def undef_fn_1469() -> int:
+    return undefined_symbol_1469
+def undef_fn_1470() -> int:
+    return undefined_symbol_1470
+def undef_fn_1471() -> int:
+    return undefined_symbol_1471
+def undef_fn_1472() -> int:
+    return undefined_symbol_1472
+def undef_fn_1473() -> int:
+    return undefined_symbol_1473
+def undef_fn_1474() -> int:
+    return undefined_symbol_1474
+def undef_fn_1475() -> int:
+    return undefined_symbol_1475
+def undef_fn_1476() -> int:
+    return undefined_symbol_1476
+def undef_fn_1477() -> int:
+    return undefined_symbol_1477
+def undef_fn_1478() -> int:
+    return undefined_symbol_1478
+def undef_fn_1479() -> int:
+    return undefined_symbol_1479
+def undef_fn_1480() -> int:
+    return undefined_symbol_1480
+def undef_fn_1481() -> int:
+    return undefined_symbol_1481
+def undef_fn_1482() -> int:
+    return undefined_symbol_1482
+def undef_fn_1483() -> int:
+    return undefined_symbol_1483
+def undef_fn_1484() -> int:
+    return undefined_symbol_1484
+def undef_fn_1485() -> int:
+    return undefined_symbol_1485
+def undef_fn_1486() -> int:
+    return undefined_symbol_1486
+def undef_fn_1487() -> int:
+    return undefined_symbol_1487
+def undef_fn_1488() -> int:
+    return undefined_symbol_1488
+def undef_fn_1489() -> int:
+    return undefined_symbol_1489
+def undef_fn_1490() -> int:
+    return undefined_symbol_1490
+def undef_fn_1491() -> int:
+    return undefined_symbol_1491
+def undef_fn_1492() -> int:
+    return undefined_symbol_1492
+def undef_fn_1493() -> int:
+    return undefined_symbol_1493
+def undef_fn_1494() -> int:
+    return undefined_symbol_1494
+def undef_fn_1495() -> int:
+    return undefined_symbol_1495
+def undef_fn_1496() -> int:
+    return undefined_symbol_1496
+def undef_fn_1497() -> int:
+    return undefined_symbol_1497
+def undef_fn_1498() -> int:
+    return undefined_symbol_1498
+def undef_fn_1499() -> int:
+    return undefined_symbol_1499
+def undef_fn_1500() -> int:
+    return undefined_symbol_1500
+def undef_fn_1501() -> int:
+    return undefined_symbol_1501
+def undef_fn_1502() -> int:
+    return undefined_symbol_1502
+def undef_fn_1503() -> int:
+    return undefined_symbol_1503
+def undef_fn_1504() -> int:
+    return undefined_symbol_1504
+def undef_fn_1505() -> int:
+    return undefined_symbol_1505
+def undef_fn_1506() -> int:
+    return undefined_symbol_1506
+def undef_fn_1507() -> int:
+    return undefined_symbol_1507
+def undef_fn_1508() -> int:
+    return undefined_symbol_1508
+def undef_fn_1509() -> int:
+    return undefined_symbol_1509
+def undef_fn_1510() -> int:
+    return undefined_symbol_1510
+def undef_fn_1511() -> int:
+    return undefined_symbol_1511
+def undef_fn_1512() -> int:
+    return undefined_symbol_1512
+def undef_fn_1513() -> int:
+    return undefined_symbol_1513
+def undef_fn_1514() -> int:
+    return undefined_symbol_1514
+def undef_fn_1515() -> int:
+    return undefined_symbol_1515
+def undef_fn_1516() -> int:
+    return undefined_symbol_1516
+def undef_fn_1517() -> int:
+    return undefined_symbol_1517
+def undef_fn_1518() -> int:
+    return undefined_symbol_1518
+def undef_fn_1519() -> int:
+    return undefined_symbol_1519
+def undef_fn_1520() -> int:
+    return undefined_symbol_1520
+def undef_fn_1521() -> int:
+    return undefined_symbol_1521
+def undef_fn_1522() -> int:
+    return undefined_symbol_1522
+def undef_fn_1523() -> int:
+    return undefined_symbol_1523
+def undef_fn_1524() -> int:
+    return undefined_symbol_1524
+def undef_fn_1525() -> int:
+    return undefined_symbol_1525
+def undef_fn_1526() -> int:
+    return undefined_symbol_1526
+def undef_fn_1527() -> int:
+    return undefined_symbol_1527
+def undef_fn_1528() -> int:
+    return undefined_symbol_1528
+def undef_fn_1529() -> int:
+    return undefined_symbol_1529
+def undef_fn_1530() -> int:
+    return undefined_symbol_1530
+def undef_fn_1531() -> int:
+    return undefined_symbol_1531
+def undef_fn_1532() -> int:
+    return undefined_symbol_1532
+def undef_fn_1533() -> int:
+    return undefined_symbol_1533
+def undef_fn_1534() -> int:
+    return undefined_symbol_1534
+def undef_fn_1535() -> int:
+    return undefined_symbol_1535
+def undef_fn_1536() -> int:
+    return undefined_symbol_1536
+def undef_fn_1537() -> int:
+    return undefined_symbol_1537
+def undef_fn_1538() -> int:
+    return undefined_symbol_1538
+def undef_fn_1539() -> int:
+    return undefined_symbol_1539
+def undef_fn_1540() -> int:
+    return undefined_symbol_1540
+def undef_fn_1541() -> int:
+    return undefined_symbol_1541
+def undef_fn_1542() -> int:
+    return undefined_symbol_1542
+def undef_fn_1543() -> int:
+    return undefined_symbol_1543
+def undef_fn_1544() -> int:
+    return undefined_symbol_1544
+def undef_fn_1545() -> int:
+    return undefined_symbol_1545
+def undef_fn_1546() -> int:
+    return undefined_symbol_1546
+def undef_fn_1547() -> int:
+    return undefined_symbol_1547
+def undef_fn_1548() -> int:
+    return undefined_symbol_1548
+def undef_fn_1549() -> int:
+    return undefined_symbol_1549
+def undef_fn_1550() -> int:
+    return undefined_symbol_1550
+def undef_fn_1551() -> int:
+    return undefined_symbol_1551
+def undef_fn_1552() -> int:
+    return undefined_symbol_1552
+def undef_fn_1553() -> int:
+    return undefined_symbol_1553
+def undef_fn_1554() -> int:
+    return undefined_symbol_1554
+def undef_fn_1555() -> int:
+    return undefined_symbol_1555
+def undef_fn_1556() -> int:
+    return undefined_symbol_1556
+def undef_fn_1557() -> int:
+    return undefined_symbol_1557
+def undef_fn_1558() -> int:
+    return undefined_symbol_1558
+def undef_fn_1559() -> int:
+    return undefined_symbol_1559
+def undef_fn_1560() -> int:
+    return undefined_symbol_1560
+def undef_fn_1561() -> int:
+    return undefined_symbol_1561
+def undef_fn_1562() -> int:
+    return undefined_symbol_1562
+def undef_fn_1563() -> int:
+    return undefined_symbol_1563
+def undef_fn_1564() -> int:
+    return undefined_symbol_1564
+def undef_fn_1565() -> int:
+    return undefined_symbol_1565
+def undef_fn_1566() -> int:
+    return undefined_symbol_1566
+def undef_fn_1567() -> int:
+    return undefined_symbol_1567
+def undef_fn_1568() -> int:
+    return undefined_symbol_1568
+def undef_fn_1569() -> int:
+    return undefined_symbol_1569
+def undef_fn_1570() -> int:
+    return undefined_symbol_1570
+def undef_fn_1571() -> int:
+    return undefined_symbol_1571
+def undef_fn_1572() -> int:
+    return undefined_symbol_1572
+def undef_fn_1573() -> int:
+    return undefined_symbol_1573
+def undef_fn_1574() -> int:
+    return undefined_symbol_1574
+def undef_fn_1575() -> int:
+    return undefined_symbol_1575
+def undef_fn_1576() -> int:
+    return undefined_symbol_1576
+def undef_fn_1577() -> int:
+    return undefined_symbol_1577
+def undef_fn_1578() -> int:
+    return undefined_symbol_1578
+def undef_fn_1579() -> int:
+    return undefined_symbol_1579
+def undef_fn_1580() -> int:
+    return undefined_symbol_1580
+def undef_fn_1581() -> int:
+    return undefined_symbol_1581
+def undef_fn_1582() -> int:
+    return undefined_symbol_1582
+def undef_fn_1583() -> int:
+    return undefined_symbol_1583
+def undef_fn_1584() -> int:
+    return undefined_symbol_1584
+def undef_fn_1585() -> int:
+    return undefined_symbol_1585
+def undef_fn_1586() -> int:
+    return undefined_symbol_1586
+def undef_fn_1587() -> int:
+    return undefined_symbol_1587
+def undef_fn_1588() -> int:
+    return undefined_symbol_1588
+def undef_fn_1589() -> int:
+    return undefined_symbol_1589
+def undef_fn_1590() -> int:
+    return undefined_symbol_1590
+def undef_fn_1591() -> int:
+    return undefined_symbol_1591
+def undef_fn_1592() -> int:
+    return undefined_symbol_1592
+def undef_fn_1593() -> int:
+    return undefined_symbol_1593
+def undef_fn_1594() -> int:
+    return undefined_symbol_1594
+def undef_fn_1595() -> int:
+    return undefined_symbol_1595
+def undef_fn_1596() -> int:
+    return undefined_symbol_1596
+def undef_fn_1597() -> int:
+    return undefined_symbol_1597
+def undef_fn_1598() -> int:
+    return undefined_symbol_1598
+def undef_fn_1599() -> int:
+    return undefined_symbol_1599
+def undef_fn_1600() -> int:
+    return undefined_symbol_1600
+def undef_fn_1601() -> int:
+    return undefined_symbol_1601
+def undef_fn_1602() -> int:
+    return undefined_symbol_1602
+def undef_fn_1603() -> int:
+    return undefined_symbol_1603
+def undef_fn_1604() -> int:
+    return undefined_symbol_1604
+def undef_fn_1605() -> int:
+    return undefined_symbol_1605
+def undef_fn_1606() -> int:
+    return undefined_symbol_1606
+def undef_fn_1607() -> int:
+    return undefined_symbol_1607
+def undef_fn_1608() -> int:
+    return undefined_symbol_1608
+def undef_fn_1609() -> int:
+    return undefined_symbol_1609
+def undef_fn_1610() -> int:
+    return undefined_symbol_1610
+def undef_fn_1611() -> int:
+    return undefined_symbol_1611
+def undef_fn_1612() -> int:
+    return undefined_symbol_1612
+def undef_fn_1613() -> int:
+    return undefined_symbol_1613
+def undef_fn_1614() -> int:
+    return undefined_symbol_1614
+def undef_fn_1615() -> int:
+    return undefined_symbol_1615
+def undef_fn_1616() -> int:
+    return undefined_symbol_1616
+def undef_fn_1617() -> int:
+    return undefined_symbol_1617
+def undef_fn_1618() -> int:
+    return undefined_symbol_1618
+def undef_fn_1619() -> int:
+    return undefined_symbol_1619
+def undef_fn_1620() -> int:
+    return undefined_symbol_1620
+def undef_fn_1621() -> int:
+    return undefined_symbol_1621
+def undef_fn_1622() -> int:
+    return undefined_symbol_1622
+def undef_fn_1623() -> int:
+    return undefined_symbol_1623
+def undef_fn_1624() -> int:
+    return undefined_symbol_1624
+def undef_fn_1625() -> int:
+    return undefined_symbol_1625
+def undef_fn_1626() -> int:
+    return undefined_symbol_1626
+def undef_fn_1627() -> int:
+    return undefined_symbol_1627
+def undef_fn_1628() -> int:
+    return undefined_symbol_1628
+def undef_fn_1629() -> int:
+    return undefined_symbol_1629
+def undef_fn_1630() -> int:
+    return undefined_symbol_1630
+def undef_fn_1631() -> int:
+    return undefined_symbol_1631
+def undef_fn_1632() -> int:
+    return undefined_symbol_1632
+def undef_fn_1633() -> int:
+    return undefined_symbol_1633
+def undef_fn_1634() -> int:
+    return undefined_symbol_1634
+def undef_fn_1635() -> int:
+    return undefined_symbol_1635
+def undef_fn_1636() -> int:
+    return undefined_symbol_1636
+def undef_fn_1637() -> int:
+    return undefined_symbol_1637
+def undef_fn_1638() -> int:
+    return undefined_symbol_1638
+def undef_fn_1639() -> int:
+    return undefined_symbol_1639
+def undef_fn_1640() -> int:
+    return undefined_symbol_1640
+def undef_fn_1641() -> int:
+    return undefined_symbol_1641
+def undef_fn_1642() -> int:
+    return undefined_symbol_1642
+def undef_fn_1643() -> int:
+    return undefined_symbol_1643
+def undef_fn_1644() -> int:
+    return undefined_symbol_1644
+def undef_fn_1645() -> int:
+    return undefined_symbol_1645
+def undef_fn_1646() -> int:
+    return undefined_symbol_1646
+def undef_fn_1647() -> int:
+    return undefined_symbol_1647
+def undef_fn_1648() -> int:
+    return undefined_symbol_1648
+def undef_fn_1649() -> int:
+    return undefined_symbol_1649
+def undef_fn_1650() -> int:
+    return undefined_symbol_1650
+def undef_fn_1651() -> int:
+    return undefined_symbol_1651
+def undef_fn_1652() -> int:
+    return undefined_symbol_1652
+def undef_fn_1653() -> int:
+    return undefined_symbol_1653
+def undef_fn_1654() -> int:
+    return undefined_symbol_1654
+def undef_fn_1655() -> int:
+    return undefined_symbol_1655
+def undef_fn_1656() -> int:
+    return undefined_symbol_1656
+def undef_fn_1657() -> int:
+    return undefined_symbol_1657
+def undef_fn_1658() -> int:
+    return undefined_symbol_1658
+def undef_fn_1659() -> int:
+    return undefined_symbol_1659
+def undef_fn_1660() -> int:
+    return undefined_symbol_1660
+def undef_fn_1661() -> int:
+    return undefined_symbol_1661
+def undef_fn_1662() -> int:
+    return undefined_symbol_1662
+def undef_fn_1663() -> int:
+    return undefined_symbol_1663
+def undef_fn_1664() -> int:
+    return undefined_symbol_1664
+def undef_fn_1665() -> int:
+    return undefined_symbol_1665
+def undef_fn_1666() -> int:
+    return undefined_symbol_1666
+def undef_fn_1667() -> int:
+    return undefined_symbol_1667
+def undef_fn_1668() -> int:
+    return undefined_symbol_1668
+def undef_fn_1669() -> int:
+    return undefined_symbol_1669
+def undef_fn_1670() -> int:
+    return undefined_symbol_1670
+def undef_fn_1671() -> int:
+    return undefined_symbol_1671
+def undef_fn_1672() -> int:
+    return undefined_symbol_1672
+def undef_fn_1673() -> int:
+    return undefined_symbol_1673
+def undef_fn_1674() -> int:
+    return undefined_symbol_1674
+def undef_fn_1675() -> int:
+    return undefined_symbol_1675
+def undef_fn_1676() -> int:
+    return undefined_symbol_1676
+def undef_fn_1677() -> int:
+    return undefined_symbol_1677
+def undef_fn_1678() -> int:
+    return undefined_symbol_1678
+def undef_fn_1679() -> int:
+    return undefined_symbol_1679
+def undef_fn_1680() -> int:
+    return undefined_symbol_1680
+def undef_fn_1681() -> int:
+    return undefined_symbol_1681
+def undef_fn_1682() -> int:
+    return undefined_symbol_1682
+def undef_fn_1683() -> int:
+    return undefined_symbol_1683
+def undef_fn_1684() -> int:
+    return undefined_symbol_1684
+def undef_fn_1685() -> int:
+    return undefined_symbol_1685
+def undef_fn_1686() -> int:
+    return undefined_symbol_1686
+def undef_fn_1687() -> int:
+    return undefined_symbol_1687
+def undef_fn_1688() -> int:
+    return undefined_symbol_1688
+def undef_fn_1689() -> int:
+    return undefined_symbol_1689
+def undef_fn_1690() -> int:
+    return undefined_symbol_1690
+def undef_fn_1691() -> int:
+    return undefined_symbol_1691
+def undef_fn_1692() -> int:
+    return undefined_symbol_1692
+def undef_fn_1693() -> int:
+    return undefined_symbol_1693
+def undef_fn_1694() -> int:
+    return undefined_symbol_1694
+def undef_fn_1695() -> int:
+    return undefined_symbol_1695
+def undef_fn_1696() -> int:
+    return undefined_symbol_1696
+def undef_fn_1697() -> int:
+    return undefined_symbol_1697
+def undef_fn_1698() -> int:
+    return undefined_symbol_1698
+def undef_fn_1699() -> int:
+    return undefined_symbol_1699
+def undef_fn_1700() -> int:
+    return undefined_symbol_1700
+def undef_fn_1701() -> int:
+    return undefined_symbol_1701
+def undef_fn_1702() -> int:
+    return undefined_symbol_1702
+def undef_fn_1703() -> int:
+    return undefined_symbol_1703
+def undef_fn_1704() -> int:
+    return undefined_symbol_1704
+def undef_fn_1705() -> int:
+    return undefined_symbol_1705
+def undef_fn_1706() -> int:
+    return undefined_symbol_1706
+def undef_fn_1707() -> int:
+    return undefined_symbol_1707
+def undef_fn_1708() -> int:
+    return undefined_symbol_1708
+def undef_fn_1709() -> int:
+    return undefined_symbol_1709
+def undef_fn_1710() -> int:
+    return undefined_symbol_1710
+def undef_fn_1711() -> int:
+    return undefined_symbol_1711
+def undef_fn_1712() -> int:
+    return undefined_symbol_1712
+def undef_fn_1713() -> int:
+    return undefined_symbol_1713
+def undef_fn_1714() -> int:
+    return undefined_symbol_1714
+def undef_fn_1715() -> int:
+    return undefined_symbol_1715
+def undef_fn_1716() -> int:
+    return undefined_symbol_1716
+def undef_fn_1717() -> int:
+    return undefined_symbol_1717
+def undef_fn_1718() -> int:
+    return undefined_symbol_1718
+def undef_fn_1719() -> int:
+    return undefined_symbol_1719
+def undef_fn_1720() -> int:
+    return undefined_symbol_1720
+def undef_fn_1721() -> int:
+    return undefined_symbol_1721
+def undef_fn_1722() -> int:
+    return undefined_symbol_1722
+def undef_fn_1723() -> int:
+    return undefined_symbol_1723
+def undef_fn_1724() -> int:
+    return undefined_symbol_1724
+def undef_fn_1725() -> int:
+    return undefined_symbol_1725
+def undef_fn_1726() -> int:
+    return undefined_symbol_1726
+def undef_fn_1727() -> int:
+    return undefined_symbol_1727
+def undef_fn_1728() -> int:
+    return undefined_symbol_1728
+def undef_fn_1729() -> int:
+    return undefined_symbol_1729
+def undef_fn_1730() -> int:
+    return undefined_symbol_1730
+def undef_fn_1731() -> int:
+    return undefined_symbol_1731
+def undef_fn_1732() -> int:
+    return undefined_symbol_1732
+def undef_fn_1733() -> int:
+    return undefined_symbol_1733
+def undef_fn_1734() -> int:
+    return undefined_symbol_1734
+def undef_fn_1735() -> int:
+    return undefined_symbol_1735
+def undef_fn_1736() -> int:
+    return undefined_symbol_1736
+def undef_fn_1737() -> int:
+    return undefined_symbol_1737
+def undef_fn_1738() -> int:
+    return undefined_symbol_1738
+def undef_fn_1739() -> int:
+    return undefined_symbol_1739
+def undef_fn_1740() -> int:
+    return undefined_symbol_1740
+def undef_fn_1741() -> int:
+    return undefined_symbol_1741
+def undef_fn_1742() -> int:
+    return undefined_symbol_1742
+def undef_fn_1743() -> int:
+    return undefined_symbol_1743
+def undef_fn_1744() -> int:
+    return undefined_symbol_1744
+def undef_fn_1745() -> int:
+    return undefined_symbol_1745
+def undef_fn_1746() -> int:
+    return undefined_symbol_1746
+def undef_fn_1747() -> int:
+    return undefined_symbol_1747
+def undef_fn_1748() -> int:
+    return undefined_symbol_1748
+def undef_fn_1749() -> int:
+    return undefined_symbol_1749
+def undef_fn_1750() -> int:
+    return undefined_symbol_1750
+def undef_fn_1751() -> int:
+    return undefined_symbol_1751
+def undef_fn_1752() -> int:
+    return undefined_symbol_1752
+def undef_fn_1753() -> int:
+    return undefined_symbol_1753
+def undef_fn_1754() -> int:
+    return undefined_symbol_1754
+def undef_fn_1755() -> int:
+    return undefined_symbol_1755
+def undef_fn_1756() -> int:
+    return undefined_symbol_1756
+def undef_fn_1757() -> int:
+    return undefined_symbol_1757
+def undef_fn_1758() -> int:
+    return undefined_symbol_1758
+def undef_fn_1759() -> int:
+    return undefined_symbol_1759
+def undef_fn_1760() -> int:
+    return undefined_symbol_1760
+def undef_fn_1761() -> int:
+    return undefined_symbol_1761
+def undef_fn_1762() -> int:
+    return undefined_symbol_1762
+def undef_fn_1763() -> int:
+    return undefined_symbol_1763
+def undef_fn_1764() -> int:
+    return undefined_symbol_1764
+def undef_fn_1765() -> int:
+    return undefined_symbol_1765
+def undef_fn_1766() -> int:
+    return undefined_symbol_1766
+def undef_fn_1767() -> int:
+    return undefined_symbol_1767
+def undef_fn_1768() -> int:
+    return undefined_symbol_1768
+def undef_fn_1769() -> int:
+    return undefined_symbol_1769
+def undef_fn_1770() -> int:
+    return undefined_symbol_1770
+def undef_fn_1771() -> int:
+    return undefined_symbol_1771
+def undef_fn_1772() -> int:
+    return undefined_symbol_1772
+def undef_fn_1773() -> int:
+    return undefined_symbol_1773
+def undef_fn_1774() -> int:
+    return undefined_symbol_1774
+def undef_fn_1775() -> int:
+    return undefined_symbol_1775
+def undef_fn_1776() -> int:
+    return undefined_symbol_1776
+def undef_fn_1777() -> int:
+    return undefined_symbol_1777
+def undef_fn_1778() -> int:
+    return undefined_symbol_1778
+def undef_fn_1779() -> int:
+    return undefined_symbol_1779
+def undef_fn_1780() -> int:
+    return undefined_symbol_1780
+def undef_fn_1781() -> int:
+    return undefined_symbol_1781
+def undef_fn_1782() -> int:
+    return undefined_symbol_1782
+def undef_fn_1783() -> int:
+    return undefined_symbol_1783
+def undef_fn_1784() -> int:
+    return undefined_symbol_1784
+def undef_fn_1785() -> int:
+    return undefined_symbol_1785
+def undef_fn_1786() -> int:
+    return undefined_symbol_1786
+def undef_fn_1787() -> int:
+    return undefined_symbol_1787
+def undef_fn_1788() -> int:
+    return undefined_symbol_1788
+def undef_fn_1789() -> int:
+    return undefined_symbol_1789
+def undef_fn_1790() -> int:
+    return undefined_symbol_1790
+def undef_fn_1791() -> int:
+    return undefined_symbol_1791
+def undef_fn_1792() -> int:
+    return undefined_symbol_1792
+def undef_fn_1793() -> int:
+    return undefined_symbol_1793
+def undef_fn_1794() -> int:
+    return undefined_symbol_1794
+def undef_fn_1795() -> int:
+    return undefined_symbol_1795
+def undef_fn_1796() -> int:
+    return undefined_symbol_1796
+def undef_fn_1797() -> int:
+    return undefined_symbol_1797
+def undef_fn_1798() -> int:
+    return undefined_symbol_1798
+def undef_fn_1799() -> int:
+    return undefined_symbol_1799
+def undef_fn_1800() -> int:
+    return undefined_symbol_1800
+def undef_fn_1801() -> int:
+    return undefined_symbol_1801
+def undef_fn_1802() -> int:
+    return undefined_symbol_1802
+def undef_fn_1803() -> int:
+    return undefined_symbol_1803
+def undef_fn_1804() -> int:
+    return undefined_symbol_1804
+def undef_fn_1805() -> int:
+    return undefined_symbol_1805
+def undef_fn_1806() -> int:
+    return undefined_symbol_1806
+def undef_fn_1807() -> int:
+    return undefined_symbol_1807
+def undef_fn_1808() -> int:
+    return undefined_symbol_1808
+def undef_fn_1809() -> int:
+    return undefined_symbol_1809
+def undef_fn_1810() -> int:
+    return undefined_symbol_1810
+def undef_fn_1811() -> int:
+    return undefined_symbol_1811
+def undef_fn_1812() -> int:
+    return undefined_symbol_1812
+def undef_fn_1813() -> int:
+    return undefined_symbol_1813
+def undef_fn_1814() -> int:
+    return undefined_symbol_1814
+def undef_fn_1815() -> int:
+    return undefined_symbol_1815
+def undef_fn_1816() -> int:
+    return undefined_symbol_1816
+def undef_fn_1817() -> int:
+    return undefined_symbol_1817
+def undef_fn_1818() -> int:
+    return undefined_symbol_1818
+def undef_fn_1819() -> int:
+    return undefined_symbol_1819
+def undef_fn_1820() -> int:
+    return undefined_symbol_1820
+def undef_fn_1821() -> int:
+    return undefined_symbol_1821
+def undef_fn_1822() -> int:
+    return undefined_symbol_1822
+def undef_fn_1823() -> int:
+    return undefined_symbol_1823
+def undef_fn_1824() -> int:
+    return undefined_symbol_1824
+def undef_fn_1825() -> int:
+    return undefined_symbol_1825
+def undef_fn_1826() -> int:
+    return undefined_symbol_1826
+def undef_fn_1827() -> int:
+    return undefined_symbol_1827
+def undef_fn_1828() -> int:
+    return undefined_symbol_1828
+def undef_fn_1829() -> int:
+    return undefined_symbol_1829
+def undef_fn_1830() -> int:
+    return undefined_symbol_1830
+def undef_fn_1831() -> int:
+    return undefined_symbol_1831
+def undef_fn_1832() -> int:
+    return undefined_symbol_1832
+def undef_fn_1833() -> int:
+    return undefined_symbol_1833
+def undef_fn_1834() -> int:
+    return undefined_symbol_1834
+def undef_fn_1835() -> int:
+    return undefined_symbol_1835
+def undef_fn_1836() -> int:
+    return undefined_symbol_1836
+def undef_fn_1837() -> int:
+    return undefined_symbol_1837
+def undef_fn_1838() -> int:
+    return undefined_symbol_1838
+def undef_fn_1839() -> int:
+    return undefined_symbol_1839
+def undef_fn_1840() -> int:
+    return undefined_symbol_1840
+def undef_fn_1841() -> int:
+    return undefined_symbol_1841
+def undef_fn_1842() -> int:
+    return undefined_symbol_1842
+def undef_fn_1843() -> int:
+    return undefined_symbol_1843
+def undef_fn_1844() -> int:
+    return undefined_symbol_1844
+def undef_fn_1845() -> int:
+    return undefined_symbol_1845
+def undef_fn_1846() -> int:
+    return undefined_symbol_1846
+def undef_fn_1847() -> int:
+    return undefined_symbol_1847
+def undef_fn_1848() -> int:
+    return undefined_symbol_1848
+def undef_fn_1849() -> int:
+    return undefined_symbol_1849
+def undef_fn_1850() -> int:
+    return undefined_symbol_1850
+def undef_fn_1851() -> int:
+    return undefined_symbol_1851
+def undef_fn_1852() -> int:
+    return undefined_symbol_1852
+def undef_fn_1853() -> int:
+    return undefined_symbol_1853
+def undef_fn_1854() -> int:
+    return undefined_symbol_1854
+def undef_fn_1855() -> int:
+    return undefined_symbol_1855
+def undef_fn_1856() -> int:
+    return undefined_symbol_1856
+def undef_fn_1857() -> int:
+    return undefined_symbol_1857
+def undef_fn_1858() -> int:
+    return undefined_symbol_1858
+def undef_fn_1859() -> int:
+    return undefined_symbol_1859
+def undef_fn_1860() -> int:
+    return undefined_symbol_1860
+def undef_fn_1861() -> int:
+    return undefined_symbol_1861
+def undef_fn_1862() -> int:
+    return undefined_symbol_1862
+def undef_fn_1863() -> int:
+    return undefined_symbol_1863
+def undef_fn_1864() -> int:
+    return undefined_symbol_1864
+def undef_fn_1865() -> int:
+    return undefined_symbol_1865
+def undef_fn_1866() -> int:
+    return undefined_symbol_1866
+def undef_fn_1867() -> int:
+    return undefined_symbol_1867
+def undef_fn_1868() -> int:
+    return undefined_symbol_1868
+def undef_fn_1869() -> int:
+    return undefined_symbol_1869
+def undef_fn_1870() -> int:
+    return undefined_symbol_1870
+def undef_fn_1871() -> int:
+    return undefined_symbol_1871
+def undef_fn_1872() -> int:
+    return undefined_symbol_1872
+def undef_fn_1873() -> int:
+    return undefined_symbol_1873
+def undef_fn_1874() -> int:
+    return undefined_symbol_1874
+def undef_fn_1875() -> int:
+    return undefined_symbol_1875
+def undef_fn_1876() -> int:
+    return undefined_symbol_1876
+def undef_fn_1877() -> int:
+    return undefined_symbol_1877
+def undef_fn_1878() -> int:
+    return undefined_symbol_1878
+def undef_fn_1879() -> int:
+    return undefined_symbol_1879
+def undef_fn_1880() -> int:
+    return undefined_symbol_1880
+def undef_fn_1881() -> int:
+    return undefined_symbol_1881
+def undef_fn_1882() -> int:
+    return undefined_symbol_1882
+def undef_fn_1883() -> int:
+    return undefined_symbol_1883
+def undef_fn_1884() -> int:
+    return undefined_symbol_1884
+def undef_fn_1885() -> int:
+    return undefined_symbol_1885
+def undef_fn_1886() -> int:
+    return undefined_symbol_1886
+def undef_fn_1887() -> int:
+    return undefined_symbol_1887
+def undef_fn_1888() -> int:
+    return undefined_symbol_1888
+def undef_fn_1889() -> int:
+    return undefined_symbol_1889
+def undef_fn_1890() -> int:
+    return undefined_symbol_1890
+def undef_fn_1891() -> int:
+    return undefined_symbol_1891
+def undef_fn_1892() -> int:
+    return undefined_symbol_1892
+def undef_fn_1893() -> int:
+    return undefined_symbol_1893
+def undef_fn_1894() -> int:
+    return undefined_symbol_1894
+def undef_fn_1895() -> int:
+    return undefined_symbol_1895
+def undef_fn_1896() -> int:
+    return undefined_symbol_1896
+def undef_fn_1897() -> int:
+    return undefined_symbol_1897
+def undef_fn_1898() -> int:
+    return undefined_symbol_1898
+def undef_fn_1899() -> int:
+    return undefined_symbol_1899
+def undef_fn_1900() -> int:
+    return undefined_symbol_1900
+def undef_fn_1901() -> int:
+    return undefined_symbol_1901
+def undef_fn_1902() -> int:
+    return undefined_symbol_1902
+def undef_fn_1903() -> int:
+    return undefined_symbol_1903
+def undef_fn_1904() -> int:
+    return undefined_symbol_1904
+def undef_fn_1905() -> int:
+    return undefined_symbol_1905
+def undef_fn_1906() -> int:
+    return undefined_symbol_1906
+def undef_fn_1907() -> int:
+    return undefined_symbol_1907
+def undef_fn_1908() -> int:
+    return undefined_symbol_1908
+def undef_fn_1909() -> int:
+    return undefined_symbol_1909
+def undef_fn_1910() -> int:
+    return undefined_symbol_1910
+def undef_fn_1911() -> int:
+    return undefined_symbol_1911
+def undef_fn_1912() -> int:
+    return undefined_symbol_1912
+def undef_fn_1913() -> int:
+    return undefined_symbol_1913
+def undef_fn_1914() -> int:
+    return undefined_symbol_1914
+def undef_fn_1915() -> int:
+    return undefined_symbol_1915
+def undef_fn_1916() -> int:
+    return undefined_symbol_1916
+def undef_fn_1917() -> int:
+    return undefined_symbol_1917
+def undef_fn_1918() -> int:
+    return undefined_symbol_1918
+def undef_fn_1919() -> int:
+    return undefined_symbol_1919
+def undef_fn_1920() -> int:
+    return undefined_symbol_1920
+def undef_fn_1921() -> int:
+    return undefined_symbol_1921
+def undef_fn_1922() -> int:
+    return undefined_symbol_1922
+def undef_fn_1923() -> int:
+    return undefined_symbol_1923
+def undef_fn_1924() -> int:
+    return undefined_symbol_1924
+def undef_fn_1925() -> int:
+    return undefined_symbol_1925
+def undef_fn_1926() -> int:
+    return undefined_symbol_1926
+def undef_fn_1927() -> int:
+    return undefined_symbol_1927
+def undef_fn_1928() -> int:
+    return undefined_symbol_1928
+def undef_fn_1929() -> int:
+    return undefined_symbol_1929
+def undef_fn_1930() -> int:
+    return undefined_symbol_1930
+def undef_fn_1931() -> int:
+    return undefined_symbol_1931
+def undef_fn_1932() -> int:
+    return undefined_symbol_1932
+def undef_fn_1933() -> int:
+    return undefined_symbol_1933
+def undef_fn_1934() -> int:
+    return undefined_symbol_1934
+def undef_fn_1935() -> int:
+    return undefined_symbol_1935
+def undef_fn_1936() -> int:
+    return undefined_symbol_1936
+def undef_fn_1937() -> int:
+    return undefined_symbol_1937
+def undef_fn_1938() -> int:
+    return undefined_symbol_1938
+def undef_fn_1939() -> int:
+    return undefined_symbol_1939
+def undef_fn_1940() -> int:
+    return undefined_symbol_1940
+def undef_fn_1941() -> int:
+    return undefined_symbol_1941
+def undef_fn_1942() -> int:
+    return undefined_symbol_1942
+def undef_fn_1943() -> int:
+    return undefined_symbol_1943
+def undef_fn_1944() -> int:
+    return undefined_symbol_1944
+def undef_fn_1945() -> int:
+    return undefined_symbol_1945
+def undef_fn_1946() -> int:
+    return undefined_symbol_1946
+def undef_fn_1947() -> int:
+    return undefined_symbol_1947
+def undef_fn_1948() -> int:
+    return undefined_symbol_1948
+def undef_fn_1949() -> int:
+    return undefined_symbol_1949
+def undef_fn_1950() -> int:
+    return undefined_symbol_1950
+def undef_fn_1951() -> int:
+    return undefined_symbol_1951
+def undef_fn_1952() -> int:
+    return undefined_symbol_1952
+def undef_fn_1953() -> int:
+    return undefined_symbol_1953
+def undef_fn_1954() -> int:
+    return undefined_symbol_1954
+def undef_fn_1955() -> int:
+    return undefined_symbol_1955
+def undef_fn_1956() -> int:
+    return undefined_symbol_1956
+def undef_fn_1957() -> int:
+    return undefined_symbol_1957
+def undef_fn_1958() -> int:
+    return undefined_symbol_1958
+def undef_fn_1959() -> int:
+    return undefined_symbol_1959
+def undef_fn_1960() -> int:
+    return undefined_symbol_1960
+def undef_fn_1961() -> int:
+    return undefined_symbol_1961
+def undef_fn_1962() -> int:
+    return undefined_symbol_1962
+def undef_fn_1963() -> int:
+    return undefined_symbol_1963
+def undef_fn_1964() -> int:
+    return undefined_symbol_1964
+def undef_fn_1965() -> int:
+    return undefined_symbol_1965
+def undef_fn_1966() -> int:
+    return undefined_symbol_1966
+def undef_fn_1967() -> int:
+    return undefined_symbol_1967
+def undef_fn_1968() -> int:
+    return undefined_symbol_1968
+def undef_fn_1969() -> int:
+    return undefined_symbol_1969
+def undef_fn_1970() -> int:
+    return undefined_symbol_1970
+def undef_fn_1971() -> int:
+    return undefined_symbol_1971
+def undef_fn_1972() -> int:
+    return undefined_symbol_1972
+def undef_fn_1973() -> int:
+    return undefined_symbol_1973
+def undef_fn_1974() -> int:
+    return undefined_symbol_1974
+def undef_fn_1975() -> int:
+    return undefined_symbol_1975
+def undef_fn_1976() -> int:
+    return undefined_symbol_1976
+def undef_fn_1977() -> int:
+    return undefined_symbol_1977
+def undef_fn_1978() -> int:
+    return undefined_symbol_1978
+def undef_fn_1979() -> int:
+    return undefined_symbol_1979
+def undef_fn_1980() -> int:
+    return undefined_symbol_1980
+def undef_fn_1981() -> int:
+    return undefined_symbol_1981
+def undef_fn_1982() -> int:
+    return undefined_symbol_1982
+def undef_fn_1983() -> int:
+    return undefined_symbol_1983
+def undef_fn_1984() -> int:
+    return undefined_symbol_1984
+def undef_fn_1985() -> int:
+    return undefined_symbol_1985
+def undef_fn_1986() -> int:
+    return undefined_symbol_1986
+def undef_fn_1987() -> int:
+    return undefined_symbol_1987
+def undef_fn_1988() -> int:
+    return undefined_symbol_1988
+def undef_fn_1989() -> int:
+    return undefined_symbol_1989
+def undef_fn_1990() -> int:
+    return undefined_symbol_1990
+def undef_fn_1991() -> int:
+    return undefined_symbol_1991
+def undef_fn_1992() -> int:
+    return undefined_symbol_1992
+def undef_fn_1993() -> int:
+    return undefined_symbol_1993
+def undef_fn_1994() -> int:
+    return undefined_symbol_1994
+def undef_fn_1995() -> int:
+    return undefined_symbol_1995
+def undef_fn_1996() -> int:
+    return undefined_symbol_1996
+def undef_fn_1997() -> int:
+    return undefined_symbol_1997
+def undef_fn_1998() -> int:
+    return undefined_symbol_1998
+def undef_fn_1999() -> int:
+    return undefined_symbol_1999
+def undef_fn_2000() -> int:
+    return undefined_symbol_2000

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -38,13 +38,27 @@ OUT="$ROOT/benchmarks/results"
 STATUS_DIR="$ROOT/benchmarks/status"
 RUNS="${RUNS:-10}"
 WARMUP="${WARMUP:-2}"
+# Persistent cache dirs for the warm columns of the tools that HAVE a result
+# cache (basilisk's --cache, mypy's incremental). Entries are keyed by the
+# target path, so one dir across fixtures never collides; the hyperfine warmup
+# runs populate them so the measured runs are cache hits.
+WARMCACHE="$OUT/.warmcache"
+MYPYCACHE="$OUT/.mypycache"
 # Regression gate: on by default; BENCH_NO_GATE=1 disables it and re-baselines.
 BENCH_GATE="1"; [[ -n "${BENCH_NO_GATE:-}" ]] && BENCH_GATE="0"
 BENCH_REGRESS_PCT="${BENCH_REGRESS_PCT:-25}"
 mkdir -p "$OUT" "$STATUS_DIR"
 
 # Canonical tool column order for the status CSV / website (stable schema).
-ALL_TOOLS="basilisk pyright mypy ty pyrefly"
+# Every tool gets a COLD column (full check from scratch) and a -warm column
+# (a repeat run using whatever that tool caches):
+#   * basilisk-warm  — opt-in result-cache hit (basilisk check --cache)
+#   * mypy-warm      — incremental .mypy_cache hit; cold mypy is --no-incremental
+#   * pyright/ty/pyrefly-warm — these keep NO cross-run result cache (verified:
+#     they write zero cache artifacts), so their warm is a genuine repeat run
+#     that lands ~= cold. The (near-)equality is the honest result: they do a
+#     full check every invocation.
+ALL_TOOLS="basilisk basilisk-warm pyright pyright-warm mypy mypy-warm ty ty-warm pyrefly pyrefly-warm"
 
 # ─── Preconditions ────────────────────────────────────────────────────────────
 if ! command -v hyperfine >/dev/null 2>&1; then
@@ -62,17 +76,37 @@ fi
 declare -a TOOL_NAMES=() TOOL_CMDS=()
 add_tool() { TOOL_NAMES+=("$1"); TOOL_CMDS+=("$2"); }
 
-add_tool "basilisk" "$BSK check {}"
-command -v pyright  >/dev/null 2>&1 && add_tool "pyright"  "pyright {}"
-command -v mypy     >/dev/null 2>&1 && add_tool "mypy"     "mypy --ignore-missing-imports --no-error-summary {}"
-command -v ty       >/dev/null 2>&1 && add_tool "ty"       "ty check {}"
-command -v pyrefly  >/dev/null 2>&1 && add_tool "pyrefly"  "pyrefly check {}"
+# Warm caches start empty; the hyperfine warmup populates them so the measured
+# warm runs are hits.
+rm -rf "$WARMCACHE" "$MYPYCACHE"; mkdir -p "$WARMCACHE" "$MYPYCACHE"
+add_tool "basilisk"      "$BSK check {}"
+add_tool "basilisk-warm" "$BSK check {} --cache --cache-dir $WARMCACHE"
+if command -v pyright >/dev/null 2>&1; then
+  # No result cache; warm is a genuine repeat run (~= cold).
+  add_tool "pyright"      "pyright {}"
+  add_tool "pyright-warm" "pyright {}"
+fi
+if command -v mypy >/dev/null 2>&1; then
+  # cold = --no-incremental (full check); warm = incremental .mypy_cache hit.
+  # Without --no-incremental the hyperfine warmup turned every cold measurement
+  # into a do-nothing cache hit, which is why mypy used to look flat/fast.
+  add_tool "mypy"      "mypy --no-incremental --ignore-missing-imports --no-error-summary {}"
+  add_tool "mypy-warm" "mypy --cache-dir $MYPYCACHE --ignore-missing-imports --no-error-summary {}"
+fi
+if command -v ty >/dev/null 2>&1; then
+  add_tool "ty"      "ty check {}"
+  add_tool "ty-warm" "ty check {}"
+fi
+if command -v pyrefly >/dev/null 2>&1; then
+  add_tool "pyrefly"      "pyrefly check {}"
+  add_tool "pyrefly-warm" "pyrefly check {}"
+fi
 
 version_of() {
-  local v=""
-  case "$1" in
+  local base="${1%-warm}" v=""
+  case "$base" in
     basilisk) v="$("$BSK" --version 2>&1 | head -1)" ;;
-    *)        v="$("$1" --version 2>&1 | head -1)" ;;
+    *)        v="$("$base" --version 2>&1 | head -1)" ;;
   esac
   printf '%s' "${v:-n/a}"
 }
@@ -103,9 +137,11 @@ else
   BENCH_SLUG="$(slugify "$(uname -s)-${BENCH_ARCH}-${BENCH_CPU}")"
 fi
 
-# Tool-version string for the CSV header.
+# Tool-version string for the CSV header (one entry per base tool; the `-warm`
+# variants share the same binary/version, so they are omitted to avoid clutter).
 BENCH_TOOLS=""
 for name in "${TOOL_NAMES[@]}"; do
+  case "$name" in *-warm) continue ;; esac
   BENCH_TOOLS+="${BENCH_TOOLS:+, }${name}=$(version_of "$name")"
 done
 
@@ -256,7 +292,7 @@ csv_lines = [
     f"# tools: {os.environ['BENCH_TOOLS']}",
     f"# runs: {os.environ['BENCH_RUNS']} (hyperfine mean wall-clock, milliseconds)",
     f"# generated: {os.environ['BENCH_GENERATED']}",
-    f"# note: cold full-file CLI runs; does not reflect warm incremental (LSP) speed.",
+    f"# note: <tool>_ms = COLD full-file CLI check from scratch. <tool>-warm_ms = a repeat run using that tool's own cache. basilisk-warm = --cache result-cache hit; mypy-warm = incremental .mypy_cache hit (cold mypy = --no-incremental). pyright/ty/pyrefly keep NO cross-run result cache, so their warm ~= cold (every run is a full check).",
     "fixture," + ",".join(f"{t}_ms" for t in all_tools),
 ]
 for stem, means in rows:
@@ -297,7 +333,7 @@ for FILE in "${FIXTURES[@]}"; do
   for i in "${!TOOL_NAMES[@]}"; do
     name="${TOOL_NAMES[$i]}"
     CMD="${TOOL_CMDS[$i]//\{\}/$FPATH}"
-    case "$name" in
+    case "${name%-warm}" in
       basilisk) n=$($CMD 2>/dev/null | grep -cE "error\[BSK" || true) ;;
       pyright)  n=$($CMD 2>/dev/null | grep -cE " - error:" || true) ;;
       mypy)     n=$($CMD 2>/dev/null | grep -cE ": error:" || true) ;;

--- a/benchmarks/status/darwin-arm64-apple-m4-max.csv
+++ b/benchmarks/status/darwin-arm64-apple-m4-max.csv
@@ -5,16 +5,18 @@
 # cores: 14
 # tools: basilisk=basilisk 0.0.0-PLACEHOLDER, pyright=pyright 1.1.408, mypy=mypy 1.19.1 (compiled: yes), ty=ty 0.0.19 (ae10022c2 2026-02-26), pyrefly=pyrefly 0.54.0
 # runs: 10 (hyperfine mean wall-clock, milliseconds)
-# generated: 2026-05-30T13:30:25+1000
-# note: cold full-file CLI runs; does not reflect warm incremental (LSP) speed.
-fixture,basilisk_ms,pyright_ms,mypy_ms,ty_ms,pyrefly_ms
-e0001_missing_param,362.2,510.3,150.7,29.4,121.7
-e0002_missing_return,259.9,548.4,162.2,37.7,110.7
-e0010_unresolved_import,124.1,459.8,158.5,370.4,785.4
-e0012_argument_type_mismatch,157.7,649.1,154.5,53.3,110.1
-e0014_assignment_incompatibility,97.7,588.0,157.6,50.4,109.0
-e0016_incompatible_override,153.2,638.6,159.9,53.5,117.4
-e0022_unhashable_dict_key,224.8,520.9,157.4,37.2,100.1
-e0023_nonexhaustive_match,118.6,519.6,159.1,23.5,107.5
-e0026_typevar_single_constraint,128.9,709.5,156.1,37.8,106.5
-e0054_final_reassignment,48.0,454.2,154.9,27.0,96.0
+# generated: 2026-06-04T21:24:14+1000
+# note: <tool>_ms = COLD full-file CLI check from scratch. <tool>-warm_ms = a repeat run using that tool's own cache. basilisk-warm = --cache result-cache hit; mypy-warm = incremental .mypy_cache hit (cold mypy = --no-incremental). pyright/ty/pyrefly keep NO cross-run result cache, so their warm ~= cold (every run is a full check).
+fixture,basilisk_ms,basilisk-warm_ms,pyright_ms,pyright-warm_ms,mypy_ms,mypy-warm_ms,ty_ms,ty-warm_ms,pyrefly_ms,pyrefly-warm_ms
+e0001_missing_param,348.7,234.6,506.0,515.2,611.4,156.7,29.9,30.5,106.5,104.9
+e0002_missing_return,245.8,101.5,562.8,561.8,630.5,155.7,36.3,37.1,112.0,109.5
+e0010_unresolved_import,125.4,72.2,459.6,466.2,644.5,166.3,370.3,377.8,794.5,784.3
+e0011_explicit_any,370.8,123.0,525.8,518.0,615.2,159.0,32.4,30.5,106.5,106.2
+e0012_argument_type_mismatch,148.7,56.0,655.0,650.7,618.4,162.7,59.3,54.9,115.2,112.7
+e0014_assignment_incompatibility,99.2,62.3,605.8,598.0,581.4,164.8,50.0,52.0,114.1,111.1
+e0016_incompatible_override,153.9,37.6,648.7,642.1,619.0,168.3,55.6,54.7,111.6,110.2
+e0018_undefined_name,261.4,143.9,502.1,487.4,613.9,158.0,50.3,49.6,535.8,533.9
+e0022_unhashable_dict_key,209.2,111.2,517.9,517.5,601.3,155.8,37.3,37.6,101.0,98.0
+e0023_nonexhaustive_match,118.3,39.1,528.4,523.3,592.9,156.6,25.1,24.5,107.7,104.6
+e0026_typevar_single_constraint,129.5,79.7,722.3,715.7,584.6,164.1,38.7,38.3,105.4,107.8
+e0054_final_reassignment,49.6,26.5,456.6,466.0,562.9,159.2,26.9,27.8,97.0,94.9

--- a/crates/basilisk-checker/Cargo.toml
+++ b/crates/basilisk-checker/Cargo.toml
@@ -13,9 +13,11 @@ basilisk-stubs.workspace    = true
 ruff_python_ast.workspace   = true
 ruff_text_size.workspace    = true
 basilisk-uv.workspace       = true
+serde.workspace             = true
 
 [dev-dependencies]
 basilisk-test-macros.workspace = true
+serde_json.workspace = true
 tempfile = "3"
 
 [lints]

--- a/crates/basilisk-checker/src/cached.rs
+++ b/crates/basilisk-checker/src/cached.rs
@@ -1,0 +1,96 @@
+//! Implements [CHKCACHE-DIAG] / [CHKCACHE-DIAG-INTERN].
+//! See docs/specs/CHECKER-CACHE-SPEC.md#chkcache-entry
+//!
+//! Owned, serde-serialisable projection of [`Diagnostic`] for the result cache.
+//!
+//! [`Diagnostic`] cannot itself round-trip through serde because its
+//! [`ErrorCode`] holds `&'static str` fields, which cannot be reconstructed from
+//! deserialised data. [`CachedDiagnostic`] owns its strings; on replay the
+//! `&'static` code/URL are recovered through a bounded process-wide interner
+//! (one leaked entry per distinct string — at most one per BSK code, so memory
+//! is constant regardless of how many diagnostics are replayed).
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock, PoisonError};
+
+use basilisk_resolver::Span;
+use basilisk_stubs::TypeProvenance;
+
+use crate::diagnostic::{Diagnostic, ErrorCode, Severity};
+
+/// Owned, serialisable form of a [`Diagnostic`].
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CachedDiagnostic {
+    /// Full code string, e.g. `"BSK-E0001"`.
+    pub code: String,
+    /// Documentation URL for the code.
+    pub docs_url: String,
+    /// Severity level.
+    pub severity: Severity,
+    /// Human-readable primary message.
+    pub message: String,
+    /// Highlighted source span.
+    pub span: Span,
+    /// Source file path.
+    pub path: String,
+    /// Optional help text.
+    pub help: Option<String>,
+    /// Optional note text.
+    pub note: Option<String>,
+    /// Provenance of the related type information, if any.
+    pub provenance: Option<TypeProvenance>,
+}
+
+impl From<&Diagnostic> for CachedDiagnostic {
+    fn from(diagnostic: &Diagnostic) -> Self {
+        Self {
+            code: diagnostic.code.code.to_owned(),
+            docs_url: diagnostic.code.docs_url.to_owned(),
+            severity: diagnostic.severity,
+            message: diagnostic.message.clone(),
+            span: diagnostic.span,
+            path: diagnostic.path.clone(),
+            help: diagnostic.help.clone(),
+            note: diagnostic.note.clone(),
+            provenance: diagnostic.provenance,
+        }
+    }
+}
+
+impl CachedDiagnostic {
+    /// Reconstruct a full [`Diagnostic`], recovering `&'static` code/URL via the
+    /// bounded interner.
+    #[must_use]
+    pub fn into_diagnostic(self) -> Diagnostic {
+        Diagnostic {
+            code: ErrorCode {
+                code: intern_str(&self.code),
+                docs_url: intern_str(&self.docs_url),
+            },
+            severity: self.severity,
+            message: self.message,
+            span: self.span,
+            path: self.path,
+            help: self.help,
+            note: self.note,
+            provenance: self.provenance,
+        }
+    }
+}
+
+/// Intern a string to `&'static str`, leaking at most once per distinct value.
+///
+/// The set of interned values is bounded by the finite set of BSK diagnostic
+/// codes and their documentation URLs, so total leaked memory is constant for
+/// the process lifetime.
+fn intern_str(value: &str) -> &'static str {
+    static POOL: OnceLock<Mutex<HashMap<String, &'static str>>> = OnceLock::new();
+    let pool = POOL.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = pool.lock().unwrap_or_else(PoisonError::into_inner);
+    if let Some(&existing) = guard.get(value) {
+        return existing;
+    }
+    let leaked: &'static str = Box::leak(value.to_owned().into_boxed_str());
+    let _ = guard.insert(value.to_owned(), leaked);
+    leaked
+}

--- a/crates/basilisk-checker/src/diagnostic.rs
+++ b/crates/basilisk-checker/src/diagnostic.rs
@@ -9,7 +9,9 @@ use basilisk_stubs::TypeProvenance;
 /// Every rule has a default severity determined by its code prefix (`E` = Error,
 /// `W` = Warning). All rules can be overridden to any severity at the line,
 /// block, file, path, or project level.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub enum Severity {
     /// Informational hint — does not block CI, shown as blue in LSP.
     Info,

--- a/crates/basilisk-checker/src/lib.rs
+++ b/crates/basilisk-checker/src/lib.rs
@@ -26,6 +26,7 @@
 //! - Per-module overrides (`per-module-overrides."fastmcp".ignore-missing-stubs`)
 //! - Per-path overrides (`per-path-overrides."vendor/**".rules.disabled`)
 
+pub mod cached;
 pub mod collection_inference;
 pub mod diagnostic;
 pub mod inference;
@@ -35,6 +36,7 @@ pub mod suppression;
 pub mod types;
 pub mod types_parsing;
 
+pub use cached::CachedDiagnostic;
 pub use diagnostic::{Diagnostic, ErrorCode, Severity};
 
 /// Run all rules and apply inline suppression / mode overrides.

--- a/crates/basilisk-checker/tests/cached_tests.rs
+++ b/crates/basilisk-checker/tests/cached_tests.rs
@@ -1,0 +1,69 @@
+//! Tests for [CHKCACHE-DIAG] / [CHKCACHE-DIAG-INTERN].
+//! See docs/specs/CHECKER-CACHE-SPEC.md#chkcache-entry
+#![allow(clippy::allow_attributes, clippy::unwrap_used, clippy::expect_used)]
+//! Crate-boundary tests for the serde-friendly diagnostic projection and the
+//! `&'static` code interner used on cache replay.
+
+use basilisk_checker::cached::CachedDiagnostic;
+use basilisk_checker::{Diagnostic, ErrorCode, Severity};
+use basilisk_resolver::Span;
+use basilisk_stubs::TypeProvenance;
+
+fn sample(code: &'static str, with_extras: bool) -> Diagnostic {
+    Diagnostic {
+        code: ErrorCode {
+            code,
+            docs_url: "https://www.basilisk-python.dev/errors/X",
+        },
+        severity: Severity::Error,
+        message: "boom".to_owned(),
+        span: Span::new(3, 9),
+        path: "m.py".to_owned(),
+        help: with_extras.then(|| "try this".to_owned()),
+        note: with_extras.then(|| "PEP 484".to_owned()),
+        provenance: with_extras.then_some(TypeProvenance::StubTier1),
+    }
+}
+
+#[test]
+fn projection_round_trips_through_serde_preserving_every_field() {
+    let original = sample("BSK-E0001", true);
+    let cached = CachedDiagnostic::from(&original);
+    let json = serde_json::to_string(&cached).expect("serialize");
+    let restored: CachedDiagnostic = serde_json::from_str(&json).expect("deserialize");
+    let diagnostic = restored.into_diagnostic();
+
+    assert_eq!(diagnostic.code.code, "BSK-E0001");
+    assert_eq!(diagnostic.code.docs_url, original.code.docs_url);
+    assert_eq!(diagnostic.severity, Severity::Error);
+    assert_eq!(diagnostic.message, "boom");
+    assert_eq!(diagnostic.span, Span::new(3, 9));
+    assert_eq!(diagnostic.path, "m.py");
+    assert_eq!(diagnostic.help.as_deref(), Some("try this"));
+    assert_eq!(diagnostic.note.as_deref(), Some("PEP 484"));
+    assert_eq!(diagnostic.provenance, Some(TypeProvenance::StubTier1));
+}
+
+#[test]
+fn optional_fields_round_trip_as_none() {
+    let cached = CachedDiagnostic::from(&sample("BSK-E0002", false));
+    let diagnostic = cached.into_diagnostic();
+    assert_eq!(diagnostic.help, None);
+    assert_eq!(diagnostic.note, None);
+    assert_eq!(diagnostic.provenance, None);
+}
+
+#[test]
+fn interner_reuses_static_storage_for_repeated_codes() {
+    // Two diagnostics with the same code must intern to the SAME `&'static`
+    // pointer — proving the interner returns the existing entry, not a fresh
+    // leak per replay.
+    let first = CachedDiagnostic::from(&sample("BSK-E0123", false)).into_diagnostic();
+    let second = CachedDiagnostic::from(&sample("BSK-E0123", false)).into_diagnostic();
+    assert_eq!(first.code.code, second.code.code);
+    assert!(
+        std::ptr::eq(first.code.code, second.code.code),
+        "interned code must reuse the same static storage"
+    );
+    assert!(std::ptr::eq(first.code.docs_url, second.code.docs_url));
+}

--- a/crates/basilisk-cli/Cargo.toml
+++ b/crates/basilisk-cli/Cargo.toml
@@ -16,6 +16,7 @@ basilisk-resolver.workspace = true
 basilisk-checker.workspace  = true
 basilisk-lsp.workspace      = true
 basilisk-common.workspace   = true
+basilisk-db.workspace       = true
 basilisk-uv.workspace       = true
 basilisk-stubs.workspace    = true
 clap.workspace              = true

--- a/crates/basilisk-cli/src/cache_check.rs
+++ b/crates/basilisk-cli/src/cache_check.rs
@@ -1,0 +1,180 @@
+//! Implements [CHKCACHE-CLI] / [CHKCACHE-FINGERPRINT].
+//! See docs/specs/CHECKER-CACHE-SPEC.md#chkcache-cli
+//!
+//! CLI glue for the opt-in result cache: turns the `--cache*` flags into a
+//! [`CacheContext`], wraps the per-file cold check with a lookup/store, and
+//! tracks hit/miss counts.
+
+use std::path::{Path, PathBuf};
+
+use basilisk_checker::{CachedDiagnostic, Diagnostic};
+use basilisk_common::fs::{content_hash, ReadRecorder};
+use basilisk_config::BasiliskConfig;
+use basilisk_db::cache::{CheckCache, Fingerprint};
+use basilisk_lsp::import_resolver::ImportSearchPaths;
+
+/// Parsed `--cache*` flags.
+#[derive(Debug, Clone)]
+pub struct CacheOptions {
+    /// Whether the cache is enabled (`--cache`).
+    pub enabled: bool,
+    /// Override for the cache directory (`--cache-dir`).
+    pub dir: Option<PathBuf>,
+    /// Whether to print hit/miss stats (`--cache-stats`).
+    pub stats: bool,
+}
+
+/// Running hit/miss tally for one `check` invocation.
+#[derive(Debug, Default)]
+pub struct CacheStats {
+    /// Number of cache hits.
+    pub hits: usize,
+    /// Number of cache misses (full checks).
+    pub misses: usize,
+}
+
+impl CacheStats {
+    /// Print the tally to stderr (kept off stdout so JSON output stays clean).
+    pub fn report(&self) {
+        eprintln!("cache: {} hit / {} miss", self.hits, self.misses);
+    }
+}
+
+/// A built cache plus the fingerprint of the non-file inputs for this run.
+#[derive(Debug)]
+pub struct CacheContext {
+    cache: CheckCache,
+    fingerprint: Fingerprint,
+}
+
+/// Build a [`CacheContext`] when the cache is enabled, else `None`.
+#[must_use]
+pub fn build_context(
+    options: &CacheOptions,
+    config: &BasiliskConfig,
+    search_paths: &ImportSearchPaths,
+    project_root: &Path,
+) -> Option<CacheContext> {
+    if !options.enabled {
+        return None;
+    }
+    let dir = options
+        .dir
+        .clone()
+        .unwrap_or_else(|| default_cache_dir(project_root));
+    let fingerprint = Fingerprint {
+        version: env!("CARGO_PKG_VERSION").to_owned(),
+        config_hash: hash_config(config),
+        env_hash: hash_env(search_paths, project_root),
+    };
+    Some(CacheContext {
+        cache: CheckCache::new(dir),
+        fingerprint,
+    })
+}
+
+/// Default cache location: `<project-root>/.basilisk/cache/check`.
+fn default_cache_dir(project_root: &Path) -> PathBuf {
+    project_root.join(".basilisk").join("cache").join("check")
+}
+
+/// Hash the *effective* config. Canonicalised through `serde_json::Value` so the
+/// hash is stable across runs despite `HashMap` iteration order.
+fn hash_config(config: &BasiliskConfig) -> u64 {
+    serde_json::to_value(config)
+        .ok()
+        .and_then(|value| serde_json::to_string(&value).ok())
+        .map_or(0, |json| content_hash(&json))
+}
+
+/// Hash the resolution environment: search paths plus `uv.lock` contents.
+fn hash_env(search_paths: &ImportSearchPaths, project_root: &Path) -> u64 {
+    let mut parts = vec![paths_field("roots", &search_paths.roots)];
+    parts.push(paths_field("extra", &search_paths.extra_paths));
+    parts.push(paths_field("stub", &search_paths.stub_paths));
+    parts.push(paths_field("members", &search_paths.workspace_members));
+    let site = search_paths
+        .site_packages
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    parts.push(format!("site={site}"));
+    parts.push(format!("registry={}", search_paths.registry.is_some()));
+    if let Ok(lock) = std::fs::read_to_string(project_root.join("uv.lock")) {
+        parts.push(format!("lock={}", content_hash(&lock)));
+    }
+    content_hash(&parts.join("\n"))
+}
+
+/// Render a labelled, order-preserving list of paths for the env fingerprint.
+fn paths_field(label: &str, paths: &[PathBuf]) -> String {
+    let joined = paths
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("{label}=[{joined}]")
+}
+
+/// Run a single file's check, served from cache when possible.
+///
+/// On a miss, `cold` runs under a [`ReadRecorder`] so the exact read-set is
+/// captured and stored. On a hit, the stored diagnostics are replayed and the
+/// target source is re-read for rendering.
+///
+/// # Errors
+///
+/// Propagates `cold`'s error, or an I/O error reading the source on a hit.
+pub fn check_file<F>(
+    context: Option<&CacheContext>,
+    stats: &mut CacheStats,
+    path: &str,
+    cold: F,
+) -> Result<(Vec<Diagnostic>, String), String>
+where
+    F: FnOnce() -> Result<(Vec<Diagnostic>, String), String>,
+{
+    let Some(context) = context else {
+        return cold();
+    };
+    let target = Path::new(path);
+    if let Some(hit) = context
+        .cache
+        .lookup::<Vec<CachedDiagnostic>>(target, &context.fingerprint)
+    {
+        stats.hits += 1;
+        let source = std::fs::read_to_string(path).map_err(|err| err.to_string())?;
+        let diagnostics = hit
+            .into_iter()
+            .map(CachedDiagnostic::into_diagnostic)
+            .collect();
+        return Ok((diagnostics, source));
+    }
+    stats.misses += 1;
+    store_fresh(context, target, path, cold)
+}
+
+/// Run `cold` under a recorder and persist the result.
+fn store_fresh<F>(
+    context: &CacheContext,
+    target: &Path,
+    path: &str,
+    cold: F,
+) -> Result<(Vec<Diagnostic>, String), String>
+where
+    F: FnOnce() -> Result<(Vec<Diagnostic>, String), String>,
+{
+    let recorder = ReadRecorder::start();
+    let result = cold();
+    let read_set = recorder.finish();
+    let (diagnostics, source) = result?;
+    let cached: Vec<CachedDiagnostic> = diagnostics.iter().map(CachedDiagnostic::from).collect();
+    match context
+        .cache
+        .store(target, &context.fingerprint, read_set, &cached)
+    {
+        Ok(()) => tracing::debug!(path, "cache miss: stored fresh result"),
+        Err(err) => tracing::warn!(path, %err, "failed to write cache entry"),
+    }
+    Ok((diagnostics, source))
+}

--- a/crates/basilisk-cli/src/main.rs
+++ b/crates/basilisk-cli/src/main.rs
@@ -21,6 +21,7 @@ use crate::output::{
 };
 
 mod adopt;
+mod cache_check;
 mod fix;
 mod output;
 
@@ -56,6 +57,17 @@ enum Command {
         /// When to use terminal colours: auto (default), always, or never.
         #[arg(long, default_value = "auto")]
         color: ColorMode,
+        /// Enable the opt-in result cache: unchanged files are served from a
+        /// persistent cache. A hit is returned only when the file, every file
+        /// it reads, the config, and the checker version are unchanged.
+        #[arg(long)]
+        cache: bool,
+        /// Override the cache directory (default: `<project>/.basilisk/cache/check`).
+        #[arg(long, value_name = "DIR")]
+        cache_dir: Option<std::path::PathBuf>,
+        /// Print cache hit/miss counts to stderr after checking.
+        #[arg(long)]
+        cache_stats: bool,
     },
     /// Apply autofixes to one or more files or directories.
     Fix {
@@ -194,9 +206,17 @@ fn main() -> ExitCode {
             paths,
             output,
             color,
+            cache,
+            cache_dir,
+            cache_stats,
         } => {
             color.apply();
-            run_check(&paths, output)
+            let cache_options = cache_check::CacheOptions {
+                enabled: cache,
+                dir: cache_dir,
+                stats: cache_stats,
+            };
+            run_check(&paths, output, &cache_options)
         }
         Command::Fix {
             paths,
@@ -403,8 +423,13 @@ fn run_stubs_status() -> u8 {
 /// - `0` — clean, no errors
 /// - `1` — type errors found
 /// - `3` — internal error
-fn run_check(paths: &[String], format: OutputFormat) -> u8 {
-    match collect_and_check(paths) {
+fn run_check(paths: &[String], format: OutputFormat, cache: &cache_check::CacheOptions) -> u8 {
+    let mut stats = cache_check::CacheStats::default();
+    let result = collect_and_check(paths, cache, &mut stats);
+    if cache.stats {
+        stats.report();
+    }
+    match result {
         Ok((diagnostics, sources)) => match format {
             OutputFormat::Json => {
                 render_diagnostics_json(&diagnostics, &sources);
@@ -446,6 +471,8 @@ fn run_check(paths: &[String], format: OutputFormat) -> u8 {
 
 fn collect_and_check(
     paths: &[String],
+    cache: &cache_check::CacheOptions,
+    stats: &mut cache_check::CacheStats,
 ) -> Result<(Vec<basilisk_checker::Diagnostic>, Vec<FileSource>), String> {
     // Load config from the first path's directory (or cwd).
     let config_root = paths
@@ -508,11 +535,16 @@ fn collect_and_check(
         "built import search paths"
     );
 
+    let cache_context = cache_check::build_context(cache, &config, &search_paths, &project_root);
+
     let mut all_diagnostics = Vec::new();
     let mut sources = Vec::new();
 
     for path in python_files {
-        match process_file(&path, &search_paths, &config) {
+        let outcome = cache_check::check_file(cache_context.as_ref(), stats, &path, || {
+            process_file(&path, &search_paths, &config)
+        });
+        match outcome {
             Ok((diags, source)) => {
                 all_diagnostics.extend(diags);
                 sources.push(FileSource { path, text: source });
@@ -685,6 +717,22 @@ mod tests {
         basilisk_config::DEFAULT_EXCLUDES.iter().copied().collect()
     }
 
+    /// Disabled cache options for tests that exercise the plain check pipeline.
+    fn no_cache() -> cache_check::CacheOptions {
+        cache_check::CacheOptions {
+            enabled: false,
+            dir: None,
+            stats: false,
+        }
+    }
+
+    /// Run `collect_and_check` with the cache disabled and a throwaway tally.
+    fn collect_and_check_uncached(
+        paths: &[String],
+    ) -> Result<(Vec<basilisk_checker::Diagnostic>, Vec<FileSource>), String> {
+        collect_and_check(paths, &no_cache(), &mut cache_check::CacheStats::default())
+    }
+
     // ── collect_python_files ──────────────────────────────────────────────────
 
     #[test]
@@ -718,7 +766,7 @@ mod tests {
         std::fs::set_permissions(&py, std::fs::Permissions::from_mode(0o000))?;
 
         let path = py.to_string_lossy().into_owned();
-        let result = collect_and_check(&[path]);
+        let result = collect_and_check_uncached(&[path]);
         std::fs::set_permissions(&py, std::fs::Permissions::from_mode(0o644))?;
         let _ = std::fs::remove_file(&py);
 
@@ -773,7 +821,7 @@ mod tests {
         let py = dir.join("basilisk_test_bad_code.py");
         std::fs::write(&py, b"def foo(x):\n    pass\n")?;
         let path = py.to_string_lossy().into_owned();
-        let (diags, _) = collect_and_check(&[path])?;
+        let (diags, _) = collect_and_check_uncached(&[path])?;
         let _ = std::fs::remove_file(&py);
         assert!(
             !diags.is_empty(),
@@ -812,7 +860,7 @@ mod tests {
         std::fs::write(&py, b"x: int = 42\n")?;
 
         let path = py.to_string_lossy().into_owned();
-        let (diags, _) = collect_and_check(&[path])?;
+        let (diags, _) = collect_and_check_uncached(&[path])?;
         let _ = std::fs::remove_dir_all(&dir);
 
         let w0050: Vec<_> = diags
@@ -840,7 +888,7 @@ mod tests {
         let py = dir.join("basilisk_test_clean_code.py");
         std::fs::write(&py, b"def greet(name: str) -> str:\n    return name\n")?;
         let path = py.to_string_lossy().into_owned();
-        let (diags, _) = collect_and_check(&[path])?;
+        let (diags, _) = collect_and_check_uncached(&[path])?;
         let _ = std::fs::remove_file(&py);
         assert!(
             diags.is_empty(),
@@ -870,7 +918,7 @@ mod tests {
         let py = dir.join("basilisk_test_rc_json_bad.py");
         std::fs::write(&py, b"def foo(x) -> None:\n    pass\n")?;
         let path = py.to_string_lossy().into_owned();
-        let code = run_check(&[path], OutputFormat::Json);
+        let code = run_check(&[path], OutputFormat::Json, &no_cache());
         let _ = std::fs::remove_file(&py);
         assert_eq!(code, 1, "bad code must make run_check return 1 (Json)");
         Ok(())
@@ -884,7 +932,7 @@ mod tests {
         let py = dir.join("basilisk_test_rc_json_clean.py");
         std::fs::write(&py, b"def greet(name: str) -> str:\n    return name\n")?;
         let path = py.to_string_lossy().into_owned();
-        let code = run_check(&[path], OutputFormat::Json);
+        let code = run_check(&[path], OutputFormat::Json, &no_cache());
         let _ = std::fs::remove_file(&py);
         assert_eq!(code, 0, "clean code must make run_check return 0 (Json)");
         Ok(())
@@ -898,7 +946,7 @@ mod tests {
         let py = dir.join("basilisk_test_rc_text_bad.py");
         std::fs::write(&py, b"def foo(x) -> None:\n    pass\n")?;
         let path = py.to_string_lossy().into_owned();
-        let code = run_check(&[path], OutputFormat::Text);
+        let code = run_check(&[path], OutputFormat::Text, &no_cache());
         let _ = std::fs::remove_file(&py);
         assert_eq!(code, 1, "bad code must make run_check return 1 (Text)");
         Ok(())
@@ -912,7 +960,7 @@ mod tests {
         let py = dir.join("basilisk_test_rc_text_clean.py");
         std::fs::write(&py, b"def greet(name: str) -> str:\n    return name\n")?;
         let path = py.to_string_lossy().into_owned();
-        let code = run_check(&[path], OutputFormat::Text);
+        let code = run_check(&[path], OutputFormat::Text, &no_cache());
         let _ = std::fs::remove_file(&py);
         assert_eq!(code, 0, "clean code must make run_check return 0 (Text)");
         Ok(())
@@ -921,7 +969,11 @@ mod tests {
     /// `run_check` internal error path: nonexistent path must return 3.
     #[test]
     fn run_check_nonexistent_path_returns_three() {
-        let code = run_check(&["/no/such/path.py".to_owned()], OutputFormat::Text);
+        let code = run_check(
+            &["/no/such/path.py".to_owned()],
+            OutputFormat::Text,
+            &no_cache(),
+        );
         assert_eq!(code, 3, "nonexistent path must make run_check return 3");
     }
 
@@ -952,7 +1004,7 @@ mod tests {
             b"def foo(x) -> None:  # type: warning[BSK-E0001]\n    pass\n",
         )?;
         let path = py.to_string_lossy().into_owned();
-        let code = run_check(&[path], OutputFormat::Text);
+        let code = run_check(&[path], OutputFormat::Text, &no_cache());
         let _ = std::fs::remove_file(&py);
         assert_eq!(
             code, 0,
@@ -971,7 +1023,7 @@ mod tests {
             b"def foo(x) -> None:  # type: warning[BSK-E0001]\n    pass\n",
         )?;
         let path = py.to_string_lossy().into_owned();
-        let code = run_check(&[path], OutputFormat::Json);
+        let code = run_check(&[path], OutputFormat::Json, &no_cache());
         let _ = std::fs::remove_file(&py);
         assert_eq!(
             code, 0,

--- a/crates/basilisk-cli/tests/e2e_cache.rs
+++ b/crates/basilisk-cli/tests/e2e_cache.rs
@@ -1,0 +1,199 @@
+//! Tests for [CHKCACHE]. See docs/specs/CHECKER-CACHE-SPEC.md
+#![allow(
+    clippy::allow_attributes,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+//! Coarse end-to-end tests for the opt-in result cache.
+//!
+//! Every test spawns the compiled `basilisk` binary, so it exercises the real
+//! flag parsing, fingerprinting, read-set capture, on-disk entry, and replay.
+//! The cardinal property under test is the [CHKCACHE-CONTRACT] guarantee: a hit
+//! is returned only when nothing that affects the diagnostics has changed, so
+//! the cache can never report a stale (wrong) result.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A throwaway directory unique to this process and call, holding both the
+/// checked sources and the cache so tests never collide or touch the repo.
+fn unique_dir(prefix: &str) -> PathBuf {
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("bsk_cache_{prefix}_{}_{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Run `basilisk check <target> --cache --cache-dir <cache> --cache-stats`.
+fn check_cached(target: &PathBuf, cache: &PathBuf) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_basilisk"))
+        .arg("check")
+        .arg(target)
+        .arg("--cache")
+        .arg("--cache-dir")
+        .arg(cache)
+        .arg("--cache-stats")
+        .output()
+        .expect("spawn basilisk")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// Assert the `--cache-stats` line reports the expected hit/miss counts.
+fn assert_stats(output: &Output, hits: usize, misses: usize) {
+    let line = format!("cache: {hits} hit / {misses} miss");
+    assert!(
+        stderr(output).contains(&line),
+        "expected `{line}` in stderr, got:\n{}",
+        stderr(output)
+    );
+}
+
+// ── CHKCACHE-TEST-HIT / CHKCACHE-TEST-STATS ─────────────────────────────────
+
+/// A second run is a hit and replays byte-identical diagnostics.
+#[test]
+fn second_run_hits_with_identical_output() {
+    let dir = unique_dir("hit");
+    let target = dir.join("t.py");
+    let cache = dir.join("cache");
+    std::fs::write(&target, "def f(x):\n    return x\n").unwrap();
+
+    let first = check_cached(&target, &cache);
+    assert_stats(&first, 0, 1);
+    let second = check_cached(&target, &cache);
+    assert_stats(&second, 1, 0);
+
+    assert_eq!(
+        stdout(&first),
+        stdout(&second),
+        "a cache hit must replay byte-identical diagnostics"
+    );
+    assert!(
+        stdout(&first).contains("BSK-E0001"),
+        "the fixture must produce a diagnostic to make the parity check meaningful"
+    );
+    assert_eq!(
+        first.status.code(),
+        second.status.code(),
+        "exit code parity"
+    );
+}
+
+// ── CHKCACHE-TEST-TARGET ────────────────────────────────────────────────────
+
+/// Editing the target between runs yields a fresh result, never the stale one.
+#[test]
+fn editing_target_invalidates() {
+    let dir = unique_dir("target");
+    let target = dir.join("t.py");
+    let cache = dir.join("cache");
+
+    std::fs::write(&target, "def f(x):\n    return x\n").unwrap();
+    let first = check_cached(&target, &cache);
+    assert!(
+        stdout(&first).contains("BSK-E0001"),
+        "first run reports error"
+    );
+
+    // Fix the error; the cached entry must NOT be served.
+    std::fs::write(&target, "def f(x: int) -> int:\n    return x\n").unwrap();
+    let second = check_cached(&target, &cache);
+    assert_stats(&second, 0, 1);
+    assert!(
+        !stdout(&second).contains("BSK-E0001"),
+        "stale cached diagnostics must not survive a target edit:\n{}",
+        stdout(&second)
+    );
+    assert_eq!(second.status.code(), Some(0), "fixed file must exit clean");
+}
+
+// ── CHKCACHE-TEST-DEP ───────────────────────────────────────────────────────
+
+/// Editing an imported dependency invalidates the importer's cached result.
+#[test]
+fn editing_dependency_invalidates() {
+    let dir = unique_dir("dep");
+    let importer = dir.join("a.py");
+    let dependency = dir.join("b.py");
+    let cache = dir.join("cache");
+    std::fs::write(
+        &importer,
+        "from b import helper\n\ndef use() -> int:\n    return helper()\n",
+    )
+    .unwrap();
+    std::fs::write(&dependency, "def helper() -> int:\n    return 1\n").unwrap();
+
+    assert_stats(&check_cached(&importer, &cache), 0, 1);
+    assert_stats(&check_cached(&importer, &cache), 1, 0);
+
+    // Touch the dependency: the importer must be re-checked, not served stale.
+    std::fs::write(&dependency, "def helper() -> str:\n    return \"x\"\n").unwrap();
+    assert_stats(&check_cached(&importer, &cache), 0, 1);
+}
+
+// ── CHKCACHE-TEST-CONFIG ────────────────────────────────────────────────────
+
+/// A config change forces a miss even when every source file is unchanged.
+#[test]
+fn changing_config_invalidates() {
+    let dir = unique_dir("config");
+    let target = dir.join("m.py");
+    let cache = dir.join("cache");
+    let pyproject = dir.join("pyproject.toml");
+    std::fs::write(&target, "x: int = 42\n").unwrap();
+    std::fs::write(
+        &pyproject,
+        "[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk.rules]\n\"BSK-W0050\" = \"warning\"\n",
+    )
+    .unwrap();
+
+    assert_stats(&check_cached(&target, &cache), 0, 1);
+    assert_stats(&check_cached(&target, &cache), 1, 0);
+
+    // Same source, different config: the fingerprint must differ → miss.
+    std::fs::write(
+        &pyproject,
+        "[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk.rules]\n\"BSK-W0050\" = \"error\"\n",
+    )
+    .unwrap();
+    assert_stats(&check_cached(&target, &cache), 0, 1);
+}
+
+// ── CHKCACHE-TEST-DISABLED ──────────────────────────────────────────────────
+
+/// Without `--cache`, no cache directory is created and output is unchanged.
+#[test]
+fn disabled_creates_no_cache_dir() {
+    let dir = unique_dir("disabled");
+    let target = dir.join("t.py");
+    std::fs::write(&target, "def f(x):\n    return x\n").unwrap();
+
+    let plain = Command::new(env!("CARGO_BIN_EXE_basilisk"))
+        .arg("check")
+        .arg(&target)
+        .output()
+        .expect("spawn basilisk");
+
+    assert!(
+        !dir.join(".basilisk").exists(),
+        "no cache directory may be created without --cache"
+    );
+    assert!(
+        stdout(&plain).contains("BSK-E0001"),
+        "plain check output must be unchanged"
+    );
+    assert!(
+        !stderr(&plain).contains("cache:"),
+        "no cache stats without --cache-stats"
+    );
+}

--- a/crates/basilisk-common/src/fs.rs
+++ b/crates/basilisk-common/src/fs.rs
@@ -1,0 +1,102 @@
+//! Implements [CHKCACHE-READSET-FS] / [CHKCACHE-READSET-GUARD].
+//! See docs/specs/CHECKER-CACHE-SPEC.md#chkcache-readset
+//!
+//! File reads with optional read-set recording for the result cache.
+//!
+//! All checker file reads (`basilisk_parser::parse_file`,
+//! `basilisk_stubs::parse_pyi_file`) route through [`read_tracked`]. When a
+//! [`ReadRecorder`] guard is active on the current thread, every read records
+//! `(canonical_path -> content_hash)`. With no recorder active the behaviour is
+//! byte-for-byte identical to `std::fs::read_to_string`, so the LSP and
+//! non-cached CLI runs are unaffected.
+//!
+//! This is std-only (no external dependency) so the crate still compiles to the
+//! WASM target the Zed extension requires.
+
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
+use std::io;
+use std::path::Path;
+
+/// A recorded read-set: canonical path -> content hash, ordered for
+/// deterministic fingerprinting.
+pub type ReadSet = BTreeMap<String, u64>;
+
+thread_local! {
+    static RECORDER: RefCell<Option<ReadSet>> = const { RefCell::new(None) };
+}
+
+/// Compute a content hash for change detection (non-cryptographic).
+///
+/// Equal hashes mean equal content for the purposes of cache invalidation; the
+/// cache re-verifies every input individually, so this is only ever used to
+/// detect *change*, never to prove identity across a trust boundary.
+#[must_use]
+pub fn content_hash(content: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    content.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Read a file to a string, recording it into the active [`ReadRecorder`] (if
+/// any) on the current thread.
+///
+/// # Errors
+///
+/// Propagates any [`std::io::Error`] from reading `path`.
+pub fn read_tracked(path: &Path) -> io::Result<String> {
+    let content = std::fs::read_to_string(path)?;
+    RECORDER.with(|cell| {
+        if let Some(set) = cell.borrow_mut().as_mut() {
+            let _ = set.insert(canonical_key(path), content_hash(&content));
+        }
+    });
+    Ok(content)
+}
+
+/// Canonicalise a path for use as a stable read-set key, falling back to the
+/// original path when canonicalisation fails (e.g. the file was just removed).
+#[must_use]
+pub fn canonical_key(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// RAII guard recording the files read via [`read_tracked`] on the current
+/// thread for its lifetime.
+///
+/// Starting a recorder replaces any in-progress one; dropping it without calling
+/// [`ReadRecorder::finish`] clears the thread-local so a later check never
+/// inherits a stale read-set.
+#[derive(Debug)]
+#[must_use = "a ReadRecorder records nothing useful unless its read-set is taken via finish()"]
+pub struct ReadRecorder {
+    _private: (),
+}
+
+impl ReadRecorder {
+    /// Begin recording reads on the current thread.
+    pub fn start() -> Self {
+        RECORDER.with(|cell| *cell.borrow_mut() = Some(ReadSet::new()));
+        Self { _private: () }
+    }
+
+    /// Stop recording and return the recorded read-set.
+    #[must_use]
+    pub fn finish(self) -> ReadSet {
+        RECORDER
+            .with(|cell| cell.borrow_mut().take())
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for ReadRecorder {
+    fn drop(&mut self) {
+        RECORDER.with(|cell| {
+            let _ = cell.borrow_mut().take();
+        });
+    }
+}

--- a/crates/basilisk-common/src/lib.rs
+++ b/crates/basilisk-common/src/lib.rs
@@ -5,6 +5,8 @@
 //! and `wasm32-wasip1` (required by the Zed extension). Any constant or type
 //! that appears in more than one crate or editor extension belongs here.
 
+pub mod fs;
+
 /// Custom LSP method names used by Basilisk.
 ///
 /// These are the method strings registered as execute-command capabilities

--- a/crates/basilisk-common/tests/fs_tests.rs
+++ b/crates/basilisk-common/tests/fs_tests.rs
@@ -1,0 +1,95 @@
+//! Tests for [CHKCACHE-READSET-FS] / [CHKCACHE-READSET-GUARD].
+//! See docs/specs/CHECKER-CACHE-SPEC.md#chkcache-readset
+#![allow(clippy::allow_attributes, clippy::unwrap_used, clippy::expect_used)]
+//! Crate-boundary tests for the read-tracking filesystem layer.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use basilisk_common::fs::{canonical_key, content_hash, read_tracked, ReadRecorder};
+
+fn temp_file(name: &str, contents: &str) -> PathBuf {
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let path = std::env::temp_dir().join(format!("bsk_fs_{}_{n}_{name}", std::process::id()));
+    std::fs::write(&path, contents).expect("write temp file");
+    path
+}
+
+#[test]
+fn content_hash_is_deterministic_and_distinguishes() {
+    assert_eq!(
+        content_hash("abc"),
+        content_hash("abc"),
+        "stable for equal input"
+    );
+    assert_ne!(
+        content_hash("abc"),
+        content_hash("abd"),
+        "differs for different input"
+    );
+}
+
+#[test]
+fn read_without_recorder_returns_content_and_records_nothing() {
+    let file = temp_file("plain.py", "x = 1\n");
+    let content = read_tracked(&file).expect("read");
+    assert_eq!(content, "x = 1\n");
+    // A recorder started afterwards sees only its own subsequent reads.
+    let recorder = ReadRecorder::start();
+    assert!(
+        recorder.finish().is_empty(),
+        "no reads recorded after start"
+    );
+    let _ = std::fs::remove_file(&file);
+}
+
+#[test]
+fn recorder_captures_reads_with_canonical_key_and_hash() {
+    let file = temp_file("tracked.py", "y = 2\n");
+    let recorder = ReadRecorder::start();
+    let _ = read_tracked(&file).expect("read");
+    let set = recorder.finish();
+    assert_eq!(set.len(), 1, "exactly one file recorded");
+    let key = canonical_key(&file);
+    assert_eq!(
+        set.get(&key).copied(),
+        Some(content_hash("y = 2\n")),
+        "key and hash recorded"
+    );
+    let _ = std::fs::remove_file(&file);
+}
+
+#[test]
+fn read_error_propagates() {
+    let missing = Path::new("/no/such/basilisk/fs/file.py");
+    assert!(read_tracked(missing).is_err(), "missing file is an error");
+}
+
+#[test]
+fn canonical_key_falls_back_for_missing_path() {
+    let missing = Path::new("/no/such/basilisk/fs/key.py");
+    assert_eq!(
+        canonical_key(missing),
+        missing.to_string_lossy(),
+        "non-canonicalisable path falls back to itself"
+    );
+}
+
+#[test]
+fn dropping_recorder_without_finish_clears_state() {
+    let file = temp_file("dropped.py", "z = 3\n");
+    {
+        let _recorder = ReadRecorder::start();
+        let _ = read_tracked(&file).expect("read");
+        // dropped here without finish()
+    }
+    // A fresh recorder must not inherit the dropped one's read-set.
+    let recorder = ReadRecorder::start();
+    let set = recorder.finish();
+    assert!(
+        set.is_empty(),
+        "dropped recorder's reads must not leak forward"
+    );
+    let _ = std::fs::remove_file(&file);
+}

--- a/crates/basilisk-config/src/overrides.rs
+++ b/crates/basilisk-config/src/overrides.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 /// Severity level for a diagnostic rule override.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 pub enum RuleSeverity {
     /// Full error (default for most rules).
     Error,
@@ -34,7 +34,7 @@ impl RuleSeverity {
 ///
 /// Applied when the imported module name matches the override key.
 /// Keys support wildcard patterns (e.g. `django.*` matches `django.db.models`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct ModuleOverride {
     /// When `true`, BSK-E0010 is suppressed for this module.
     pub ignore_missing_stubs: bool,
@@ -44,7 +44,7 @@ pub struct ModuleOverride {
 ///
 /// Applied when the file path matches the override key pattern.
 /// Keys use glob patterns (e.g. `vendor/**` matches `vendor/lib/foo.py`).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct PathOverride {
     /// Rules to completely disable for files matching this path pattern.
     pub disabled_rules: Vec<String>,

--- a/crates/basilisk-config/src/parse.rs
+++ b/crates/basilisk-config/src/parse.rs
@@ -11,7 +11,7 @@ use crate::overrides::{ModuleOverride, PathOverride, RuleSeverity};
 /// This is the rich configuration model with per-module and per-path overrides.
 /// It supplements the `WorkspaceConfig` in `basilisk-lsp` which handles
 /// analysis mode, python version, and other LSP-level settings.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct BasiliskConfig {
     /// Directory names to exclude from file discovery.
     ///

--- a/crates/basilisk-db/Cargo.toml
+++ b/crates/basilisk-db/Cargo.toml
@@ -5,5 +5,13 @@ version.workspace    = true
 edition.workspace    = true
 license.workspace    = true
 
+[dependencies]
+basilisk-common = { path = "../basilisk-common" }
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/crates/basilisk-db/src/cache.rs
+++ b/crates/basilisk-db/src/cache.rs
@@ -1,0 +1,126 @@
+//! Implements [CHKCACHE-ENTRY] / [CHKCACHE-FINGERPRINT].
+//! See docs/specs/CHECKER-CACHE-SPEC.md#chkcache-entry
+//!
+//! A generic, content-addressed, on-disk result cache.
+//!
+//! [`CheckCache`] is agnostic to *what* it caches: the consumer (the CLI)
+//! supplies a serialisable payload (the diagnostics) and the fingerprint of the
+//! non-file inputs (version, config, environment). The cache stores the exact
+//! read-set captured during the check and, on lookup, re-verifies every recorded
+//! file against its stored hash. A hit is returned only when the fingerprint and
+//! every file match — the [`CHKCACHE-CONTRACT`] guarantee.
+
+use std::path::{Path, PathBuf};
+
+use basilisk_common::fs::{canonical_key, content_hash, ReadSet};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// The non-file inputs that affect a check result.
+///
+/// These are fingerprinted as a unit; any change forces a miss.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Fingerprint {
+    /// Checker version (`CARGO_PKG_VERSION`).
+    pub version: String,
+    /// Hash of the effective configuration.
+    pub config_hash: u64,
+    /// Hash of the resolution environment (search paths, `uv.lock`).
+    pub env_hash: u64,
+}
+
+/// A persistent result cache rooted at a directory.
+#[derive(Debug, Clone)]
+pub struct CheckCache {
+    dir: PathBuf,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Dep {
+    path: String,
+    hash: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Entry<T> {
+    version: String,
+    config_hash: u64,
+    env_hash: u64,
+    deps: Vec<Dep>,
+    payload: T,
+}
+
+impl CheckCache {
+    /// Create a cache rooted at `dir`. The directory is created lazily on the
+    /// first [`CheckCache::store`].
+    #[must_use]
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
+    /// Return the cached payload for `target` iff the fingerprint matches and
+    /// every recorded dependency is byte-identical to when it was stored.
+    ///
+    /// Returns `None` on any mismatch, missing/unreadable dependency, or
+    /// unparseable entry — never a stale result.
+    #[must_use]
+    pub fn lookup<T: DeserializeOwned>(
+        &self,
+        target: &Path,
+        fingerprint: &Fingerprint,
+    ) -> Option<T> {
+        let raw = std::fs::read_to_string(self.entry_path(target)).ok()?;
+        let entry: Entry<T> = serde_json::from_str(&raw).ok()?;
+        if entry.version != fingerprint.version
+            || entry.config_hash != fingerprint.config_hash
+            || entry.env_hash != fingerprint.env_hash
+        {
+            return None;
+        }
+        entry
+            .deps
+            .iter()
+            .all(Self::dep_unchanged)
+            .then_some(entry.payload)
+    }
+
+    /// Store `payload` for `target`, recording the exact `read_set` so a future
+    /// lookup can re-verify it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`std::io::Error`] if the cache directory or entry file cannot
+    /// be written, or if the payload cannot be serialised.
+    pub fn store<T: Serialize>(
+        &self,
+        target: &Path,
+        fingerprint: &Fingerprint,
+        read_set: ReadSet,
+        payload: &T,
+    ) -> std::io::Result<()> {
+        std::fs::create_dir_all(&self.dir)?;
+        let deps = read_set
+            .into_iter()
+            .map(|(path, hash)| Dep { path, hash })
+            .collect();
+        let entry = Entry {
+            version: fingerprint.version.clone(),
+            config_hash: fingerprint.config_hash,
+            env_hash: fingerprint.env_hash,
+            deps,
+            payload,
+        };
+        let raw = serde_json::to_string(&entry).map_err(std::io::Error::other)?;
+        std::fs::write(self.entry_path(target), raw)
+    }
+
+    /// Re-read a recorded dependency and compare against its stored hash.
+    fn dep_unchanged(dep: &Dep) -> bool {
+        std::fs::read_to_string(&dep.path).is_ok_and(|current| content_hash(&current) == dep.hash)
+    }
+
+    /// On-disk path for a target's entry: `<dir>/<hash-of-canonical-path>.json`.
+    fn entry_path(&self, target: &Path) -> PathBuf {
+        let key = canonical_key(target);
+        self.dir.join(format!("{:016x}.json", content_hash(&key)))
+    }
+}

--- a/crates/basilisk-db/src/lib.rs
+++ b/crates/basilisk-db/src/lib.rs
@@ -1,21 +1,19 @@
 //! Implements [CHKARCH-INCREMENTAL-SALSA]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-INCREMENTAL-SALSA
 //! Incremental computation database for Basilisk.
 //!
-//! This crate will house the Salsa-based incremental database in Phase 2.
-//! Currently a placeholder for workspace coherence.
+//! This crate houses the opt-in CLI result cache ([`cache`], see
+//! [CHKCACHE](../../../docs/specs/CHECKER-CACHE-SPEC.md)) and will grow into the
+//! Salsa-based incremental database in Phase 2.
 
-/// Compute a cache key for a source string.
+pub mod cache;
+
+/// Compute a content-based cache key for a source string.
 ///
-/// Returns a content-based hash suitable for detecting changes.
-/// Phase 2: uses the standard library's `DefaultHasher`.  The real
-/// implementation will use a collision-resistant hash (e.g. xxHash).
+/// Delegates to the shared [`basilisk_common::fs::content_hash`] so every layer
+/// (stub cache, result cache, read-recorder) computes identical hashes.
 #[must_use]
 pub fn hash_source(source: &str) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    source.hash(&mut hasher);
-    hasher.finish()
+    basilisk_common::fs::content_hash(source)
 }
 
 /// Check whether a source file with the given hash needs to be rechecked.

--- a/crates/basilisk-db/tests/cache_tests.rs
+++ b/crates/basilisk-db/tests/cache_tests.rs
@@ -1,0 +1,159 @@
+//! Tests for [CHKCACHE-ENTRY] / [CHKCACHE-FINGERPRINT] / [CHKCACHE-CONTRACT].
+//! See docs/specs/CHECKER-CACHE-SPEC.md#chkcache-entry
+#![allow(clippy::allow_attributes, clippy::unwrap_used, clippy::expect_used)]
+//! Crate-boundary tests for the result cache, covering every soundness branch:
+//! a hit is returned only when the fingerprint and every recorded file match.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use basilisk_common::fs::{canonical_key, content_hash};
+use basilisk_db::cache::{CheckCache, Fingerprint};
+
+/// A fresh, unique temp directory for one test.
+fn temp_dir(name: &str) -> PathBuf {
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("bsk_db_{name}_{}_{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+fn fingerprint() -> Fingerprint {
+    Fingerprint {
+        version: "1.2.3".to_owned(),
+        config_hash: 42,
+        env_hash: 7,
+    }
+}
+
+/// Write a source file and return its `(canonical key, content hash)`.
+fn write_dep(dir: &Path, name: &str, contents: &str) -> (PathBuf, String, u64) {
+    let path = dir.join(name);
+    std::fs::write(&path, contents).expect("write dep");
+    let key = canonical_key(&path);
+    (path, key, content_hash(contents))
+}
+
+#[test]
+fn roundtrip_hit_returns_payload() {
+    let dir = temp_dir("roundtrip");
+    let cache = CheckCache::new(dir.join("cache"));
+    let (target, key, hash) = write_dep(&dir, "t.py", "x = 1\n");
+    let read_set: BTreeMap<String, u64> = [(key, hash)].into_iter().collect();
+
+    cache
+        .store(&target, &fingerprint(), read_set, &vec!["diag".to_owned()])
+        .expect("store");
+    let hit: Option<Vec<String>> = cache.lookup(&target, &fingerprint());
+    assert_eq!(hit, Some(vec!["diag".to_owned()]), "unchanged inputs → hit");
+}
+
+#[test]
+fn missing_entry_is_a_miss() {
+    let dir = temp_dir("noentry");
+    let cache = CheckCache::new(dir.join("cache"));
+    let (target, ..) = write_dep(&dir, "t.py", "x = 1\n");
+    let miss: Option<Vec<String>> = cache.lookup(&target, &fingerprint());
+    assert_eq!(miss, None, "no stored entry → miss");
+}
+
+#[test]
+fn corrupt_entry_is_a_miss() {
+    let dir = temp_dir("corrupt");
+    let cache_dir = dir.join("cache");
+    let cache = CheckCache::new(cache_dir.clone());
+    let (target, key, hash) = write_dep(&dir, "t.py", "x = 1\n");
+    let read_set: BTreeMap<String, u64> = [(key, hash)].into_iter().collect();
+    cache
+        .store(&target, &fingerprint(), read_set, &vec!["diag".to_owned()])
+        .expect("store");
+
+    // Overwrite the single entry file with garbage.
+    for entry in std::fs::read_dir(&cache_dir).expect("read cache dir") {
+        std::fs::write(entry.expect("dir entry").path(), "not json").expect("corrupt");
+    }
+    let miss: Option<Vec<String>> = cache.lookup(&target, &fingerprint());
+    assert_eq!(miss, None, "unparseable entry → miss, never a panic");
+}
+
+#[test]
+fn fingerprint_mismatches_are_misses() {
+    let dir = temp_dir("fp");
+    let cache = CheckCache::new(dir.join("cache"));
+    let (target, key, hash) = write_dep(&dir, "t.py", "x = 1\n");
+    let read_set: BTreeMap<String, u64> = [(key, hash)].into_iter().collect();
+    cache
+        .store(&target, &fingerprint(), read_set, &vec!["diag".to_owned()])
+        .expect("store");
+
+    let bumped_version = Fingerprint {
+        version: "9.9.9".to_owned(),
+        ..fingerprint()
+    };
+    let bumped_config = Fingerprint {
+        config_hash: 999,
+        ..fingerprint()
+    };
+    let bumped_env = Fingerprint {
+        env_hash: 999,
+        ..fingerprint()
+    };
+    for (label, fp) in [
+        ("version", bumped_version),
+        ("config", bumped_config),
+        ("env", bumped_env),
+    ] {
+        let miss: Option<Vec<String>> = cache.lookup(&target, &fp);
+        assert_eq!(miss, None, "{label} change must force a miss");
+    }
+}
+
+#[test]
+fn changed_dependency_is_a_miss() {
+    let dir = temp_dir("changedep");
+    let cache = CheckCache::new(dir.join("cache"));
+    let (target, tkey, thash) = write_dep(&dir, "a.py", "import b\n");
+    let (dep, dkey, dhash) = write_dep(&dir, "b.py", "old\n");
+    let read_set: BTreeMap<String, u64> = [(tkey, thash), (dkey, dhash)].into_iter().collect();
+    cache
+        .store(&target, &fingerprint(), read_set, &vec!["diag".to_owned()])
+        .expect("store");
+
+    std::fs::write(&dep, "new contents\n").expect("edit dep");
+    let miss: Option<Vec<String>> = cache.lookup(&target, &fingerprint());
+    assert_eq!(miss, None, "a changed dependency must force a miss");
+}
+
+#[test]
+fn missing_dependency_is_a_miss() {
+    let dir = temp_dir("missdep");
+    let cache = CheckCache::new(dir.join("cache"));
+    let (target, tkey, thash) = write_dep(&dir, "a.py", "import b\n");
+    let (dep, dkey, dhash) = write_dep(&dir, "b.py", "data\n");
+    let read_set: BTreeMap<String, u64> = [(tkey, thash), (dkey, dhash)].into_iter().collect();
+    cache
+        .store(&target, &fingerprint(), read_set, &vec!["diag".to_owned()])
+        .expect("store");
+
+    std::fs::remove_file(&dep).expect("remove dep");
+    let miss: Option<Vec<String>> = cache.lookup(&target, &fingerprint());
+    assert_eq!(miss, None, "a deleted dependency must force a miss");
+}
+
+#[test]
+fn unserialisable_payload_errors() {
+    let dir = temp_dir("badpayload");
+    let cache = CheckCache::new(dir.join("cache"));
+    let (target, key, hash) = write_dep(&dir, "t.py", "x = 1\n");
+    let read_set: BTreeMap<String, u64> = [(key, hash)].into_iter().collect();
+
+    // A map with non-string keys cannot be serialised to JSON → store errors.
+    let payload: HashMap<(i32, i32), i32> = [((1, 2), 3)].into_iter().collect();
+    let result = cache.store(&target, &fingerprint(), read_set, &payload);
+    assert!(
+        result.is_err(),
+        "an unserialisable payload must surface an error"
+    );
+}

--- a/crates/basilisk-parser/Cargo.toml
+++ b/crates/basilisk-parser/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace    = true
 license.workspace    = true
 
 [dependencies]
+basilisk-common              = { path = "../basilisk-common" }
 ruff_python_parser.workspace = true
 ruff_python_ast.workspace    = true
 thiserror                    = "2.0"

--- a/crates/basilisk-parser/src/lib.rs
+++ b/crates/basilisk-parser/src/lib.rs
@@ -46,7 +46,10 @@ pub fn parse_source(source: String, path: String) -> Result<ParsedModule, ParseE
 /// Returns [`ParseError::Io`] on read failure or [`ParseError::Syntax`] on
 /// parse failure.
 pub fn parse_file(path: &str) -> Result<ParsedModule, ParseError> {
-    std::fs::read_to_string(path)
+    // Routed through `read_tracked` so the result cache can record exactly which
+    // files a check read. Inert (identical to `fs::read_to_string`) when no
+    // recorder is active. See [CHKCACHE-READSET-FS].
+    basilisk_common::fs::read_tracked(std::path::Path::new(path))
         .map_err(|source| ParseError::Io {
             path: path.to_owned(),
             source,

--- a/crates/basilisk-resolver/Cargo.toml
+++ b/crates/basilisk-resolver/Cargo.toml
@@ -10,6 +10,7 @@ basilisk-parser.workspace = true
 basilisk-stubs.workspace  = true
 ruff_python_ast.workspace = true
 ruff_text_size.workspace  = true
+serde.workspace           = true
 thiserror                 = "2.0"
 
 [dev-dependencies]

--- a/crates/basilisk-resolver/src/scope/span.rs
+++ b/crates/basilisk-resolver/src/scope/span.rs
@@ -4,7 +4,7 @@
 use ruff_text_size::TextRange;
 
 /// A byte-offset span within a source file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Span {
     /// Byte offset of the start (inclusive).
     pub start: u32,

--- a/crates/basilisk-stubs/Cargo.toml
+++ b/crates/basilisk-stubs/Cargo.toml
@@ -6,10 +6,12 @@ edition.workspace    = true
 license.workspace    = true
 
 [dependencies]
+basilisk-common = { path = "../basilisk-common" }
 phf.workspace = true
 ruff_python_ast.workspace = true
 ruff_python_parser.workspace = true
 ruff_text_size.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/basilisk-stubs/src/pyi_parser.rs
+++ b/crates/basilisk-stubs/src/pyi_parser.rs
@@ -52,7 +52,9 @@ pub fn parse_pyi_file(
     source: StubSource,
     tier: StubTier,
 ) -> Result<StubModule, StubParseError> {
-    let content = std::fs::read_to_string(path).map_err(|err| StubParseError::Io {
+    // Routed through `read_tracked` so the result cache records stub reads too.
+    // See [CHKCACHE-READSET-FS].
+    let content = basilisk_common::fs::read_tracked(path).map_err(|err| StubParseError::Io {
         path: path.to_path_buf(),
         source: err,
     })?;

--- a/crates/basilisk-stubs/src/types.rs
+++ b/crates/basilisk-stubs/src/types.rs
@@ -54,7 +54,7 @@ pub enum StubTier {
 /// Where a type's information originated, from the perspective of the type
 /// checker.  Used for cascade suppression (suppress downstream errors from
 /// untyped imports) and hover annotations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum TypeProvenance {
     /// From source code annotations or inference.
     Source,

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,6 +9,7 @@ Specifications define the target behavior and architecture. They are the source 
 | [CHECKER-ARCHITECTURE-SPEC.md](specs/CHECKER-ARCHITECTURE-SPEC.md) | Core type checker architecture — type system, diagnostic codes, error ranges, and design philosophy. |
 | [CHECKER-TYPE-INFERENCE-SPEC.md](specs/CHECKER-TYPE-INFERENCE-SPEC.md) | Bidirectional type inference — variable/collection/generic inference, type narrowing, redundant annotation principle (W0050). |
 | [CHECKER-STUB-RESOLUTION-SPEC.md](specs/CHECKER-STUB-RESOLUTION-SPEC.md) | PEP 561 stub resolution, typeshed bundling, type provenance tracking, suppression system, auto-stub generation. |
+| [CHECKER-CACHE-SPEC.md](specs/CHECKER-CACHE-SPEC.md) | Opt-in, content-addressed CLI result cache — correctness contract (never miss an error), read-set fingerprinting, warm/cold detection. |
 | [COMPILER-ARCHITECTURE-SPEC.md](specs/COMPILER-ARCHITECTURE-SPEC.md) | Python-to-native compiler via LLVM — ownership model, memory backends, GPU support. |
 | [LSP-ARCHITECTURE-SPEC.md](specs/LSP-ARCHITECTURE-SPEC.md) | Single source of truth for LSP features, DAP integration, custom commands, configuration, and binary resolution. |
 | [LSP-ANALYSIS-MODES-SPEC.md](specs/LSP-ANALYSIS-MODES-SPEC.md) | Analysis modes (openFilesOnly, wholeModule, crossModule), workspace index, import graph, cross-file LSP features. |
@@ -34,6 +35,7 @@ Implementation roadmaps tracking phasing, priorities, and progress.
 | [LSP-PLAN.md](plans/LSP-PLAN.md) | Overall LSP roadmap — seven phases from core features through cross-module analysis. |
 | [CHECKER-CROSS-MODULE-PLAN.md](plans/CHECKER-CROSS-MODULE-PLAN.md) | Cross-file LSP features, type provenance, Salsa integration, auto-stub generation. |
 | [CHECKER-PEP-CONFORMANCE-PLAN.md](plans/CHECKER-PEP-CONFORMANCE-PLAN.md) | PEP conformance push — target 85%, tiered task list by complexity and impact. |
+| [CHECKER-CACHE-PLAN.md](plans/CHECKER-CACHE-PLAN.md) | Build order for the opt-in CLI result cache + warm/cold benchmark wiring. |
 | [LSP-AI-PLAN.md](plans/LSP-AI-PLAN.md) | AI provider abstraction — model-agnostic hooks for fixes, completions, refactoring. |
 | [LSP-PROFILING-PLAN.md](plans/LSP-PROFILING-PLAN.md) | Embed py-spy profiler into LSP for CPU profiling and hotspot visualization. |
 | [LSP-PROFILER-PROCESS-PANEL-PLAN.md](plans/LSP-PROFILER-PROCESS-PANEL-PLAN.md) | Python Processes activity-bar panel — LSP-driven process enumeration (sysinfo), sort/group, one-click CPU/memory profiling without the Command Palette. |

--- a/docs/plans/CHECKER-CACHE-PLAN.md
+++ b/docs/plans/CHECKER-CACHE-PLAN.md
@@ -1,0 +1,47 @@
+# Checker Result Cache — Implementation Plan
+
+Implements [`CHKCACHE`](../specs/CHECKER-CACHE-SPEC.md). Opt-in, correctness-first
+CLI result cache + warm/cold benchmark wiring.
+
+## Build order (bottom-up, build green at each step)
+
+1. **`basilisk-common::fs`** (`CHKCACHE-READSET-FS`/`-GUARD`) — `read_tracked`,
+   thread-local `ReadRecorder` RAII guard, `content_hash`. Reused by parser +
+   stubs.
+2. **Wire reads** — `parse_file` and `parse_pyi_file` call `read_tracked`. No
+   behaviour change when no recorder is active.
+3. **Serde projection** (`CHKCACHE-DIAG`) — derive Serialize/Deserialize on
+   `Severity`, `Span`, `TypeProvenance`; add owned `CachedDiagnostic` with
+   `From<&Diagnostic>` + `into_diagnostic` via bounded interner
+   (`CHKCACHE-DIAG-INTERN`).
+4. **`basilisk-db::cache`** (`CHKCACHE-ENTRY`/`-FINGERPRINT`) — generic
+   `CheckCache<T>` over a serde payload: `lookup`, `store`, dep re-verification,
+   cache-dir management.
+5. **CLI wiring** (`CHKCACHE-CLI`) — flags, lookup→(miss: run under recorder,
+   store), hit/miss counters, `--cache-stats`. Extract into
+   `basilisk-cli/src/cache_check.rs` to keep `main.rs` lean.
+6. **Tests** (`CHKCACHE-TEST-*`) — coarse e2e in `basilisk-cli/tests`.
+7. **Benchmark** — `benchmarks/run.sh`: mypy `--no-incremental` (cold, honest);
+   basilisk warm (cache) + cold (`--prepare` clears cache dir); 2 new rule
+   fixtures; update `benchmark_report.py`, website data + render, status CSV
+   schema.
+
+## Key decisions (made, not open)
+
+- **Read-recorder, not import-list inference** — the only airtight read-set.
+- **Store dep list in entry, re-verify on lookup** — solves the
+  "don't-know-deps-before-running" bootstrap soundly (`CHKCACHE-SOUNDNESS`).
+- **`docs_url` derived, code interned** — sidesteps `&'static str` round-trip.
+- **Opt-in** — until the site-packages env hole (`CHKCACHE-LIMITS`) is closed.
+- **Benchmark: symmetric warm + cold for every tool.** cold = full check; warm =
+  a repeat run using that tool's own cache. basilisk-warm = `--cache` hit;
+  mypy-warm = incremental `.mypy_cache` hit (cold mypy = `--no-incremental`).
+  pyright/ty/pyrefly keep no cross-run result cache (verified: first-ever run ==
+  repeat run, zero cache artifacts), so their warm ≈ cold — which is itself the
+  honest result.
+- **Stepping stone, not destination** (`CHKCACHE-POSITIONING`) — a result cache
+  is only *useful* with watcher-driven, dependency-aware (smart) invalidation;
+  v1 has neither (it re-verifies lazily on the next lookup), so it helps batch
+  re-runs but not the interactive editor. The proper long-term mechanism is the
+  Salsa migration (`basilisk-db` Phase 2), which gives watcher-driven sub-file
+  invalidation for free and subsumes this hand-rolled read-set.

--- a/docs/specs/CHECKER-CACHE-SPEC.md
+++ b/docs/specs/CHECKER-CACHE-SPEC.md
@@ -1,0 +1,178 @@
+# Checker Result Cache — Specification
+
+**Spec group:** `CHKCACHE`
+**Status:** v1 (opt-in)
+**Related:** [`CHKARCH-INCREMENTAL-SALSA`](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-INCREMENTAL-SALSA), [`CHKARCH-CLI`](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CLI)
+
+The CLI (`basilisk check`) recomputes every diagnostic from scratch on each
+invocation. This spec defines an **opt-in, persistent, content-addressed result
+cache** that lets an unchanged check return instantly while guaranteeing it can
+never change *which* diagnostics are reported.
+
+The cache exists so a *warm* (cache-hit) check is measurably faster than a *cold*
+(full) one — and so that warm vs cold is detectable, which the benchmark relies
+on.
+
+---
+
+## `CHKCACHE-CONTRACT` — The correctness contract (non-negotiable)
+
+> **A cache hit is permitted only when every input that can affect the
+> diagnostics is provably byte-identical to when the entry was written. Any
+> doubt is a MISS. The cache may make a check faster; it must never make it
+> wrong.**
+
+"Inputs that can affect the diagnostics" for `basilisk check <file>` are:
+
+1. **The target file's bytes.** (`CHKCACHE-INPUT-TARGET`)
+2. **The bytes of every other source/stub file the checker actually read** while
+   producing the result — transitive imports and `.pyi` stubs included.
+   (`CHKCACHE-INPUT-DEPS`)
+3. **The effective configuration** — the resolved `BasiliskConfig` (rule
+   severities, per-path/per-module overrides, excludes, stub paths, auto-stub
+   mode, …). (`CHKCACHE-INPUT-CONFIG`)
+4. **The resolution environment** — import search roots, site-packages dirs,
+   and the `uv.lock` contents when present. A change here can change *which*
+   files an import resolves to. (`CHKCACHE-INPUT-ENV`)
+5. **The checker version** — `CARGO_PKG_VERSION`. A new binary may change rule
+   logic or bundled stubs, so it invalidates every entry.
+   (`CHKCACHE-INPUT-VERSION`)
+
+A hit requires **all five** to match. If any differ, or anything cannot be
+determined (a recorded dependency is now missing/unreadable, the entry cannot be
+parsed, the config cannot be fingerprinted), the result is a MISS and the check
+runs in full.
+
+### `CHKCACHE-SOUNDNESS` — Why this never misses an error
+
+The check is a pure function of inputs (1)–(5): identical inputs ⟹ identical
+diagnostics, *and* identical inputs ⟹ the check reads the identical set of files.
+Therefore, if the target and every recorded dependency are byte-identical and the
+config/env/version match, re-running the check would read the same files and
+produce the same diagnostics — so returning the stored diagnostics is sound. The
+only way the read-set could differ is if some recorded input changed, which is
+exactly what a hit checks for. ∎
+
+The dependency set is captured by **recording the actual file reads** during the
+miss path (see `CHKCACHE-READSET`), not by inferring it from the import list — so
+a transitively-read stub that influenced the result is always fingerprinted.
+
+### `CHKCACHE-LIMITS` — Documented v1 boundary
+
+The environment fingerprint (`CHKCACHE-INPUT-ENV`) hashes the search-path
+configuration and `uv.lock`. Installing or removing packages **directly into a
+virtualenv's site-packages without a `uv.lock` change** is not auto-detected in
+v1. This is why the cache is **opt-in**: clear the cache (or omit `--cache`)
+after mutating the environment outside the lockfile. Source, config, lockfile,
+and version changes are always detected. This boundary is the reason v1 ships
+behind a flag rather than on by default.
+
+### `CHKCACHE-POSITIONING` — When this cache helps, and the Salsa endgame
+
+This v1 cache is **correct everywhere but only *useful* in narrow conditions**,
+and the documentation must say so plainly.
+
+- **`CHKCACHE-POSITIONING-WATCHER` — a cache is only useful with invalidation on
+  edit.** A result cache earns its keep when something tells it *which* files
+  changed so unchanged work can be skipped. In a long-lived process that means a
+  **file watcher** that invalidates entries the moment a file is edited. v1 has
+  no watcher: it is a one-shot CLI cache that lazily re-verifies the recorded
+  read-set on the *next* lookup (re-reading and re-hashing every dependency).
+  That keeps it correct, but its value is confined to **repeated batch runs over
+  a mostly-unchanged tree** (CI re-runs, pre-commit, `basilisk check` loops). In
+  an interactive editor it is the wrong shape — the LSP already holds documents
+  in memory and is notified of edits, so a re-verify-on-read disk cache buys
+  little.
+
+- **`CHKCACHE-POSITIONING-SMART` — invalidation must be smart, not blanket.**
+  Re-checking every file because one changed defeats the purpose. Useful
+  invalidation is **dependency-aware**: an edit invalidates only the edited file
+  and its transitive importers (the reverse of the read-set this cache already
+  records), leaving everything else cached. v1 approximates this lazily and
+  per-file; it does not maintain the reverse dependency graph needed to
+  invalidate *eagerly* and *precisely* on a watcher event.
+
+- **`CHKCACHE-POSITIONING-SALSA` — Salsa (basilisk-db Phase 2) is the better
+  vehicle.** Watcher-driven, smart, sub-file invalidation is exactly what a
+  query-memoization engine gives for free: with Salsa
+  ([`CHKARCH-INCREMENTAL-SALSA`](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-INCREMENTAL-SALSA)),
+  parse / semantic-index / infer / check become tracked queries, an edit
+  invalidates only the affected queries and their dependents, and the
+  granularity is per-function rather than per-file. That subsumes this cache: the
+  read-set this cache records by hand is the dependency graph Salsa tracks
+  automatically. **v1 is therefore a deliberately small, correct stepping
+  stone** — it proves the fingerprint/read-set model and gives the benchmark a
+  real warm number today — not the destination. When `basilisk-db` Phase 2
+  lands, the persistent result cache should be reframed as (or replaced by) a
+  Salsa-backed durable database, and this whole-file content-hash cache retired.
+
+---
+
+## `CHKCACHE-READSET` — Capturing the exact read-set
+
+All checker file reads go through two functions:
+
+- `basilisk_parser::parse_file` (target + imported `.py` sources)
+- `basilisk_stubs::parse_pyi_file` (`.pyi` stubs)
+
+Both route their `read_to_string` through `basilisk_common::fs::read_tracked`
+(`CHKCACHE-READSET-FS`). When a thread-local `ReadRecorder` is active, every read
+records `(canonical_path, content_hash)`. The recorder is an RAII guard
+(`CHKCACHE-READSET-GUARD`): inert when absent (zero behaviour change for the LSP
+and for non-cached CLI runs), active only for the duration of a cached check.
+
+---
+
+## `CHKCACHE-FINGERPRINT` — The fingerprint
+
+`fingerprint = hash(version ‖ config_hash ‖ env_hash ‖ sorted[(path, content_hash)…])`
+
+where the read-set is sorted by canonical path for determinism. Hashing uses the
+existing `basilisk_db::hash_source` (`DefaultHasher`); the cache stores the
+**full read-set with per-file hashes** in the entry so a lookup re-verifies each
+file individually rather than trusting a single rolled-up number.
+
+---
+
+## `CHKCACHE-ENTRY` — On-disk entry
+
+One JSON file per target, named by the hash of the target's canonical path,
+under the cache directory (`CHKCACHE-DIR`, default `.basilisk/cache/check`).
+Each entry stores:
+
+- `version`, `config_hash`, `env_hash`
+- `deps`: `[(canonical_path, content_hash)]` (includes the target)
+- `diagnostics`: `[CachedDiagnostic]` — an owned, serde projection of
+  `Diagnostic` (`CHKCACHE-DIAG`). `docs_url` is **not** stored: it is rebuilt
+  deterministically from the code. On replay, the `&'static` `code`/`docs_url`
+  are produced via a bounded process-wide interner (`CHKCACHE-DIAG-INTERN`,
+  ≤ one entry per distinct BSK code).
+
+A lookup loads the entry, checks `version`/`config_hash`/`env_hash`, then
+re-hashes every `deps` path against its stored hash. All match ⟹ HIT.
+
+---
+
+## `CHKCACHE-CLI` — CLI surface
+
+- `--cache` — enable the cache (off by default). (`CHKCACHE-CLI-ENABLE`)
+- `--cache-dir <DIR>` — override the cache location. (`CHKCACHE-CLI-DIR`)
+- `--cache-stats` — print `cache: N hit / M miss` to stderr after the run, so a
+  warm run is detectable. Hit/miss is also emitted via `tracing`.
+  (`CHKCACHE-CLI-STATS`)
+
+Disabled (default) ⟹ behaviour is byte-for-byte identical to today.
+
+---
+
+## `CHKCACHE-TEST` — Test obligations (coarse e2e)
+
+1. `CHKCACHE-TEST-HIT` — second cached run yields identical diagnostics.
+2. `CHKCACHE-TEST-TARGET` — editing the target between runs yields fresh
+   diagnostics, never the stale cached set.
+3. `CHKCACHE-TEST-DEP` — editing an imported dependency yields fresh diagnostics.
+4. `CHKCACHE-TEST-CONFIG` — a config change forces a miss.
+5. `CHKCACHE-TEST-DISABLED` — without `--cache`, no cache dir is created and
+   output is unchanged.
+6. `CHKCACHE-TEST-STATS` — `--cache-stats` reports a miss then a hit across two
+   runs.


### PR DESCRIPTION
## TLDR
Add an opt-in, soundness-first on-disk result cache to `basilisk check` (`--cache`) that serves unchanged files from a persistent cache, while remaining byte-for-byte inert unless the flag is passed.

## What Was Added?
- **`--cache`, `--cache-dir`, `--cache-stats` flags** on `basilisk check` (all default-off). A hit is returned only when the target bytes, every file the check read, the effective config, the resolution environment, and the checker version are all unchanged.
- **`basilisk-db::cache`** (`CheckCache`, `Fingerprint`) — on-disk entry store that re-verifies every recorded input on lookup before returning a hit.
- **`basilisk-common::fs`** — `read_tracked` + a thread-local `ReadRecorder` that captures the exact per-check read-set. Std-only, so `basilisk-common` still compiles to the Zed `wasm32-wasip2` target.
- **`basilisk-checker::CachedDiagnostic`** — a serde projection of `Diagnostic` for persistence, with a static-code interner.
- **`basilisk-cli::cache_check`** — CLI glue translating the flags into a lookup/store wrapped around the cold check, plus hit/miss stats.
- **Benchmark harness**: new fixtures (`e0011_explicit_any.py`, `e0018_undefined_name.py`) and a reworked `benchmarks/run.sh` that reports an honest warm-vs-cold comparison.
- **Spec/plan**: `docs/specs/CHECKER-CACHE-SPEC.md` (the `CHKCACHE` spec group), `docs/plans/CHECKER-CACHE-PLAN.md`, and a `docs/INDEX.md` entry.

## What Was Changed or Deleted?
- `basilisk-parser::parse_file` and `basilisk-stubs::parse_pyi_file` now read via `read_tracked` instead of `std::fs::read_to_string`. When no recorder is active this is byte-for-byte identical to the old call (`CHKCACHE-READSET-FS`); a single thread-local check sees `None` and does nothing.
- Added `serde::Serialize`/`Deserialize` derives to `Severity`, `Span`, `TypeProvenance`, and the `basilisk-config` types so results can be persisted — purely additive, no runtime behaviour.
- The `basilisk-cli` check pipeline threads `CacheOptions`/`CacheStats` through and short-circuits straight to the original cold check when `--cache` is absent.
- **No behaviour change for the LSP or any non-cached CLI run** — `ReadRecorder::start()` is only ever called behind the `--cache` gate.

## How Do The Automated Tests Prove It Works?
The correctness contract (`CHKCACHE-CONTRACT`) is proven end-to-end and at unit level:

- **CLI e2e** (`crates/basilisk-cli/tests/e2e_cache.rs`): `second_run_hits_with_identical_output` (a hit reproduces byte-identical diagnostics), `editing_target_invalidates`, `editing_dependency_invalidates`, `changing_config_invalidates` (each fingerprint input forces a miss), and `disabled_creates_no_cache_dir` — proving the feature is inert without `--cache` (no cache directory is even created).
- **Cache store** (`crates/basilisk-db/tests/cache_tests.rs`): `roundtrip_hit_returns_payload`, `missing_entry_is_a_miss`, `corrupt_entry_is_a_miss`, `fingerprint_mismatches_are_misses`, `changed_dependency_is_a_miss`, `missing_dependency_is_a_miss`, `unserialisable_payload_errors`.
- **Read-set recorder** (`crates/basilisk-common/tests/fs_tests.rs`): `read_without_recorder_returns_content_and_records_nothing` (zero behaviour change when inactive), `recorder_captures_reads_with_canonical_key_and_hash`, `dropping_recorder_without_finish_clears_state`, `read_error_propagates`, `canonical_key_falls_back_for_missing_path`, `content_hash_is_deterministic_and_distinguishes`.
- **Diagnostic projection** (`crates/basilisk-checker/tests/cached_tests.rs`): `projection_round_trips_through_serde_preserving_every_field`, `optional_fields_round_trip_as_none`, `interner_reuses_static_storage_for_repeated_codes`.

Coverage gates all hold (basilisk-db **100%**, basilisk-cli 89% ≥ 88%, basilisk-checker 94% ≥ 93%); the mutation score is unchanged at **90.79%** (83 mutants, identical baseline — the new code adds no `rules/` mutants); PEP conformance is unchanged.

## Spec / Doc Changes
- New `docs/specs/CHECKER-CACHE-SPEC.md` defining the `CHKCACHE` spec group: the correctness contract, soundness argument, read-set capture, fingerprint composition, on-disk entry format, documented v1 limits, and how this positions against the Salsa endgame.
- New `docs/plans/CHECKER-CACHE-PLAN.md`; `docs/INDEX.md` updated.

## Breaking Changes
- [x] None — the cache is strictly opt-in (`--cache`); all existing behaviour is byte-for-byte unchanged when the flag is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
