### PR TITLE
Hide profiling UI behind a single test-only switch ([PROFILE-UI-GATE])

### DIFF
--- a/docs/specs/LSP-PROFILING-SPEC.md
+++ b/docs/specs/LSP-PROFILING-SPEC.md
@@ -4,6 +4,12 @@
 
 Embed a state-of-the-art Python profiler directly into the Basilisk LSP. No `pip install`. No separate tool. One binary does type checking, debugging, and profiling. The profiler attaches to running Python processes, samples call stacks, and surfaces hotspots inline in the editor — VS Code and Zed.
 
+## UI Availability Gate {#PROFILE-UI-GATE}
+
+The profiler is complete in the LSP, but its VS Code surfaces are hidden from shipped users until the end-to-end experience is reliable — an entry point that errors or does nothing is worse first-run UX than none.
+
+A single switch, `isProfilingUiEnabled(context)` (`vscode-extension/src/profiling-ui.ts`), returns `true` only under test (`ExtensionMode.Test`) and `false` in shipped and dev-host sessions, so the suite still exercises the full UI. `extension.ts` mirrors it into the `basilisk.profilingEnabled` context key that every profiling `when` clause keys off; `memory-profiler.ts` reads it for the one surface no `when` clause can reach (the memory status-bar item). Nothing is removed — all commands stay advertised ([PROFILE-REQUESTS]) and registered. To ship profiling, return `true` unconditionally and drop the gate.
+
 ## Why py-spy {#PROFILE-PYSPY}
 
 py-spy is a **Rust crate on crates.io**. Basilisk is Rust. This is the only Python profiler that can be embedded as a library dependency in a Rust project.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -72,7 +72,7 @@
         {
           "id": "basilisk.pythonProcesses",
           "name": "Python Processes",
-          "when": "basilisk.hasWorkspace"
+          "when": "basilisk.hasWorkspace && basilisk.profilingEnabled"
         },
         {
           "id": "basilisk.info",
@@ -355,6 +355,46 @@
           "when": "false"
         },
         {
+          "command": "basilisk.profileStart",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.profileStop",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.profileSnapshot",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.profileAttachToDebug",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.profileDiff",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.profileCurrentFile",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.refreshProcesses",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.sortProcesses",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.groupProcesses",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.filterProcesses",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
           "command": "basilisk.profileProcess",
           "when": "false"
         },
@@ -372,31 +412,31 @@
         },
         {
           "command": "basilisk.memoryMenu",
-          "when": "basilisk.debugging"
+          "when": "basilisk.debugging && basilisk.profilingEnabled"
         },
         {
           "command": "basilisk.memoryStart",
-          "when": "basilisk.debugging"
+          "when": "basilisk.debugging && basilisk.profilingEnabled"
         },
         {
           "command": "basilisk.memorySnapshot",
-          "when": "basilisk.debugging"
+          "when": "basilisk.debugging && basilisk.profilingEnabled"
         },
         {
           "command": "basilisk.memoryDiff",
-          "when": "basilisk.debugging"
+          "when": "basilisk.debugging && basilisk.profilingEnabled"
         },
         {
           "command": "basilisk.memoryGcCollect",
-          "when": "basilisk.debugging"
+          "when": "basilisk.debugging && basilisk.profilingEnabled"
         },
         {
           "command": "basilisk.memoryReferences",
-          "when": "basilisk.debugging"
+          "when": "basilisk.debugging && basilisk.profilingEnabled"
         },
         {
           "command": "basilisk.memoryStop",
-          "when": "basilisk.debugging"
+          "when": "basilisk.debugging && basilisk.profilingEnabled"
         }
       ],
       "view/title": [
@@ -515,13 +555,13 @@
         "command": "basilisk.profileStart",
         "key": "ctrl+shift+p ctrl+shift+s",
         "mac": "cmd+shift+p cmd+shift+s",
-        "when": "editorLangId == python"
+        "when": "editorLangId == python && basilisk.profilingEnabled"
       },
       {
         "command": "basilisk.profileStop",
         "key": "ctrl+shift+p ctrl+shift+x",
         "mac": "cmd+shift+p cmd+shift+x",
-        "when": "basilisk.profiling"
+        "when": "basilisk.profiling && basilisk.profilingEnabled"
       }
     ],
     "breakpoints": [

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -22,6 +22,7 @@ import { registerPythonProcesses } from "./process-explorer";
 import { createStore, type Store } from "./store";
 import { registerProfiler, disposeProfiler } from "./profiler";
 import { registerMemoryProfiler, disposeMemoryProfiler } from "./memory-profiler";
+import { isProfilingUiEnabled } from "./profiling-ui";
 import { reportRuntimeFailure, resolveBasiliskRuntime } from "./shipwright-runtime";
 
 /** Priority for the Basilisk status bar item (higher = further left). */
@@ -161,6 +162,14 @@ function registerPanelsAndCommands(context: vscode.ExtensionContext, s: Store): 
   // Set context key so panel visibility conditions work.
   const hasWorkspace = (vscode.workspace.workspaceFolders?.length ?? 0) > 0;
   void vscode.commands.executeCommand("setContext", "basilisk.hasWorkspace", hasWorkspace);
+
+  // [PROFILE-UI-GATE] Single switch for every profiling `when` clause: on under
+  // test, hidden for shipped users until the profiler experience is reliable.
+  void vscode.commands.executeCommand(
+    "setContext",
+    "basilisk.profilingEnabled",
+    isProfilingUiEnabled(context),
+  );
 
   // Activity bar panels — register once (tree view IDs must be unique).
   const moduleResult = registerModuleExplorer(context, s);

--- a/vscode-extension/src/memory-profiler.ts
+++ b/vscode-extension/src/memory-profiler.ts
@@ -15,6 +15,7 @@
 import * as vscode from "vscode";
 import { Logger } from "./logger";
 import type { Store } from "./store";
+import { isProfilingUiEnabled } from "./profiling-ui";
 import { currentStoppedFrameId, evaluateInDebugSession } from "./dap-evaluate";
 import {
   disposeMemoryDashboard,
@@ -66,6 +67,8 @@ let memoryStatusBarItem: vscode.StatusBarItem | undefined;
 let activeMemorySessionId: string | undefined;
 /** Most recent snapshot, so a later "Compare" can show it alongside the diff. */
 let lastDashboardSnapshot: MemoryDashboardSnapshot | undefined;
+/** [PROFILE-UI-GATE] Whether the (imperative) memory indicator may be shown. */
+let memoryUiEnabled = false;
 
 // ── Registration ──────────────────────────────────────────────────────────
 
@@ -113,6 +116,10 @@ export function registerMemoryProfiler(
     vscode.debug.onDidTerminateDebugSession(() => { refreshMemoryStatusBar(); }),
   ];
 
+  // [PROFILE-UI-GATE] The memory indicator is the one profiling surface no `when`
+  // clause can reach, so it shares the single switch in code: shown under test,
+  // hidden for shipped users (see refreshMemoryStatusBar).
+  memoryUiEnabled = isProfilingUiEnabled(context);
   refreshMemoryStatusBar();
   return disposables;
 }
@@ -392,6 +399,8 @@ async function handleMemoryReferences(store: Store): Promise<void> {
  */
 function refreshMemoryStatusBar(): void {
   if (memoryStatusBarItem === undefined) { return; }
+  // [PROFILE-UI-GATE] Same switch as the declarative surfaces, applied in code.
+  if (!memoryUiEnabled) { memoryStatusBarItem.hide(); return; }
 
   const debugging = vscode.debug.activeDebugSession?.type === "basilisk-debug";
   const tracking = activeMemorySessionId !== undefined;

--- a/vscode-extension/src/profiling-ui.ts
+++ b/vscode-extension/src/profiling-ui.ts
@@ -1,0 +1,23 @@
+// Implements [PROFILE-UI-GATE]. See docs/specs/LSP-PROFILING-SPEC.md#PROFILE-UI-GATE
+/**
+ * The single switch for the profiling UI.
+ *
+ * Profiling is functionally complete in the LSP but its VS Code surfaces are
+ * hidden from shipped users until the experience is reliable — a half-working
+ * entry point is worse first-run UX than none. The whole extension still wires
+ * profiling up, so the test suite keeps exercising it: the surfaces are enabled
+ * exactly when VS Code runs us under test (`ExtensionMode.Test`) and hidden in
+ * every shipped (`Production`) and dev-host (`Development`) session.
+ *
+ * One predicate drives everything: the `basilisk.profilingEnabled` context key
+ * (which every profiling `when` clause in package.json keys off) and the single
+ * imperative surface no `when` clause can reach (the memory status-bar item).
+ * To ship profiling, return `true` here unconditionally and delete this gate.
+ */
+
+import * as vscode from "vscode";
+
+/** Whether the profiling UI surfaces should be shown in this session. */
+export function isProfilingUiEnabled(context: vscode.ExtensionContext): boolean {
+  return context.extensionMode === vscode.ExtensionMode.Test;
+}


### PR DESCRIPTION
## TLDR
Hide the VS Code profiling UI (CPU + memory profilers and the Python Processes panel) behind a single test-only switch so shipped users never see not-yet-reliable entry points, while keeping the full UI active under test.

## What Was Added?
- **`vscode-extension/src/profiling-ui.ts`** — a new single-source-of-truth switch, `isProfilingUiEnabled(context)`, which returns `true` only when VS Code runs the extension under test (`ExtensionMode.Test`) and `false` in shipped (`Production`) and dev-host (`Development`) sessions. No hand-maintained flag and no test-side plumbing — the test harness runs in `Test` mode, so the UI lights up there automatically and nowhere else.

## What Was Changed or Deleted?
Every profiling surface is now gated on the switch, with the branching kept to two call sites:
- **`extension.ts`** — mirrors the switch into a new `basilisk.profilingEnabled` VS Code context key via one `setContext`.
- **`package.json` (`contributes`)** — every profiling `when` clause keys off it:
  - Python Processes view: `basilisk.hasWorkspace` → `basilisk.hasWorkspace && basilisk.profilingEnabled`.
  - Profiler command-palette entries (`profileStart/Stop/Snapshot/AttachToDebug/Diff`, `profileCurrentFile`, and the panel's `refresh/sort/group/filterProcesses`) — newly added with `when: basilisk.profilingEnabled` (they were previously shown unconditionally).
  - Memory command-palette entries: `basilisk.debugging` → `basilisk.debugging && basilisk.profilingEnabled`.
  - Profiler keybindings (`profileStart`, `profileStop`): now also require `basilisk.profilingEnabled`.
- **`memory-profiler.ts`** — the memory status-bar item is the one surface no `when` clause can reach (created in code, shown on debug-session events); `registerMemoryProfiler` reads the same switch into a module flag and `refreshMemoryStatusBar` hides it when off.

Nothing is deleted: all profiler/memory commands stay registered and advertised by the LSP, and the inline-only process commands keep their existing `"when": "false"`. To ship profiling, return `true` from the switch and drop the gate.

## How Do The Automated Tests Prove It Works?
- `make ci` passes end-to-end (Rust lint + coverage, VS Code e2e, Neovim, Zed, release build).
- VS Code extension e2e suite: **328 passing, 0 failing**; VSIX line coverage **87% ≥ 86%** gate.
- `profiling-ui.ts` reports **100%** statement/branch/function/line coverage — the switch is fully exercised by extension activation in `Test` mode (which is why no dedicated gate test is needed).
- The "Basilisk Activity Panel Accessibility Audit → toolbar/context menu entries have 'when' clauses" tests pass, confirming the added/edited `when` clauses are well-formed.
- The existing "Profiler — Start/Stop Lifecycle", "Profiler — Decoration Lifecycle", and "Profiler — Error Handling" suites still pass: commands remain registered, and under test the gate is on so the UI is live.

## Spec / Doc Changes
- Added a concise `## UI Availability Gate {#PROFILE-UI-GATE}` section to `docs/specs/LSP-PROFILING-SPEC.md` describing the switch, where it lives, the two surfaces it drives, and how to re-enable.

## Breaking Changes
- [ ] None

Intentional UX change (not an API break): the profiling UI is deliberately hidden in shipped/dev-host builds until the experience is reliable. All commands remain registered and the LSP still advertises them, so nothing downstream breaks — the surfaces simply do not appear for end users yet.
