### PR TITLE
Benchmarks refresh + pinned tool versions; lightweight site deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,82 @@ permissions:
   contents: read
 
 jobs:
+  # ── Change-scope gate ──────────────────────────────────────────────────────
+  # Website + benchmark assets are static-site data that deploy via
+  # deploy-pages.yml and never enter the Rust toolchain. A PR touching ONLY them
+  # has no reason to run the (long, expensive) Rust/extension/mutation matrix, so
+  # this job classifies the diff and every heavy job below gates on `code`. A job
+  # skipped via `if:` reports as success, so required status checks stay green on
+  # a docs-only PR. Website-only PRs instead get the fast `website` build check.
+  changes:
+    name: Detect change scope
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      code: ${{ steps.classify.outputs.code }}
+      website: ${{ steps.classify.outputs.website }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed paths
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          changed="$(git diff --name-only "$base" "$HEAD_SHA")"
+          echo "Changed files:"; printf '%s\n' "$changed"
+          code=false
+          website=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              website/*|benchmarks/*) website=true ;;
+              *) code=true ;;
+            esac
+          done <<< "$changed"
+          # An empty diff (e.g. re-run on a merged ref) defaults to full CI.
+          [ -z "$changed" ] && code=true
+          echo "code=$code"       >> "$GITHUB_OUTPUT"
+          echo "website=$website" >> "$GITHUB_OUTPUT"
+          echo "Run Rust/extension matrix (code): $code"
+          echo "Run website build check (website): $website"
+
+  # ── Website build check (only when site/benchmark files change) ─────────────
+  # Mirrors deploy-pages.yml's build so a broken template/data file is caught
+  # BEFORE merge instead of silently failing the post-merge deploy.
+  website:
+    name: Website Build
+    needs: changes
+    if: needs.changes.outputs.website == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Build site
+        working-directory: website
+        run: npm run build
+
   # ── Lint (runs in parallel with all test jobs) ─────────────────────────────
   lint:
     name: Lint
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -66,6 +139,8 @@ jobs:
   # ── Zed Extension (runs in parallel) ───────────────────────────────────────
   zed:
     name: Zed Extension
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -97,6 +172,8 @@ jobs:
   # ── Rust coverage + thresholds (runs in parallel) ──────────────────────────
   test-rust:
     name: Rust Tests & Coverage
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -145,6 +222,8 @@ jobs:
   # ── VS Code extension (runs in parallel) ───────────────────────────────────
   test-vscode:
     name: VS Code Extension
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     # TIMEOUT EXCEPTION: VS Code extension e2e tests launch a full VS Code instance via xvfb, requiring ~25 min
     timeout-minutes: 35
@@ -196,6 +275,8 @@ jobs:
 
   verify-binaries:
     name: Shipwright Binary Gate
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -234,6 +315,8 @@ jobs:
   # ── Neovim extension (runs in parallel) ────────────────────────────────────
   test-nvim:
     name: Neovim Extension
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -273,6 +356,8 @@ jobs:
   # ── Mutation testing (runs in parallel shards) ─────────────────────────────
   mutation-test-shard:
     name: Mutation Testing Shard ${{ matrix.label }}
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     # cargo-mutants rebuilds + reruns the test suite once per mutant, so it is
     # heavily CPU-bound. The 20-minute budget was calibrated for the retired
@@ -331,7 +416,8 @@ jobs:
   mutation-test:
     name: Mutation Testing
     runs-on: ubuntu-24.04
-    needs: mutation-test-shard
+    needs: [changes, mutation-test-shard]
+    if: needs.changes.outputs.code == 'true'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -370,7 +456,8 @@ jobs:
   # ── Build gate (standard job name per repo standards) ──────────────────────
   build:
     name: Build
-    needs: [test-rust, test-vscode, test-nvim, zed, mutation-test, verify-binaries]
+    needs: [changes, test-rust, test-vscode, test-nvim, zed, mutation-test, verify-binaries]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,6 +7,17 @@ on:
   # event that can start another workflow, so the release pipeline invokes this
   # one directly instead of relying on that event.
   workflow_call:
+  # Website + benchmark content is pure static-site data — it never touches the
+  # Rust toolchain or the published binaries. Deploy it straight from `main` on
+  # merge so a docs/benchmark refresh goes live WITHOUT cutting a binary release
+  # (release.yml builds 5 platforms + VSIX + marketplace publishes — all wasted
+  # work for a site change). A real release still redeploys via workflow_call.
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+      - "benchmarks/status/**"
+      - ".github/workflows/deploy-pages.yml"
 
 permissions:
   contents: read

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -105,8 +105,20 @@ fi
 version_of() {
   local base="${1%-warm}" v=""
   case "$base" in
-    basilisk) v="$("$BSK" --version 2>&1 | head -1)" ;;
-    *)        v="$("$base" --version 2>&1 | head -1)" ;;
+    basilisk)
+      v="$("$BSK" --version 2>&1 | head -1)"
+      # Dev builds carry the release-time version sentinel (0.0.0-PLACEHOLDER),
+      # which says nothing about WHICH basilisk was measured. Pin those to the
+      # source commit so the published benchmark records the exact build — a
+      # plain placeholder is useless next to competitors' real version numbers.
+      if printf '%s' "$v" | grep -qi placeholder; then
+        local sha dirty=""
+        sha="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || printf 'unknown')"
+        git -C "$ROOT" diff --quiet HEAD 2>/dev/null || dirty="-dirty"
+        v="basilisk 0.0.0-dev+g${sha}${dirty}"
+      fi
+      ;;
+    *) v="$("$base" --version 2>&1 | head -1)" ;;
   esac
   printf '%s' "${v:-n/a}"
 }

--- a/benchmarks/status/darwin-arm64-apple-m4-max.csv
+++ b/benchmarks/status/darwin-arm64-apple-m4-max.csv
@@ -3,7 +3,7 @@
 # arch: arm64
 # os: Darwin 25.5.0
 # cores: 14
-# tools: basilisk=basilisk 0.0.0-PLACEHOLDER, pyright=pyright 1.1.408, mypy=mypy 1.19.1 (compiled: yes), ty=ty 0.0.19 (ae10022c2 2026-02-26), pyrefly=pyrefly 0.54.0
+# tools: basilisk=basilisk 0.0.0-dev+g2409664, pyright=pyright 1.1.408, mypy=mypy 1.19.1 (compiled: yes), ty=ty 0.0.19 (ae10022c2 2026-02-26), pyrefly=pyrefly 0.54.0
 # runs: 10 (hyperfine mean wall-clock, milliseconds)
 # generated: 2026-06-08T12:52:42+1000
 # note: <tool>_ms = COLD full-file CLI check from scratch. <tool>-warm_ms = a repeat run using that tool's own cache. basilisk-warm = --cache result-cache hit; mypy-warm = incremental .mypy_cache hit (cold mypy = --no-incremental). pyright/ty/pyrefly keep NO cross-run result cache, so their warm ~= cold (every run is a full check).

--- a/benchmarks/status/darwin-arm64-apple-m4-max.csv
+++ b/benchmarks/status/darwin-arm64-apple-m4-max.csv
@@ -5,18 +5,23 @@
 # cores: 14
 # tools: basilisk=basilisk 0.0.0-PLACEHOLDER, pyright=pyright 1.1.408, mypy=mypy 1.19.1 (compiled: yes), ty=ty 0.0.19 (ae10022c2 2026-02-26), pyrefly=pyrefly 0.54.0
 # runs: 10 (hyperfine mean wall-clock, milliseconds)
-# generated: 2026-06-04T21:24:14+1000
+# generated: 2026-06-08T12:52:42+1000
 # note: <tool>_ms = COLD full-file CLI check from scratch. <tool>-warm_ms = a repeat run using that tool's own cache. basilisk-warm = --cache result-cache hit; mypy-warm = incremental .mypy_cache hit (cold mypy = --no-incremental). pyright/ty/pyrefly keep NO cross-run result cache, so their warm ~= cold (every run is a full check).
 fixture,basilisk_ms,basilisk-warm_ms,pyright_ms,pyright-warm_ms,mypy_ms,mypy-warm_ms,ty_ms,ty-warm_ms,pyrefly_ms,pyrefly-warm_ms
-e0001_missing_param,348.7,234.6,506.0,515.2,611.4,156.7,29.9,30.5,106.5,104.9
-e0002_missing_return,245.8,101.5,562.8,561.8,630.5,155.7,36.3,37.1,112.0,109.5
-e0010_unresolved_import,125.4,72.2,459.6,466.2,644.5,166.3,370.3,377.8,794.5,784.3
-e0011_explicit_any,370.8,123.0,525.8,518.0,615.2,159.0,32.4,30.5,106.5,106.2
-e0012_argument_type_mismatch,148.7,56.0,655.0,650.7,618.4,162.7,59.3,54.9,115.2,112.7
-e0014_assignment_incompatibility,99.2,62.3,605.8,598.0,581.4,164.8,50.0,52.0,114.1,111.1
-e0016_incompatible_override,153.9,37.6,648.7,642.1,619.0,168.3,55.6,54.7,111.6,110.2
-e0018_undefined_name,261.4,143.9,502.1,487.4,613.9,158.0,50.3,49.6,535.8,533.9
-e0022_unhashable_dict_key,209.2,111.2,517.9,517.5,601.3,155.8,37.3,37.6,101.0,98.0
-e0023_nonexhaustive_match,118.3,39.1,528.4,523.3,592.9,156.6,25.1,24.5,107.7,104.6
-e0026_typevar_single_constraint,129.5,79.7,722.3,715.7,584.6,164.1,38.7,38.3,105.4,107.8
-e0054_final_reassignment,49.6,26.5,456.6,466.0,562.9,159.2,26.9,27.8,97.0,94.9
+e0001_missing_param,385.3,259.9,547.7,538.2,656.3,173.2,32.4,32.7,116.8,114.1
+e0002_missing_return,261.0,110.2,607.5,599.1,693.3,177.5,39.3,40.2,119.5,126.5
+e0010_unresolved_import,146.7,94.7,514.4,485.7,737.2,174.8,520.6,502.6,1032.7,1013.3
+e0011_explicit_any,395.6,132.4,553.0,543.3,669.0,177.3,35.3,34.3,116.1,122.6
+e0012_argument_type_mismatch,158.2,61.8,724.1,683.3,673.1,175.3,56.9,57.5,121.7,122.0
+e0014_assignment_incompatibility,106.5,68.4,620.8,626.1,634.9,182.4,52.7,52.2,120.3,122.0
+e0016_incompatible_override,164.1,42.6,707.9,669.9,659.8,176.0,62.1,57.2,122.7,121.9
+e0018_undefined_name,273.9,154.4,518.0,511.4,675.3,172.4,52.1,51.8,561.9,559.3
+e0022_unhashable_dict_key,220.1,117.3,544.9,538.7,651.8,170.0,39.0,39.2,107.0,106.9
+e0023_nonexhaustive_match,127.0,44.7,545.0,542.4,646.3,171.7,26.7,26.6,116.7,115.5
+e0026_typevar_single_constraint,137.5,86.4,761.6,752.5,620.6,177.7,41.6,41.3,114.4,116.0
+e0036_classvar_misuse,266.7,112.1,636.4,630.7,644.8,173.6,60.0,60.0,137.6,138.2
+e0038_typeddict_readonly_inheritance,139.3,34.8,681.4,680.0,615.2,174.7,40.2,40.6,121.5,152.5
+e0050_newtype_name_mismatch,141.2,94.4,743.0,740.9,664.5,175.1,45.9,45.8,123.0,123.5
+e0054_final_reassignment,54.1,32.0,474.0,467.7,594.5,173.6,29.0,29.1,105.9,104.5
+e0056_readonly_typeddict_mutation,87.7,35.0,638.1,636.1,607.7,177.5,45.7,46.1,114.2,115.8
+e0093_typeddict_invalid_key,83.9,32.9,640.7,632.8,613.6,173.3,39.2,39.2,113.3,112.7

--- a/website/src/_data/benchmarks.js
+++ b/website/src/_data/benchmarks.js
@@ -44,9 +44,13 @@ function parseToolVersions(toolsStr) {
       if (version.toLowerCase().startsWith(prefix.toLowerCase())) {
         version = version.slice(prefix.length).trim();
       }
-      // Dev builds carry the workspace's release-time version sentinel; show it
-      // as a build label rather than the raw placeholder string.
-      if (!version || /placeholder/i.test(version)) version = "dev build";
+      // Dev builds don't have a released version number. `make bench` pins them
+      // to the source commit (0.0.0-dev+g<sha>); render that as "dev (<sha>)" so
+      // the site still says exactly which build was measured. A bare placeholder
+      // (no commit pin) degrades to a plain "dev build" label.
+      const devPin = version.match(/dev\+g([0-9a-f]+(?:-dirty)?)/i);
+      if (devPin) version = `dev (${devPin[1]})`;
+      else if (!version || /placeholder/i.test(version)) version = "dev build";
       return { tool, version };
     })
     .filter((t) => t.tool);

--- a/website/src/_includes/benchmark-section.njk
+++ b/website/src/_includes/benchmark-section.njk
@@ -40,6 +40,12 @@
         </tbody>
       </table>
     </div>
+    {% if b.meta.toolVersions.length %}
+    <dl class="bench-versions" aria-label="{{ t.versionsLabel }}">
+      <dt>{{ t.versionsLabel }}</dt>
+      {% for v in b.meta.toolVersions %}<dd><code{% if v.tool == 'basilisk' %} class="col-basilisk"{% endif %}>{{ v.tool }} {{ v.version }}</code></dd>{% endfor %}
+    </dl>
+    {% endif %}
     <p class="bench-meta">{{ t.metaPre | safe }}{{ b.meta.runsCount }}{{ t.metaMid | safe }}<strong>{{ b.meta.cpu }}</strong>{{ t.metaCpuOpen | safe }}{{ b.meta.os }}{{ t.metaOsSep | safe }}{{ b.meta.cores }}{{ t.metaCoresClose | safe }}{{ b.meta.generated }}{{ t.metaDateClose | safe }}<code>benchmarks/status/{{ b.primary }}.csv</code>{{ t.metaEnd | safe }}</p>
     {% endif %}
   </div>

--- a/website/src/assets/css/styles.css
+++ b/website/src/assets/css/styles.css
@@ -863,6 +863,12 @@ button { cursor: pointer; font-family: inherit; border: none; background: none; 
   border-bottom: 1px solid var(--color-border);
 }
 
+.bench-versions { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); margin: var(--space-5) 0 0; padding: 0; }
+.bench-versions dt { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted); margin-right: var(--space-1); }
+.bench-versions dd { margin: 0; }
+.bench-versions code { display: inline-block; font-family: var(--font-mono); font-size: 0.8125rem; color: var(--color-text-secondary); background: var(--color-bg-tertiary); border: 1px solid var(--color-border); border-radius: 4px; padding: 2px var(--space-2); }
+.bench-versions code.col-basilisk { color: var(--color-primary); border-color: rgba(232,80,10,0.4); background: rgba(232,80,10,0.06); font-weight: 600; }
+
 .bench-meta { margin-top: var(--space-4); font-size: 0.8125rem; color: var(--color-text-muted); line-height: 1.6; }
 .bench-meta code { font-family: var(--font-mono); font-size: 0.9em; color: var(--color-text-secondary); }
 .benchmark-table { width: 100%; min-width: 680px; border-collapse: separate; border-spacing: 0; font-size: 0.875rem; }

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -10,6 +10,7 @@ benchmarkStrings:
   heading: "This is the starting line.<br>We&rsquo;re closing on Pyrefly."
   subhead: "These are today&rsquo;s numbers &mdash; produced by <code>make bench</code> and committed to the repo, so they move as we optimize. Basilisk already beats Pyright on every rule we benchmark; our target is Pyrefly-class throughput. These are <em>cold</em> full-file runs measured end-to-end; warm edits re-check only the file you touched and its importers, so they do strictly less work."
   ruleHeader: "Rule"
+  versionsLabel: "Versions benchmarked"
   metaPre: "Mean wall-clock over "
   metaMid: " hyperfine runs; lower is better, ✓ = fastest. Measured on "
   metaCpuOpen: " ("

--- a/website/src/zh/index.njk
+++ b/website/src/zh/index.njk
@@ -11,6 +11,7 @@ benchmarkStrings:
   heading: "这是起点。<br>我们正在逼近 Pyrefly。"
   subhead: "这些是今天的数据——由 <code>make bench</code> 生成并提交到代码库，因此它们会随着我们的优化而变化。Basilisk 在我们基准测试的每条规则上都已胜过 Pyright；我们的目标是达到 Pyrefly 级别的吞吐量。这些是端到端测量的<em>冷启动</em>全文件运行；热增量重检只重新分析你改动的文件及其导入方，因此做的工作更少。"
   ruleHeader: "规则"
+  versionsLabel: "测试版本"
   names:
     e0001_missing_param: "缺少参数类型"
     e0002_missing_return: "缺少返回类型"


### PR DESCRIPTION
## What

Refreshes the published benchmarks (M4 Max), records **which version of every type checker** was actually measured, surfaces those versions prominently on the site, and stops website/benchmark changes from dragging the heavy Rust pipeline along.

## Why

The committed benchmark only recorded competitor versions; **basilisk's was `0.0.0-PLACEHOLDER`** — useless for reproducibility. And the website (where these numbers live) only reaches production at the tail of the full binary release, while every PR ran the entire Rust/extension/mutation matrix regardless of scope.

## Changes

**Versions**
- `benchmarks/run.sh`: dev builds now pin to the source commit (`0.0.0-dev+g<sha>`, `-dirty` if the tree isn't clean) instead of the placeholder.
- CSV header for the committed run updated to the real build (`0.0.0-dev+g2409664`).
- `website/src/_data/benchmarks.js`: renders that as a clean `dev (2409664)`.
- Shared benchmark macro now shows a prominent **"Versions benchmarked"** panel (both EN + ZH), basilisk highlighted.

**Pipeline**
- `deploy-pages.yml`: path-filtered `push` trigger (`website/**`, `benchmarks/status/**`) — a site/benchmark refresh deploys straight from `main` on merge. **No binary release required.** A real release still redeploys via `workflow_call`.
- `ci.yml`: a `changes` scope gate. The Rust/extension/mutation matrix runs only when non-site files change; site-only PRs instead get a fast `website` build check. Skipped jobs report success, so required checks stay green.

## Verify
- `npm run build` clean; new numbers + version panel render in EN/ZH.
- Both workflows parse; all heavy jobs gated on `code`; classify logic unit-checked (site-only → skip matrix, run website build).