### PR TITLE
Profiling & memory: fix UX defects #79/#81/#82, full e2e coverage, Linux ptrace precheck

### DIFF
--- a/crates/basilisk-lsp/src/profiler/helper_client/mod.rs
+++ b/crates/basilisk-lsp/src/profiler/helper_client/mod.rs
@@ -20,19 +20,24 @@
 //! inherits an inaccessible working directory.
 
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use basilisk_profiler_protocol::{read_message, write_message, Command, Message};
-use tokio::io::BufReader;
+use basilisk_profiler_protocol::{
+    classify_attach_error, read_message, write_message, AttachErrorKind, Command, Message,
+};
+use tokio::io::{AsyncReadExt, BufReader};
 use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::UnixListener;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 use tracing::{info, warn};
 
-use super::sampler::{SampleBatch, SamplerConfig, SamplerError, SamplerHandle};
+use super::sampler::{
+    sampler_error_from_kind, SampleBatch, SamplerConfig, SamplerError, SamplerHandle,
+};
 
 mod wire;
 pub use wire::build_elevation_script;
@@ -46,6 +51,11 @@ const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
 const STOP_POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// How long to wait for the helper's final `stopped` after we send `stop`.
 const STOP_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long to wait for a dead helper's exit status and stderr while
+/// diagnosing a failed handshake (issue #81).
+const EXIT_DIAGNOSIS_TIMEOUT: Duration = Duration::from_secs(3);
+/// How many trailing stderr lines to surface in a handshake diagnosis.
+const STDERR_TAIL_LINES: usize = 5;
 /// Sample-batch channel depth (mirrors the in-process sampler).
 const SAMPLE_CHANNEL_DEPTH: usize = 256;
 
@@ -223,9 +233,12 @@ async fn handshake(
             )))
         }
         Err(_elapsed) => {
-            return Err(SamplerError::AttachFailed(
-                "timed out waiting for the profiler helper to connect".to_owned(),
-            ))
+            // The helper never connected — e.g. the user dismissed the macOS
+            // elevation prompt. Its exit status/stderr say why (issue #81).
+            let diagnosis = helper_exit_diagnosis(child).await;
+            return Err(SamplerError::AttachFailed(format!(
+                "timed out waiting for the profiler helper to connect ({diagnosis})"
+            )));
         }
     };
 
@@ -245,15 +258,26 @@ async fn handshake(
     let python_version =
         match timeout(HANDSHAKE_TIMEOUT, read_message::<_, Message>(&mut reader)).await {
             Ok(Ok(Some(Message::Attached { python, .. }))) => python,
+            // The helper reported WHY it failed — surface the real, classified
+            // cause instead of a generic attach error (issue #81).
+            Ok(Ok(Some(Message::Error { kind, message }))) => {
+                return Err(sampler_error_from_kind(kind, pid, message))
+            }
             Ok(Ok(Some(Message::Samples { .. } | Message::Stopped))) => {
                 return Err(SamplerError::AttachFailed(
                     "helper sent an unexpected message before confirming attach".to_owned(),
                 ))
             }
             Ok(Ok(None)) => {
-                return Err(SamplerError::AttachFailed(
-                    "helper closed the connection before confirming attach".to_owned(),
-                ))
+                // Bare EOF (e.g. an old helper, or one killed before it could
+                // report) — reap it and surface exit status + stderr (issue #81).
+                let diagnosis = helper_exit_diagnosis(child).await;
+                let message =
+                    format!("helper closed the connection before confirming attach ({diagnosis})");
+                return Err(match classify_attach_error(&message) {
+                    AttachErrorKind::PermissionDenied => SamplerError::PermissionDenied(message),
+                    _ => SamplerError::AttachFailed(message),
+                });
             }
             Ok(Err(err)) => {
                 return Err(SamplerError::AttachFailed(format!(
@@ -261,9 +285,10 @@ async fn handshake(
                 )))
             }
             Err(_elapsed) => {
-                return Err(SamplerError::AttachFailed(
-                    "timed out waiting for the helper to confirm attach".to_owned(),
-                ))
+                let diagnosis = helper_exit_diagnosis(child).await;
+                return Err(SamplerError::AttachFailed(format!(
+                    "timed out waiting for the helper to confirm attach ({diagnosis})"
+                )));
             }
         };
 
@@ -276,6 +301,51 @@ async fn handshake(
     })
 }
 
+/// Reap a helper that failed the handshake and describe its exit status and
+/// trailing stderr — the diagnosable cause issue #81 demanded in place of a
+/// bare EOF. Kills the helper if it refuses to exit within the bounded wait.
+/// Implements [PROFILE-HELPER-PROTOCOL-ERRORS] (exit-diagnosis fallback).
+async fn helper_exit_diagnosis(mut child: tokio::process::Child) -> String {
+    let mut stderr_text = String::new();
+    if let Some(mut stderr) = child.stderr.take() {
+        let _ = timeout(
+            EXIT_DIAGNOSIS_TIMEOUT,
+            stderr.read_to_string(&mut stderr_text),
+        )
+        .await;
+    }
+    let status = match timeout(EXIT_DIAGNOSIS_TIMEOUT, child.wait()).await {
+        Ok(Ok(status)) => format!("helper exited with {status}"),
+        Ok(Err(err)) => format!("helper exit status unavailable: {err}"),
+        Err(_elapsed) => {
+            let _ = child.start_kill();
+            "helper did not exit".to_owned()
+        }
+    };
+    let tail = stderr_tail(&stderr_text);
+    if tail.is_empty() {
+        status
+    } else {
+        format!("{status}; stderr: {tail}")
+    }
+}
+
+/// The last few non-empty stderr lines, joined for a single-line diagnosis.
+fn stderr_tail(stderr: &str) -> String {
+    let lines: Vec<&str> = stderr
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    let skip = lines.len().saturating_sub(STDERR_TAIL_LINES);
+    lines
+        .iter()
+        .skip(skip)
+        .copied()
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
 /// Spawn the helper process per the requested mode (detached — never awaited).
 ///
 /// `tokio::process::Command::spawn` returns immediately (it does not await the
@@ -286,8 +356,11 @@ fn spawn_helper(
     socket_path: &Path,
 ) -> Result<tokio::process::Child, SamplerError> {
     match spawn {
+        // Stderr is piped so a failed handshake can surface the helper's own
+        // error output instead of an undiagnosable EOF (issue #81).
         HelperSpawn::Direct(path) => tokio::process::Command::new(path)
             .arg(socket_path)
+            .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .map_err(|err| {
@@ -309,8 +382,11 @@ fn spawn_elevated(socket_path: &Path) -> Result<tokio::process::Child, SamplerEr
         &socket_path.display().to_string(),
     );
     info!(helper = %helper.display(), "spawning elevated profiler helper via osascript");
+    // Stderr is piped so an elevation failure (e.g. the user cancelling the
+    // privilege prompt) is surfaced with osascript's own message (issue #81).
     tokio::process::Command::new("osascript")
         .args(["-e", &script])
+        .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
         .map_err(|err| {
@@ -413,6 +489,10 @@ async fn read_until_stopped(
                 }
             }
             Ok(Some(Message::Stopped) | None) => break,
+            Ok(Some(Message::Error { kind, message })) => {
+                warn!(?kind, %message, "helper reported an error during sampling");
+                break;
+            }
             Ok(Some(Message::Attached { .. })) => {}
             Err(err) => {
                 warn!(%err, "error reading from profiler helper");

--- a/crates/basilisk-lsp/src/profiler/mod.rs
+++ b/crates/basilisk-lsp/src/profiler/mod.rs
@@ -34,6 +34,7 @@ mod pipeline_tests;
 mod scenario_tests;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 
 use tokio::sync::Mutex;
@@ -134,6 +135,19 @@ pub struct SessionInfo {
     pub duration: f64,
 }
 
+/// A live progress sample for [PROFILE-NOTIFICATIONS-PROGRESS].
+#[derive(Debug, Clone)]
+pub struct ProgressInfo {
+    /// Session being reported.
+    pub session_id: String,
+    /// Samples collected so far.
+    pub sample_count: u64,
+    /// Seconds since the session started.
+    pub duration: f64,
+    /// Hottest function seen so far (empty until data crosses thresholds).
+    pub top_function: String,
+}
+
 /// Result of starting a profiling session.
 #[derive(Debug, Clone)]
 pub struct StartResult {
@@ -173,9 +187,12 @@ pub struct StopResult {
 /// Manages active profiling sessions for the LSP.
 ///
 /// One session per PID. Lives on `LspServer` alongside `DebugSessionManager`.
+/// Cloning shares the session table, so a clone can drive the progress
+/// notifier task ([PROFILE-NOTIFICATIONS-PROGRESS]).
+#[derive(Clone)]
 pub struct ProfileSessionManager {
-    /// Active sessions keyed by session ID.
-    sessions: Mutex<HashMap<String, ProfileSession>>,
+    /// Active sessions keyed by session ID (shared across clones).
+    sessions: Arc<Mutex<HashMap<String, ProfileSession>>>,
 }
 
 impl std::fmt::Debug for ProfileSessionManager {
@@ -196,7 +213,7 @@ impl ProfileSessionManager {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            sessions: Mutex::new(HashMap::new()),
+            sessions: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -356,6 +373,27 @@ impl ProfileSessionManager {
             hotspot_config: session.hotspot_config.clone(),
             sample_weight: session.sample_weight,
             sample_rate: session.sample_rate,
+        })
+    }
+
+    /// Drain pending samples and report live progress for one session, or
+    /// `None` once the session has ended (which stops the notifier task).
+    /// Implements [PROFILE-NOTIFICATIONS-PROGRESS].
+    pub async fn progress(&self, session_id: &str) -> Option<ProgressInfo> {
+        let mut sessions = self.sessions.lock().await;
+        let session = sessions.get_mut(session_id)?;
+        drain_samples(session);
+        let top_function = session
+            .data
+            .hot_functions(&session.hotspot_config)
+            .first()
+            .map(|hot| hot.name.clone())
+            .unwrap_or_default();
+        Some(ProgressInfo {
+            session_id: session.session_id.clone(),
+            sample_count: session.data.total_samples,
+            duration: session.started_at.elapsed().as_secs_f64(),
+            top_function,
         })
     }
 

--- a/crates/basilisk-lsp/src/profiler/privilege.rs
+++ b/crates/basilisk-lsp/src/profiler/privilege.rs
@@ -61,7 +61,8 @@ pub(crate) async fn create_sampler(config: &SamplerConfig) -> Result<SamplerHand
     let status = check_profiling_permissions(config.pid).map_err(ProfileError::ExportFailed)?;
 
     match status {
-        PermissionStatus::Allowed => sampler::start_sampler(config).map_err(ProfileError::Sampler),
+        PermissionStatus::Allowed => sampler::start_sampler(config)
+            .map_err(|err| ProfileError::Sampler(with_platform_guidance(err))),
         PermissionStatus::ElevationRequired(reason) => {
             info!(pid = config.pid, %reason, "elevation required; sampling via elevated helper");
             start_elevated_sampler(config)
@@ -72,6 +73,30 @@ pub(crate) async fn create_sampler(config: &SamplerConfig) -> Result<SamplerHand
             SamplerError::PermissionDenied(reason),
         )),
     }
+}
+
+/// Append platform remedies to a permission failure so a denied attach stays
+/// actionable (issue #81): on Linux a real `EPERM` from py-spy gets the
+/// `ptrace_scope` remedies the upfront check can no longer assert (see
+/// [`classify_ptrace_scope`]). Other errors and platforms pass through.
+#[cfg(target_os = "linux")]
+fn with_platform_guidance(err: SamplerError) -> SamplerError {
+    match err {
+        SamplerError::PermissionDenied(msg) => SamplerError::PermissionDenied(format!(
+            "{msg}. ptrace is restricted on this system: run \
+             `sudo sysctl kernel.yama.ptrace_scope=0`, or \
+             `sudo setcap cap_sys_ptrace+ep $(which basilisk)`, or \
+             profile the process via a debug session."
+        )),
+        other => other,
+    }
+}
+
+/// Non-Linux: no extra guidance to add — macOS routes through elevation and
+/// Windows needs none for same-user targets.
+#[cfg(not(target_os = "linux"))]
+fn with_platform_guidance(err: SamplerError) -> SamplerError {
+    err
 }
 
 /// macOS: stream samples from the elevated helper over a Unix socket.
@@ -182,29 +207,40 @@ fn check_linux_permissions(pid: u32) -> PermissionStatus {
     }
 
     match read_ptrace_scope() {
-        Ok(0) => PermissionStatus::Allowed,
-        Ok(1) => PermissionStatus::Denied(
-            "ptrace_scope is 1 (restricted). Only parent processes can trace children. \
-             Options: run `sudo sysctl kernel.yama.ptrace_scope=0` or \
-             `sudo setcap cap_sys_ptrace+ep $(which basilisk)` or \
-             profile child processes via debug sessions."
-                .to_owned(),
-        ),
-        Ok(2) => PermissionStatus::Denied(
-            "ptrace_scope is 2 (admin-only). Requires CAP_SYS_PTRACE. \
-             Run: `sudo setcap cap_sys_ptrace+ep $(which basilisk)`"
-                .to_owned(),
-        ),
-        Ok(3) => PermissionStatus::Denied(
-            "ptrace_scope is 3 (no ptrace). Profiling external processes is disabled \
-             by kernel policy. Profile child processes via debug sessions instead."
-                .to_owned(),
-        ),
-        Ok(scope) => PermissionStatus::Denied(format!("Unknown ptrace_scope value: {scope}")),
+        Ok(scope) => classify_ptrace_scope(scope),
         Err(err) => {
             warn!(%err, "could not read ptrace_scope, assuming allowed");
             PermissionStatus::Allowed
         }
+    }
+}
+
+/// Map a Yama `ptrace_scope` value to a permission status (pure, so every
+/// platform's test suite can pin the policy).
+///
+/// `1` (restricted) is deliberately **Allowed**: Yama still permits two
+/// grants this precheck cannot see — *ancestor* relationships (a debug
+/// session's debuggee is the LSP's grandchild via `debugpy.adapter`) and
+/// targets that opted in via `PR_SET_PTRACER`. Denying upfront falsely
+/// blocked the flagship "Run & Profile" flows on default Ubuntu; instead the
+/// attach is attempted and a real `EPERM` is surfaced with remedies appended
+/// (see `with_platform_guidance`). Scopes `2`/`3` are kernel-enforced
+/// regardless of relationship, so they stay denied with the remedy.
+#[cfg(any(target_os = "linux", test))]
+fn classify_ptrace_scope(scope: u8) -> PermissionStatus {
+    match scope {
+        0 | 1 => PermissionStatus::Allowed,
+        2 => PermissionStatus::Denied(
+            "ptrace_scope is 2 (admin-only). Requires CAP_SYS_PTRACE. \
+             Run: `sudo setcap cap_sys_ptrace+ep $(which basilisk)`"
+                .to_owned(),
+        ),
+        3 => PermissionStatus::Denied(
+            "ptrace_scope is 3 (no ptrace). Profiling external processes is disabled \
+             by kernel policy. Profile child processes via debug sessions instead."
+                .to_owned(),
+        ),
+        other => PermissionStatus::Denied(format!("Unknown ptrace_scope value: {other}")),
     }
 }
 
@@ -431,6 +467,41 @@ mod tests {
     fn linux_reads_ptrace_scope_without_panic() {
         // Should return a valid status regardless of the actual scope value.
         let _result = check_linux_permissions(1);
+    }
+
+    /// Restricted Yama (`ptrace_scope=1`) must attempt the attach instead of
+    /// denying upfront: the kernel still grants ancestors (debug-session
+    /// debuggees) and `PR_SET_PTRACER` opt-ins, which the precheck cannot see.
+    #[test]
+    fn restricted_ptrace_scope_attempts_attach_instead_of_denying() {
+        assert_eq!(classify_ptrace_scope(0), PermissionStatus::Allowed);
+        assert_eq!(
+            classify_ptrace_scope(1),
+            PermissionStatus::Allowed,
+            "scope=1 (default Ubuntu) must not falsely deny debuggee/opt-in targets"
+        );
+        assert!(
+            matches!(classify_ptrace_scope(2), PermissionStatus::Denied(ref r) if r.contains("setcap")),
+            "scope=2 stays denied with the setcap remedy"
+        );
+        assert!(
+            matches!(classify_ptrace_scope(3), PermissionStatus::Denied(ref r) if r.contains("debug session")),
+            "scope=3 stays denied, pointing at debug sessions"
+        );
+    }
+
+    /// A real EPERM from py-spy must come back with the Linux remedies (#81).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_permission_failures_carry_ptrace_remedies() {
+        let err = with_platform_guidance(SamplerError::PermissionDenied(
+            "Operation not permitted".to_owned(),
+        ));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ptrace") && msg.contains("setcap"),
+            "guidance must name the remedies: {msg}"
+        );
     }
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/crates/basilisk-lsp/src/profiler/sampler.rs
+++ b/crates/basilisk-lsp/src/profiler/sampler.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use basilisk_profiler_protocol::{classify_attach_error, AttachErrorKind};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
@@ -139,6 +140,20 @@ impl std::fmt::Display for SamplerError {
 
 impl std::error::Error for SamplerError {}
 
+/// Map a classified attach failure onto the matching [`SamplerError`] variant.
+///
+/// Shared by the in-process sampler and the elevated-helper client so both
+/// attach paths report identical, distinct failure modes (issue #81).
+#[must_use]
+pub fn sampler_error_from_kind(kind: AttachErrorKind, pid: u32, message: String) -> SamplerError {
+    match kind {
+        AttachErrorKind::ProcessNotFound => SamplerError::ProcessNotFound(pid),
+        AttachErrorKind::NotPython => SamplerError::NotPython(pid),
+        AttachErrorKind::PermissionDenied => SamplerError::PermissionDenied(message),
+        AttachErrorKind::AttachFailed => SamplerError::AttachFailed(message),
+    }
+}
+
 /// Convert a u32 PID to the platform-specific type py-spy expects.
 ///
 /// py-spy uses `remoteprocess::Pid` which is `i32` on Unix and `u32` on Windows.
@@ -179,15 +194,7 @@ pub fn start_sampler(config: &SamplerConfig) -> Result<SamplerHandle, SamplerErr
 
     let spy = py_spy::PythonSpy::new(pid, &spy_config).map_err(|err| {
         let msg = err.to_string();
-        if msg.contains("ermission") {
-            SamplerError::PermissionDenied(msg)
-        } else if msg.contains("ot a python") || msg.contains("ot Python") {
-            SamplerError::NotPython(config.pid)
-        } else if msg.contains("No such process") || msg.contains("not found") {
-            SamplerError::ProcessNotFound(config.pid)
-        } else {
-            SamplerError::AttachFailed(msg)
-        }
+        sampler_error_from_kind(classify_attach_error(&msg), config.pid, msg)
     })?;
 
     let python_version = format!(

--- a/crates/basilisk-lsp/src/server/profiler_handlers.rs
+++ b/crates/basilisk-lsp/src/server/profiler_handlers.rs
@@ -5,11 +5,52 @@
 //! Each handler extracts arguments, delegates to [`ProfileSessionManager`],
 //! and returns structured JSON responses matching the profiling protocol spec.
 
+use std::time::Duration;
+
 use tower_lsp::jsonrpc::Result as LspResult;
 use tower_lsp::lsp_types::MessageType;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use super::LspServer;
+
+/// How often live progress is pushed to the editor while profiling.
+const PROGRESS_NOTIFY_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Custom notification carrying live profiling progress.
+struct ProfilerProgressNotification;
+
+impl tower_lsp::lsp_types::notification::Notification for ProfilerProgressNotification {
+    type Params = serde_json::Value;
+    const METHOD: &'static str = basilisk_common::notifications::PROFILER_PROGRESS;
+}
+
+/// Implements [PROFILE-NOTIFICATIONS-PROGRESS]: push periodic progress
+/// (sample count, duration, top function) until the session ends, so editors
+/// can show a live status indicator while profiling.
+fn spawn_progress_notifier(server: &LspServer, session_id: String) {
+    let manager = server.profiler_manager.clone();
+    let client = server.client.clone();
+    let _notifier = tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(PROGRESS_NOTIFY_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            let _tick = ticker.tick().await;
+            let Some(progress) = manager.progress(&session_id).await else {
+                debug!(%session_id, "profiling session ended; stopping progress notifier");
+                break;
+            };
+            let params = serde_json::json!({
+                "sessionId": progress.session_id,
+                "sampleCount": progress.sample_count,
+                "duration": progress.duration,
+                "topFunction": progress.top_function,
+            });
+            client
+                .send_notification::<ProfilerProgressNotification>(params)
+                .await;
+        }
+    });
+}
 
 /// Construct a profiler-domain LSP error.
 fn profiler_error(code: i64, message: impl Into<String>) -> tower_lsp::jsonrpc::Error {
@@ -88,6 +129,8 @@ pub(super) async fn execute_profiler_start(
                     ),
                 )
                 .await;
+
+            spawn_progress_notifier(server, result.session_id.clone());
 
             Ok(Some(serde_json::json!({
                 "sessionId": result.session_id,

--- a/crates/basilisk-lsp/tests/profiler_helper_socket.rs
+++ b/crates/basilisk-lsp/tests/profiler_helper_socket.rs
@@ -229,9 +229,11 @@ async fn helper_listener_is_bound_before_helper_connects() {
 
     let err = result.expect_err("attaching to a non-Python process must fail");
     let msg = err.to_string();
+    // The helper must CONNECT (listener bound) and then fail the ATTACH —
+    // since #81 it reports the structured py-spy cause over the socket.
     assert!(
-        msg.contains("closed the connection before confirming attach"),
-        "the helper must CONNECT (listener bound) then fail to attach; got: {msg}"
+        msg.contains("py-spy attach failed"),
+        "the helper must connect (listener bound) then report its attach failure; got: {msg}"
     );
     assert!(
         !msg.contains("timed out waiting for the profiler helper to connect"),
@@ -514,6 +516,160 @@ async fn elevated_spawn_is_macos_only() {
     assert!(
         err.to_string().contains("only supported on macOS"),
         "expected a macOS-only error, got: {err}"
+    );
+}
+
+// ── Issue #81: attach failures must be diagnosable ───────────────────────────
+//
+// Tests for [PROFILE-HELPER-PROTOCOL-ERRORS]. The bug: when py-spy
+// attach fails inside the helper, the helper exits without reporting anything
+// over the socket, the LSP reads a clean EOF, and the user sees the bare
+// "helper closed the connection before confirming attach" with no exit code,
+// no stderr, and no underlying cause.
+
+/// The bare, non-actionable EOF message from issue #81. No surfaced error may
+/// consist of only this text.
+const BARE_EOF_MSG: &str = "helper closed the connection before confirming attach";
+
+/// Issue #81 (cause surfacing): attaching the REAL helper to a live non-Python
+/// process must surface the underlying py-spy failure to the caller — not a
+/// bare "helper closed the connection" EOF.
+#[tokio::test]
+async fn attach_failure_to_non_python_target_surfaces_pyspy_cause() {
+    use basilisk_lsp::profiler::helper_client::{start_helper_sampler, HelperSpawn};
+    use basilisk_lsp::profiler::sampler::SamplerConfig;
+
+    let helper = helper_binary_path();
+    let mut sleeper = ProcessGuard::new(
+        Command::new("sleep")
+            .arg("30")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn sleep"),
+    );
+    let config = SamplerConfig {
+        pid: sleeper.id(),
+        sample_rate: 100,
+        include_native: false,
+        include_idle: false,
+        duration: None,
+    };
+
+    let result = timeout(
+        Duration::from_secs(30),
+        start_helper_sampler(&config, HelperSpawn::Direct(helper)),
+    )
+    .await
+    .expect("start_helper_sampler must not hang");
+    sleeper.kill();
+
+    let err = result.expect_err("attaching to a non-Python process must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("py-spy attach failed"),
+        "the helper's real attach error must reach the caller (#81), got: {msg}"
+    );
+}
+
+/// Issue #81 (distinct failure modes): a target PID that no longer exists must
+/// be reported as a distinct, actionable cause — not a bare EOF.
+#[tokio::test]
+async fn attach_to_exited_target_reports_distinct_cause() {
+    use basilisk_lsp::profiler::helper_client::{start_helper_sampler, HelperSpawn};
+    use basilisk_lsp::profiler::sampler::{SamplerConfig, SamplerError};
+
+    let helper = helper_binary_path();
+
+    // A PID that is guaranteed dead: spawn a no-op and reap it.
+    let mut done = Command::new("true").spawn().expect("spawn true");
+    let dead_pid = done.id();
+    let _ = done.wait();
+
+    let config = SamplerConfig {
+        pid: dead_pid,
+        sample_rate: 100,
+        include_native: false,
+        include_idle: false,
+        duration: None,
+    };
+    let err = timeout(
+        Duration::from_secs(30),
+        start_helper_sampler(&config, HelperSpawn::Direct(helper)),
+    )
+    .await
+    .expect("must not hang")
+    .expect_err("attaching to an exited process must fail");
+
+    let msg = err.to_string();
+    let is_distinct = matches!(err, SamplerError::ProcessNotFound(_))
+        || msg.contains("No such process")
+        || msg.to_lowercase().contains("not found");
+    assert!(
+        is_distinct,
+        "an exited target must be reported as process-not-found, not a bare EOF (#81): {msg}"
+    );
+    assert!(
+        !msg.trim_end().ends_with(BARE_EOF_MSG),
+        "error must not be the bare EOF message (#81): {msg}"
+    );
+}
+
+/// Write an executable fake helper that connects, reads the attach command,
+/// writes a recognizable failure to stderr, and exits with a nonzero status —
+/// the silent-death shape that issue #81 says must be diagnosable.
+fn write_silent_death_fake_helper() -> PathBuf {
+    let dir = std::env::temp_dir().join("basilisk_helper_socket_e2e");
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    let path = dir.join(format!("fake-helper-{}.py", unique_suffix()));
+    let script = format!(
+        "#!/usr/bin/env {python}\nimport socket, sys\ns = socket.socket(socket.AF_UNIX)\ns.connect(sys.argv[1])\ns.recv(4096)\nsys.stderr.write(\"task_for_pid mismatch: helper lacks entitlement\\n\")\nsys.stderr.flush()\nsys.exit(7)\n",
+        python = python_path()
+    );
+    std::fs::write(&path, script).expect("write fake helper");
+    let mut perms = std::fs::metadata(&path)
+        .expect("stat fake helper")
+        .permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod fake helper");
+    path
+}
+
+/// Issue #81 (exit code + stderr surfacing): when the helper dies before
+/// confirming attach WITHOUT reporting a structured error, the LSP must capture
+/// and surface the helper's exit status and stderr so the failure is
+/// diagnosable.
+#[tokio::test]
+async fn helper_dying_before_attach_surfaces_exit_status_and_stderr() {
+    use basilisk_lsp::profiler::helper_client::{start_helper_sampler, HelperSpawn};
+    use basilisk_lsp::profiler::sampler::SamplerConfig;
+
+    let fake_helper = write_silent_death_fake_helper();
+    let config = SamplerConfig {
+        pid: std::process::id(),
+        sample_rate: 100,
+        include_native: false,
+        include_idle: false,
+        duration: None,
+    };
+
+    let err = timeout(
+        Duration::from_secs(30),
+        start_helper_sampler(&config, HelperSpawn::Direct(fake_helper.clone())),
+    )
+    .await
+    .expect("must not hang")
+    .expect_err("a helper that dies before confirming attach must fail");
+    let _ = std::fs::remove_file(&fake_helper);
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("task_for_pid mismatch"),
+        "the helper's stderr must be surfaced so the user sees WHY (#81): {msg}"
+    );
+    assert!(
+        msg.contains('7'),
+        "the helper's exit status (7) must be surfaced (#81): {msg}"
     );
 }
 

--- a/crates/basilisk-lsp/tests/profiler_helper_socket.rs
+++ b/crates/basilisk-lsp/tests/profiler_helper_socket.rs
@@ -272,6 +272,9 @@ async fn collect_sample_batches(
                 }
             }
             Ok(Ok(Some(Message::Attached { .. }))) => {}
+            Ok(Ok(Some(Message::Error { kind, message }))) => {
+                panic!("helper reported an error mid-sampling: {kind:?}: {message}")
+            }
             Ok(Ok(Some(Message::Stopped) | None)) => break,
             Ok(Err(err)) => panic!("sample read failed: {err}"),
             Err(_elapsed) => break,

--- a/crates/basilisk-profiler-helper/src/main.rs
+++ b/crates/basilisk-profiler-helper/src/main.rs
@@ -20,7 +20,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use basilisk_profiler_protocol::{
-    read_message, write_message, Command, FrameData, Message, TraceData,
+    classify_attach_error, read_message, write_message, AttachErrorKind, Command, FrameData,
+    Message, TraceData,
 };
 use shipwright::{dispatch, BuildInfo, VersionSpec};
 use shipwright_manifest::{ExecutableKind, Language};
@@ -146,7 +147,36 @@ fn attach_pyspy(
     Ok((spy, version))
 }
 
+/// Whether the target PID is alive (signal-0 probe via `kill`).
+///
+/// Implements [PROFILE-HELPER-PROTOCOL-ERRORS].
+/// Refines attach-failure classification (issue #81): py-spy reports the same
+/// "Failed to open process" for a dead target and for a live one the helper
+/// lacks privileges to read — the user needs to know which.
+fn target_alive(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .status()
+        .map(|status| status.success())
+        .is_ok_and(|alive| alive)
+}
+
+/// Classify an attach failure, refining ambiguous "cannot open" errors with a
+/// liveness probe so target-gone and permission-denied are reported distinctly.
+fn classify_helper_attach_error(pid: u32, message: &str) -> AttachErrorKind {
+    match classify_attach_error(message) {
+        AttachErrorKind::ProcessNotFound | AttachErrorKind::AttachFailed if target_alive(pid) => {
+            AttachErrorKind::PermissionDenied
+        }
+        kind => kind,
+    }
+}
+
 /// Main protocol loop: read attach, sample, respond.
+///
+/// Attach failures are reported back over the socket as a structured
+/// [`Message::Error`] before the helper exits, so the LSP never sees an
+/// undiagnosable bare EOF (issue #81).
 async fn run_protocol(
     mut reader: BufReader<tokio::net::unix::OwnedReadHalf>,
     mut writer: tokio::net::unix::OwnedWriteHalf,
@@ -154,7 +184,21 @@ async fn run_protocol(
     let (pid, sample_rate, include_native) = read_attach_command(&mut reader).await?;
     info!(pid, sample_rate, include_native, "attaching to process");
 
-    let (spy, python_version) = attach_pyspy(pid, sample_rate, include_native)?;
+    let (spy, python_version) = match attach_pyspy(pid, sample_rate, include_native) {
+        Ok(attached) => attached,
+        Err(message) => {
+            let kind = classify_helper_attach_error(pid, &message);
+            let _ = send_message(
+                &mut writer,
+                &Message::Error {
+                    kind,
+                    message: message.clone(),
+                },
+            )
+            .await;
+            return Err(message);
+        }
+    };
 
     send_message(
         &mut writer,

--- a/crates/basilisk-profiler-protocol/src/lib.rs
+++ b/crates/basilisk-profiler-protocol/src/lib.rs
@@ -102,17 +102,22 @@ pub enum AttachErrorKind {
 /// Classify a py-spy attach error message into an [`AttachErrorKind`].
 ///
 /// Shared by the in-process sampler and the elevated helper so both attach
-/// paths report identical, distinct failure modes (issue #81).
+/// paths report identical, distinct failure modes (issue #81). Matching is
+/// lowercase substring because py-spy's wording varies across platforms
+/// (macOS: "Failed to open process - check if it is running.", Linux:
+/// "Failed to get process executable name. Check that the process is
+/// running.").
 #[must_use]
 pub fn classify_attach_error(message: &str) -> AttachErrorKind {
-    // Case-tolerant substrings: py-spy's wording varies across platforms.
-    if message.contains("ermission") || message.contains("Operation not permitted") {
+    let lowered = message.to_lowercase();
+    if lowered.contains("permission") || lowered.contains("operation not permitted") {
         AttachErrorKind::PermissionDenied
-    } else if message.contains("ot a python") || message.contains("ot Python") {
+    } else if lowered.contains("not a python") {
         AttachErrorKind::NotPython
-    } else if message.contains("No such process")
-        || message.contains("not found")
-        || message.contains("check if it is running")
+    } else if lowered.contains("no such process")
+        || lowered.contains("not found")
+        || lowered.contains("check if it is running")
+        || lowered.contains("check that the process is running")
     {
         AttachErrorKind::ProcessNotFound
     } else {
@@ -271,6 +276,17 @@ mod tests {
         assert_eq!(
             classify_attach_error("Failed to open process - check if it is running."),
             AttachErrorKind::ProcessNotFound
+        );
+        // py-spy's Linux wording for a dead PID.
+        assert_eq!(
+            classify_attach_error(
+                "Failed to get process executable name. Check that the process is running."
+            ),
+            AttachErrorKind::ProcessNotFound
+        );
+        assert_eq!(
+            classify_attach_error("PID 9 is Not a Python process"),
+            AttachErrorKind::NotPython
         );
         assert_eq!(
             classify_attach_error("something exotic exploded"),

--- a/crates/basilisk-profiler-protocol/src/lib.rs
+++ b/crates/basilisk-profiler-protocol/src/lib.rs
@@ -22,6 +22,13 @@
 //! LSP    -> {"cmd":"stop"}
 //! helper -> {"type":"stopped"}
 //! ```
+//!
+//! On failure the helper reports a structured error instead of silently
+//! closing the socket (issue #81 — a bare EOF is undiagnosable):
+//!
+//! ```text
+//! helper -> {"type":"error","kind":"process-not-found","message":"..."}
+//! ```
 
 use std::io::{Error, ErrorKind, Result};
 
@@ -64,6 +71,53 @@ pub enum Message {
     },
     /// Sampling has stopped; the helper is about to exit.
     Stopped,
+    /// The helper failed (issue #81). Sent before exiting so the LSP can
+    /// surface the real cause instead of an undiagnosable EOF.
+    Error {
+        /// Coarse failure classification for editor-side error mapping.
+        kind: AttachErrorKind,
+        /// Human-readable cause (e.g. the underlying py-spy error).
+        message: String,
+    },
+}
+
+/// Why an attach failed, classified so each mode gets a distinct, actionable
+/// message ([PROFILE-ERRORS] maps these to LSP error codes).
+///
+/// Implements [PROFILE-HELPER-PROTOCOL-ERRORS]. See
+/// docs/specs/LSP-PROFILING-SPEC.md#PROFILE-HELPER-PROTOCOL-ERRORS
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum AttachErrorKind {
+    /// The target PID does not exist (or exited before attach).
+    ProcessNotFound,
+    /// The target exists but is not a Python process.
+    NotPython,
+    /// Attaching requires privileges the helper does not have.
+    PermissionDenied,
+    /// Any other attach failure.
+    AttachFailed,
+}
+
+/// Classify a py-spy attach error message into an [`AttachErrorKind`].
+///
+/// Shared by the in-process sampler and the elevated helper so both attach
+/// paths report identical, distinct failure modes (issue #81).
+#[must_use]
+pub fn classify_attach_error(message: &str) -> AttachErrorKind {
+    // Case-tolerant substrings: py-spy's wording varies across platforms.
+    if message.contains("ermission") || message.contains("Operation not permitted") {
+        AttachErrorKind::PermissionDenied
+    } else if message.contains("ot a python") || message.contains("ot Python") {
+        AttachErrorKind::NotPython
+    } else if message.contains("No such process")
+        || message.contains("not found")
+        || message.contains("check if it is running")
+    {
+        AttachErrorKind::ProcessNotFound
+    } else {
+        AttachErrorKind::AttachFailed
+    }
 }
 
 /// A single thread's stack trace, in wire form.
@@ -175,6 +229,53 @@ mod tests {
         let decoded: Option<Message> = read_message(&mut reader).await?;
         assert_eq!(decoded, Some(msg));
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn round_trips_error_message_with_kebab_case_kind() -> Result<()> {
+        let msg = Message::Error {
+            kind: AttachErrorKind::PermissionDenied,
+            message: "py-spy attach failed: Operation not permitted".to_owned(),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        write_message(&mut buf, &msg).await?;
+        let wire = String::from_utf8_lossy(&buf);
+        assert!(
+            wire.contains(r#""type":"error""#) && wire.contains(r#""kind":"permission-denied""#),
+            "error frames must be tagged and kebab-cased: {wire}"
+        );
+        let mut reader = BufReader::new(buf.as_slice());
+        let decoded: Option<Message> = read_message(&mut reader).await?;
+        assert_eq!(decoded, Some(msg));
+        Ok(())
+    }
+
+    #[test]
+    fn classifies_attach_errors_into_distinct_kinds() {
+        assert_eq!(
+            classify_attach_error("Operation not permitted (os error 1)"),
+            AttachErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            classify_attach_error("Permission denied attaching to PID"),
+            AttachErrorKind::PermissionDenied
+        );
+        assert_eq!(
+            classify_attach_error("PID 7 is not a python process"),
+            AttachErrorKind::NotPython
+        );
+        assert_eq!(
+            classify_attach_error("No such process (os error 3)"),
+            AttachErrorKind::ProcessNotFound
+        );
+        assert_eq!(
+            classify_attach_error("Failed to open process - check if it is running."),
+            AttachErrorKind::ProcessNotFound
+        );
+        assert_eq!(
+            classify_attach_error("something exotic exploded"),
+            AttachErrorKind::AttachFailed
+        );
     }
 
     #[tokio::test]

--- a/docs/plans/LSP-PROFILER-PROCESS-PANEL-PLAN.md
+++ b/docs/plans/LSP-PROFILER-PROCESS-PANEL-PLAN.md
@@ -134,10 +134,12 @@ This is the headline fix — spec `{#PROFILE-PROCESSES-LAUNCH}`:
   calls the existing `basilisk.profiler.start` / memory-start with that row's `pid`. **No input box.**
 - **Row context menu:** Profile CPU · Track Memory · Copy PID · Reveal Script in Editor.
 - **Panel toolbar:** **Refresh** · **Sort…** · **Group…** · **Filter** ·
-  **▶ Run & Profile Current File** (`basilisk.profileCurrentFile`) — launches the active `.py` under a
-  child interpreter Basilisk owns (no elevation) and auto-attaches the profiler. The true one-click path.
+  **🔥 Run & Profile CPU (Current File)** (`basilisk.profileCurrentFileCpu`) ·
+  **🗄️ Run & Track Memory (Current File)** (`basilisk.trackMemoryCurrentFile`) — metric-explicit
+  launches of the active `.py` under a child interpreter Basilisk owns (no elevation), auto-attaching
+  the matching tracker (#82 retired the single ambiguous `basilisk.profileCurrentFile` button).
 - **Welcome view** (`viewsWelcome`) when no Python processes are running:
-  *"No Python processes running. [Run & Profile Current File]"*.
+  *"No Python processes running. [Run & Profile CPU (Current File)] [Run & Track Memory (Current File)]"*.
 
 `basilisk.profileStart` (the old palette command) is **kept** but rewritten: instead of an input box it
 **focuses this panel** and shows a toast "Pick a process below, or Run & Profile Current File". The
@@ -148,7 +150,8 @@ lying "auto-detect" prompt is deleted.
 - `views.basilisk-explorer[]` += `{ id: "basilisk.pythonProcesses", name: "Python Processes", when: "basilisk.hasWorkspace" }`.
 - New commands: `basilisk.refreshProcesses`, `basilisk.sortProcesses`, `basilisk.groupProcesses`,
   `basilisk.filterProcesses`, `basilisk.profileProcess`, `basilisk.memoryTrackProcess`,
-  `basilisk.profileCurrentFile`, `basilisk.copyProcessPid`, `basilisk.revealProcessScript`.
+  `basilisk.profileCurrentFileCpu`, `basilisk.trackMemoryCurrentFile`, `basilisk.copyProcessPid`,
+  `basilisk.revealProcessScript`.
 - `menus.view/title` (toolbar) + `menus.view/item/context` (inline + context) wired with
   `when: view == basilisk.pythonProcesses`.
 - `viewsWelcome` entry for the empty state.
@@ -234,8 +237,9 @@ Add to [LSP-PROFILING-SPEC.md](../specs/LSP-PROFILING-SPEC.md), all under a new
       menus, `view/item/context` inline + context menus, `viewsWelcome` empty state, new settings.
 - [ ] `basilisk.profileProcess` / `basilisk.memoryTrackProcess`: start CPU/memory profiling with the
       row's `pid` — **no input box**.
-- [ ] `basilisk.profileCurrentFile`: launch active `.py` under a Basilisk-owned child interpreter and
-      auto-attach (no elevation) — the one-click path; reuse the debug-launch plumbing where possible.
+- [ ] `basilisk.profileCurrentFileCpu` / `basilisk.trackMemoryCurrentFile`: launch active `.py` under a
+      Basilisk-owned child interpreter and auto-attach the named metric (no elevation) — the one-click
+      path; reuse the debug-launch plumbing where possible.
 - [ ] `basilisk.copyProcessPid`, `basilisk.revealProcessScript`.
 
 ### Phase 5 — Tests, polish, ratchet

--- a/docs/specs/LSP-PROFILING-SPEC.md
+++ b/docs/specs/LSP-PROFILING-SPEC.md
@@ -226,7 +226,10 @@ VS Code contributes a `basilisk.pythonProcesses` tree view in the
 
 Auto-refresh is gated on view visibility (interval from
 `basilisk.profiler.processRefreshMs`, default 2000); a manual refresh button is
-always present. An empty state (`viewsWelcome`) offers **Run & Profile Current File**.
+always present. Process rows carry a stable `TreeItem.id` (`pythonProcess:<pid>`)
+so VS Code can map inline-button clicks back to elements across refreshes
+(issue #79). An empty state (`viewsWelcome`) offers the two metric-explicit
+launches described in [#PROFILE-PROCESSES-LAUNCH-FILE].
 
 #### Sort modes {#PROFILE-PROCESSES-PANEL-SORT}
 
@@ -246,6 +249,31 @@ row context menu adds Copy PID and Reveal Script. The old palette command
 `basilisk.profileStart` is **kept but rewritten**: instead of prompting for a PID
 it focuses this panel and shows a toast ("Pick a process below"). The lying
 "auto-detect" prompt is deleted.
+
+VS Code can invoke an inline tree command with **no argument** (issue #79 —
+e.g. a click racing the panel's auto-refresh), so the handlers resolve their
+target as: explicit item → the panel's current selection → only then a warning
+(`createProcessRowActions` in `process-launch.ts`). Both row commands share
+this resolution.
+
+#### Run & profile the current file {#PROFILE-PROCESSES-LAUNCH-FILE}
+
+The view-title entry point must state **what it tracks** (issue #82 — the old
+single "Run & Profile Current File" `$(run-all)` button named no metric). Two
+metric-explicit buttons mirror the per-row actions, same labels and icons:
+
+- **🔥 Run & Profile CPU (Current File)** (`basilisk.profileCurrentFileCpu`) —
+  launches the active `.py` under `basilisk-debug` with `profileOnLaunch: true`;
+  profiler.ts honours that launch-config flag (or the global
+  `basilisk.profiler.profileOnLaunch` setting) and attaches the CPU profiler to
+  the captured debuggee PID ([#PROFILE-SAME-PROCESS]).
+- **🗄️ Run & Track Memory (Current File)** (`basilisk.trackMemoryCurrentFile`) —
+  launches with `stopOnEntry: true` + `memoryTrackOnLaunch: true`; tracemalloc
+  needs a paused debuggee ([#PROFILE-MEMORY-HOWTO]), so memory-profiler.ts
+  starts tracking at the entry pause and then resumes the program.
+
+Both appear in the title bar, the panel's empty state, and (gated on
+[#PROFILE-UI-GATE]) the command palette.
 
 ## Sample Aggregation {#PROFILE-AGGREGATION}
 
@@ -627,6 +655,24 @@ helper -> {"type":"stopped"}
 ```
 
 `traces` carry the minimal per-thread / per-frame fields py-spy produces; the LSP converts them back into py-spy shapes and feeds the same aggregator the in-process sampler uses.
+
+#### Attach-failure reporting {#PROFILE-HELPER-PROTOCOL-ERRORS}
+
+A failed attach must never surface as a bare EOF (issue #81). Two layers guarantee a diagnosable cause:
+
+1. **Structured error frame.** When py-spy attach fails, the helper sends
+   `{"type":"error","kind":"<kind>","message":"<py-spy cause>"}` before exiting.
+   `kind` is one of `process-not-found`, `not-python`, `permission-denied`,
+   `attach-failed` (`AttachErrorKind` in `basilisk-profiler-protocol`), shared
+   with the in-process sampler via `classify_attach_error` so both attach paths
+   report identical failure modes. The helper refines py-spy's ambiguous
+   "cannot open process" with a liveness probe: target alive ⇒
+   `permission-denied`, target gone ⇒ `process-not-found`.
+2. **Exit diagnosis fallback.** If the socket still EOFs (or the handshake/accept
+   times out) before `attached`, the LSP reaps the helper (its stderr is piped at
+   spawn) and appends its exit status plus trailing stderr to the error — this
+   also surfaces `osascript` elevation failures such as the user cancelling the
+   privilege prompt.
 
 ### Helper Socket Sampling {#PROFILE-HELPER-SOCKET}
 

--- a/docs/specs/LSP-PROFILING-SPEC.md
+++ b/docs/specs/LSP-PROFILING-SPEC.md
@@ -685,7 +685,16 @@ The LSP side (`basilisk-lsp/src/profiler/helper_client.rs`) owns the socket life
 
 ### Linux {#PROFILE-PERMISSIONS-LINUX}
 
-Works without root if `ptrace_scope=0`. Options for restricted environments: `sudo`, `setcap cap_sys_ptrace+ep`, or profile child processes only.
+Works without root if `ptrace_scope=0`. Under the default `ptrace_scope=1`
+(restricted) the precheck **attempts the attach instead of denying upfront**:
+Yama still grants *ancestors* (a debug session's debuggee is the LSP's
+grandchild via `debugpy.adapter`) and targets that opted in via
+`PR_SET_PTRACER`, neither of which the precheck can observe. A real `EPERM`
+from py-spy is surfaced as a classified permission error
+([#PROFILE-HELPER-PROTOCOL-ERRORS]) with the remedies appended:
+`sudo sysctl kernel.yama.ptrace_scope=0`, `setcap cap_sys_ptrace+ep`, or
+profiling via a debug session. Scopes `2`/`3` are kernel-enforced regardless
+of process relationships and stay denied upfront with the matching remedy.
 
 ### Windows {#PROFILE-PERMISSIONS-WINDOWS}
 

--- a/scripts/test-nvim.sh
+++ b/scripts/test-nvim.sh
@@ -71,8 +71,14 @@ if command -v nvim &>/dev/null; then
     expected_specs="$(find tests/lsp -name '*_spec.lua' | wc -l | tr -d ' ')"
     lsp_out="$(mktemp)"
     set +e
+    # Per-file timeout: plenary's default is 50s, and the heaviest spec
+    # (coverage_boost_spec.lua) legitimately needs ~51s against the
+    # coverage-instrumented LSP binary — the child gets SIGTERMed mid-summary
+    # and the run fails on "15/16 spec files produced a summary" with zero
+    # actual test failures. 120s keeps the gate strict (every spec must still
+    # summarise clean) without truncating slow-but-passing files.
     LUACOV=1 nvim --headless -u tests/minimal_init.lua \
-        -c "PlenaryBustedDirectory tests/lsp {minimal_init = 'tests/minimal_init.lua', sequential = true}" 2>&1 \
+        -c "PlenaryBustedDirectory tests/lsp {minimal_init = 'tests/minimal_init.lua', sequential = true, timeout = 120000}" 2>&1 \
         | tee "$lsp_out"
     nvim_rc=${PIPESTATUS[0]}
     set -e

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -83,7 +83,7 @@
       },
       {
         "view": "basilisk.pythonProcesses",
-        "contents": "No Python processes running.\n[Run & Profile Current File](command:basilisk.profileCurrentFile)\n[Refresh](command:basilisk.refreshProcesses)"
+        "contents": "No Python processes running.\n[Run & Profile CPU (Current File)](command:basilisk.profileCurrentFileCpu)\n[Run & Track Memory (Current File)](command:basilisk.trackMemoryCurrentFile)\n[Refresh](command:basilisk.refreshProcesses)"
       }
     ],
     "commands": [
@@ -308,10 +308,16 @@
         "icon": "$(filter)"
       },
       {
-        "command": "basilisk.profileCurrentFile",
-        "title": "Run & Profile Current File",
+        "command": "basilisk.profileCurrentFileCpu",
+        "title": "Run & Profile CPU (Current File)",
         "category": "Basilisk",
-        "icon": "$(run-all)"
+        "icon": "$(flame)"
+      },
+      {
+        "command": "basilisk.trackMemoryCurrentFile",
+        "title": "Run & Track Memory (Current File)",
+        "category": "Basilisk",
+        "icon": "$(database)"
       },
       {
         "command": "basilisk.profileProcess",
@@ -363,7 +369,11 @@
           "when": "basilisk.profilingEnabled"
         },
         {
-          "command": "basilisk.profileCurrentFile",
+          "command": "basilisk.profileCurrentFileCpu",
+          "when": "basilisk.profilingEnabled"
+        },
+        {
+          "command": "basilisk.trackMemoryCurrentFile",
           "when": "basilisk.profilingEnabled"
         },
         {
@@ -469,29 +479,34 @@
           "group": "navigation"
         },
         {
-          "command": "basilisk.profileCurrentFile",
+          "command": "basilisk.profileCurrentFileCpu",
           "when": "view == basilisk.pythonProcesses",
           "group": "navigation@1"
         },
         {
-          "command": "basilisk.refreshProcesses",
+          "command": "basilisk.trackMemoryCurrentFile",
           "when": "view == basilisk.pythonProcesses",
           "group": "navigation@2"
         },
         {
-          "command": "basilisk.sortProcesses",
+          "command": "basilisk.refreshProcesses",
           "when": "view == basilisk.pythonProcesses",
           "group": "navigation@3"
         },
         {
-          "command": "basilisk.groupProcesses",
+          "command": "basilisk.sortProcesses",
           "when": "view == basilisk.pythonProcesses",
           "group": "navigation@4"
         },
         {
-          "command": "basilisk.filterProcesses",
+          "command": "basilisk.groupProcesses",
           "when": "view == basilisk.pythonProcesses",
           "group": "navigation@5"
+        },
+        {
+          "command": "basilisk.filterProcesses",
+          "when": "view == basilisk.pythonProcesses",
+          "group": "navigation@6"
         }
       ],
       "view/item/context": [

--- a/vscode-extension/src/memory-decorations.ts
+++ b/vscode-extension/src/memory-decorations.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import { Logger } from "./logger";
+import { recordApplied, type AppliedDecoration } from "./profiler-decorations";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -54,6 +55,17 @@ export interface MemoryDiffResult {
   totalFreed: number;
   netGrowth: number;
   suspectedLeaks: SuspectedLeak[];
+}
+
+// ── Applied-decoration ledger ─────────────────────────────────────────────
+// Implements [PROFILE-VIS-HEATMAP] (memory track) observability — same e2e
+// seam as the CPU heat map, since `setDecorations` is write-only.
+
+let appliedMemDecorations: AppliedDecoration[] = [];
+
+/** The memory/leak decorations currently applied across visible editors. */
+export function appliedMemoryDecorations(): readonly AppliedDecoration[] {
+  return appliedMemDecorations;
 }
 
 // ── Decoration types ──────────────────────────────────────────────────────
@@ -176,6 +188,7 @@ export function applyMemoryDecorations(result: MemorySnapshotResult): void {
     for (const [color, options] of optionsByColor) {
       editor.setDecorations(getMemDecorationTypeForColor(color), options);
     }
+    recordApplied(appliedMemDecorations, filePath, optionsByColor);
   }
 
   Logger.info(`Memory decorations applied: ${result.topAllocations.length} allocations`);
@@ -230,6 +243,7 @@ export function applyLeakDecorations(result: MemoryDiffResult): void {
     for (const [color, options] of optionsByColor) {
       editor.setDecorations(getMemDecorationTypeForColor(color), options);
     }
+    recordApplied(appliedMemDecorations, filePath, optionsByColor);
   }
 
   Logger.info(`Leak decorations applied: ${result.suspectedLeaks.length} suspected leaks`);
@@ -242,6 +256,7 @@ export function clearMemoryDecorations(): void {
       editor.setDecorations(decorationType, []);
     }
   }
+  appliedMemDecorations = [];
 }
 
 /** Dispose all memory decoration types. */
@@ -250,4 +265,5 @@ export function disposeMemoryDecorations(): void {
     decorationType.dispose();
   }
   memDecorationTypes.clear();
+  appliedMemDecorations = [];
 }

--- a/vscode-extension/src/memory-profiler.ts
+++ b/vscode-extension/src/memory-profiler.ts
@@ -132,6 +132,15 @@ export function registerMemoryProfiler(
   return disposables;
 }
 
+/**
+ * The active memory-tracking session id, or undefined when not tracking.
+ * E2e seam for [PROFILE-MEMORY-HOWTO]/[PROFILE-PROCESSES-LAUNCH-FILE]: lets
+ * tests observe that tracking really started (e.g. the track-on-launch flow).
+ */
+export function activeMemorySession(): string | undefined {
+  return activeMemorySessionId;
+}
+
 /** Quick-pick menu of memory actions — the clickable alternative to the palette. */
 async function handleMemoryMenu(): Promise<void> {
   const tracking = activeMemorySessionId !== undefined;

--- a/vscode-extension/src/memory-profiler.ts
+++ b/vscode-extension/src/memory-profiler.ts
@@ -17,6 +17,7 @@ import { Logger } from "./logger";
 import type { Store } from "./store";
 import { isProfilingUiEnabled } from "./profiling-ui";
 import { currentStoppedFrameId, evaluateInDebugSession } from "./dap-evaluate";
+import { POLL_INTERVAL_MS, STARTUP_TIMEOUT_MS } from "./timeouts";
 import {
   disposeMemoryDashboard,
   openMemoryDashboard,
@@ -112,7 +113,14 @@ export function registerMemoryProfiler(
     ),
     // Show/hide the memory status-bar entry as Basilisk debug sessions come and go.
     vscode.debug.onDidChangeActiveDebugSession(() => { refreshMemoryStatusBar(); }),
-    vscode.debug.onDidStartDebugSession(() => { refreshMemoryStatusBar(); }),
+    vscode.debug.onDidStartDebugSession((session) => {
+      refreshMemoryStatusBar();
+      // "Run & Track Memory (Current File)" (#82): the launch stopped on
+      // entry; inject tracemalloc there, then resume the program.
+      if (session.type === "basilisk-debug" && session.configuration.memoryTrackOnLaunch === true) {
+        void startMemoryTrackingOnLaunch(store);
+      }
+    }),
     vscode.debug.onDidTerminateDebugSession(() => { refreshMemoryStatusBar(); }),
   ];
 
@@ -212,6 +220,41 @@ async function runMemoryScript(
     void vscode.window.showWarningMessage(`Basilisk: ${msg}`);
     return null;
   }
+}
+
+// ── Track-memory-on-launch ────────────────────────────────────────────────
+
+/**
+ * Auto-start flow for the "Run & Track Memory (Current File)" entry point
+ * (#82). Memory tracking needs a paused debuggee ([PROFILE-MEMORY-HOWTO]), so
+ * the launch config sets `stopOnEntry`; tracemalloc is injected at the entry
+ * pause and the debuggee is resumed so the program runs with tracking on.
+ * Implements [PROFILE-PROCESSES-LAUNCH-FILE] (memory leg).
+ */
+async function startMemoryTrackingOnLaunch(store: Store): Promise<void> {
+  const frameId = await waitForStoppedFrame();
+  if (frameId === null) {
+    void vscode.window.showWarningMessage(
+      "Basilisk: The debuggee did not pause at entry — pause at a breakpoint, then start memory tracking.",
+    );
+    return;
+  }
+  await handleMemoryStart(store);
+  if (activeMemorySessionId !== undefined) {
+    Logger.info("Memory tracking started on launch — resuming the debuggee");
+    await vscode.commands.executeCommand("workbench.action.debug.continue");
+  }
+}
+
+/** Poll for a stopped frame until the startup budget runs out. */
+async function waitForStoppedFrame(): Promise<number | null> {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const frameId = await currentStoppedFrameId();
+    if (frameId !== null) { return frameId; }
+    await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  return null;
 }
 
 // ── Command handlers ──────────────────────────────────────────────────────

--- a/vscode-extension/src/memory-profiler.ts
+++ b/vscode-extension/src/memory-profiler.ts
@@ -316,10 +316,15 @@ async function handleMemorySnapshot(store: Store): Promise<void> {
     lastDashboardSnapshot = toDashboardSnapshot(result);
     Logger.info(`Memory snapshot: ${lastDashboardSnapshot.currentMemory} bytes current`);
     // Open the V8 .heapprofile in VS Code's built-in profile viewer (flame chart
-    // + table, Self/Total size) — the same UI as Node.js heap profiles.
+    // + table, Self/Total size) — the same UI as Node.js heap profiles. Beside
+    // the source, so the snapshotted file keeps its allocation decorations.
     const heapProfilePath = asString(result.heapProfilePath);
     if (heapProfilePath !== "") {
-      await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(heapProfilePath));
+      await vscode.commands.executeCommand(
+        "vscode.open",
+        vscode.Uri.file(heapProfilePath),
+        vscode.ViewColumn.Beside,
+      );
     } else {
       // Fall back to the Basilisk dashboard if the file wasn't produced.
       openMemoryDashboard(lastDashboardSnapshot);

--- a/vscode-extension/src/process-explorer.ts
+++ b/vscode-extension/src/process-explorer.ts
@@ -13,7 +13,7 @@
 import * as vscode from "vscode";
 import { type Store } from "./store";
 import { Logger } from "./logger";
-import { startProfilingForPid } from "./profiler";
+import { registerLaunchCommands } from "./process-launch";
 
 // ── LSP response types ───────────────────────────────────────────────────
 
@@ -117,6 +117,8 @@ class ProcessGroupItem extends vscode.TreeItem {
     public readonly members: readonly ProcessInfo[],
   ) {
     super(label, vscode.TreeItemCollapsibleState.Expanded);
+    // Stable identity so VS Code preserves expansion state across refreshes.
+    this.id = `processGroup:${label}`;
     this.description = `${members.length}`;
     this.contextValue = "processGroup";
     this.iconPath = new vscode.ThemeIcon("folder");
@@ -131,6 +133,11 @@ class ProcessTreeItem extends vscode.TreeItem {
       scriptName !== undefined ? `${process.name} — ${scriptName}` : process.name,
       vscode.TreeItemCollapsibleState.None,
     );
+
+    // Stable identity across the panel's 2s auto-refresh: without it VS Code
+    // can fail to map an inline-button click back to a (recreated) element and
+    // invokes the command with no argument (#79).
+    this.id = `pythonProcess:${process.pid}`;
 
     const version = process.pythonVersion ?? "—";
     this.description =
@@ -310,51 +317,6 @@ export class PythonProcessesProvider implements vscode.TreeDataProvider<TreeItem
   }
 }
 
-// ── Launch actions ───────────────────────────────────────────────────────
-
-/** Guard: narrow to a real selection, warning when an action has no row. */
-function ensureSelection(item: ProcessTreeItem | undefined): item is ProcessTreeItem {
-  if (item === undefined) {
-    vscode.window.showWarningMessage("Basilisk: Select a Python process to profile.");
-    return false;
-  }
-  return true;
-}
-
-/** Start CPU profiling the given process row — no input box (the #62 fix). */
-async function profileProcess(store: Store, item: ProcessTreeItem | undefined): Promise<void> {
-  if (!ensureSelection(item)) { return; }
-  const preset = vscode.workspace.getConfiguration("basilisk").get<string>("profiler.preset", "default");
-  await startProfilingForPid(store, item.process.pid, preset);
-}
-
-/** Start memory-oriented profiling for the given process row. */
-async function memoryTrackProcess(store: Store, item: ProcessTreeItem | undefined): Promise<void> {
-  if (!ensureSelection(item)) { return; }
-  await startProfilingForPid(store, item.process.pid, "memory");
-}
-
-/** Run the active `.py` file under a debug session with profiling on launch. */
-async function profileCurrentFile(): Promise<void> {
-  const editor = vscode.window.activeTextEditor;
-  if (editor?.document.languageId !== "python") {
-    vscode.window.showWarningMessage("Basilisk: Open a Python file to run and profile.");
-    return;
-  }
-  const file = editor.document.uri;
-  const folder = vscode.workspace.getWorkspaceFolder(file);
-  const started = await vscode.debug.startDebugging(folder, {
-    type: "basilisk-debug",
-    request: "launch",
-    name: "Run & Profile Current File",
-    program: file.fsPath,
-    profileOnLaunch: true,
-  });
-  if (!started) {
-    vscode.window.showErrorMessage("Basilisk: Could not launch the current file for profiling.");
-  }
-}
-
 // ── Registration ─────────────────────────────────────────────────────────
 
 /** Default poll interval (ms) when the setting is absent. */
@@ -378,6 +340,7 @@ export function registerPythonProcesses(
   wireVisibilityRefresh(treeView, provider);
 
   const disposables = [
+    ...registerLaunchCommands(store, treeView),
     vscode.commands.registerCommand("basilisk.refreshProcesses", () => { provider.refresh(); }),
     vscode.commands.registerCommand("basilisk.sortProcesses", () => { provider.cycleSortMode(); }),
     vscode.commands.registerCommand("basilisk.groupProcesses", () => { provider.cycleGroupMode(); }),
@@ -388,13 +351,6 @@ export function registerPythonProcesses(
       });
       provider.setFilter(input ?? "");
     }),
-    vscode.commands.registerCommand("basilisk.profileProcess", async (item?: ProcessTreeItem) =>
-      profileProcess(store, item),
-    ),
-    vscode.commands.registerCommand("basilisk.memoryTrackProcess", async (item?: ProcessTreeItem) =>
-      memoryTrackProcess(store, item),
-    ),
-    vscode.commands.registerCommand("basilisk.profileCurrentFile", async () => profileCurrentFile()),
     vscode.commands.registerCommand("basilisk.copyProcessPid", (item?: ProcessTreeItem) => {
       if (item !== undefined) {
         void vscode.env.clipboard.writeText(String(item.process.pid));

--- a/vscode-extension/src/process-launch.ts
+++ b/vscode-extension/src/process-launch.ts
@@ -1,0 +1,153 @@
+// Implements [PROFILE-PROCESSES-LAUNCH]. See docs/specs/LSP-PROFILING-SPEC.md#PROFILE-PROCESSES-LAUNCH
+/**
+ * Launch actions for the Python Processes panel.
+ *
+ * Two surfaces, one language: per-row inline actions ("Profile CPU" 🔥 /
+ * "Track Memory" 🗄️ — the #62 fix, hardened for #79) and the metric-explicit
+ * title-bar launches for the current file ("Run & Profile CPU" / "Run & Track
+ * Memory" — the #82 fix). The tree rendering lives in process-explorer.ts;
+ * this module owns what happens when the user clicks.
+ */
+
+import * as vscode from "vscode";
+import { startProfilingForPid } from "./profiler";
+import { type Store } from "./store";
+import { type ProcessInfo } from "./process-explorer";
+
+// ── Per-row actions (#79) ────────────────────────────────────────────────
+
+/** The slice of the panel's TreeView the launch actions read (test seam). */
+export interface ProcessRowSource {
+  readonly selection: readonly vscode.TreeItem[];
+}
+
+/** A tree row that targets a concrete process. */
+type ProcessRowItem = vscode.TreeItem & { readonly process: ProcessInfo };
+
+/** Structural guard: does this tree item carry a profilable process? */
+function isProcessRow(item: vscode.TreeItem | undefined): item is ProcessRowItem {
+  const pid = (item as { process?: { pid?: unknown } } | undefined)?.process?.pid;
+  return typeof pid === "number";
+}
+
+/**
+ * Resolve the row an inline action targets. VS Code sometimes invokes inline
+ * tree-view commands with no argument (#79 — e.g. a click racing the panel's
+ * auto-refresh), so fall back to the panel's current selection before warning.
+ */
+function resolveProcessRow(
+  item: vscode.TreeItem | undefined,
+  view: ProcessRowSource,
+): ProcessRowItem | undefined {
+  if (isProcessRow(item)) { return item; }
+  return view.selection.find((entry): entry is ProcessRowItem => isProcessRow(entry));
+}
+
+/** Guard: narrow to a real target, warning when an action has no row. */
+function ensureSelection(item: ProcessRowItem | undefined): item is ProcessRowItem {
+  if (item === undefined) {
+    vscode.window.showWarningMessage(
+      "Basilisk: Select a Python process row, then use Profile CPU or Track Memory.",
+    );
+    return false;
+  }
+  return true;
+}
+
+/** Start CPU profiling the given process row — no input box (the #62 fix). */
+async function profileProcess(store: Store, item: ProcessRowItem | undefined): Promise<void> {
+  if (!ensureSelection(item)) { return; }
+  const preset = vscode.workspace.getConfiguration("basilisk").get<string>("profiler.preset", "default");
+  await startProfilingForPid(store, item.process.pid, preset);
+}
+
+/** Start memory-oriented profiling for the given process row. */
+async function memoryTrackProcess(store: Store, item: ProcessRowItem | undefined): Promise<void> {
+  if (!ensureSelection(item)) { return; }
+  await startProfilingForPid(store, item.process.pid, "memory");
+}
+
+/**
+ * The per-row launch handlers exactly as VS Code invokes them for the inline
+ * buttons and context menu. Exported so tests can drive the real command
+ * surface, including the no-argument invocation of issue #79.
+ */
+export function createProcessRowActions(
+  store: Store,
+  view: ProcessRowSource,
+): {
+  readonly profileProcess: (item?: vscode.TreeItem) => Promise<void>;
+  readonly memoryTrackProcess: (item?: vscode.TreeItem) => Promise<void>;
+} {
+  return {
+    profileProcess: async (item) => profileProcess(store, resolveProcessRow(item, view)),
+    memoryTrackProcess: async (item) => memoryTrackProcess(store, resolveProcessRow(item, view)),
+  };
+}
+
+// ── Current-file launches (#82) ──────────────────────────────────────────
+// Implements [PROFILE-PROCESSES-LAUNCH-FILE].
+// See docs/specs/LSP-PROFILING-SPEC.md#PROFILE-PROCESSES-LAUNCH-FILE
+
+/** Which metric a metric-explicit "Run & …" launch tracks (#82). */
+export type LaunchMetric = "cpu" | "memory";
+
+/**
+ * Build the debug configuration for a metric-explicit run-and-profile launch.
+ * Exported so tests can assert each metric produces the right launch shape.
+ *
+ * CPU sets `profileOnLaunch` (honoured by profiler.ts). Memory stops on entry
+ * because tracemalloc is injected via DAP `evaluate`, which needs a paused
+ * debuggee ([PROFILE-MEMORY-HOWTO]); memory-profiler.ts starts tracking at the
+ * entry pause and then resumes the program.
+ */
+export function buildProfileLaunchConfig(
+  metric: LaunchMetric,
+  program: string,
+): vscode.DebugConfiguration {
+  if (metric === "cpu") {
+    return {
+      type: "basilisk-debug",
+      request: "launch",
+      name: "Run & Profile CPU (Current File)",
+      program,
+      profileOnLaunch: true,
+    };
+  }
+  return {
+    type: "basilisk-debug",
+    request: "launch",
+    name: "Run & Track Memory (Current File)",
+    program,
+    stopOnEntry: true,
+    memoryTrackOnLaunch: true,
+  };
+}
+
+/** Run the active `.py` file under a debug session, tracking the given metric. */
+async function profileCurrentFile(metric: LaunchMetric): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (editor?.document.languageId !== "python") {
+    vscode.window.showWarningMessage("Basilisk: Open a Python file to run and profile.");
+    return;
+  }
+  const file = editor.document.uri;
+  const folder = vscode.workspace.getWorkspaceFolder(file);
+  const started = await vscode.debug.startDebugging(folder, buildProfileLaunchConfig(metric, file.fsPath));
+  if (!started) {
+    vscode.window.showErrorMessage("Basilisk: Could not launch the current file for profiling.");
+  }
+}
+
+// ── Registration ─────────────────────────────────────────────────────────
+
+/** Register every launch command the Python Processes panel contributes. */
+export function registerLaunchCommands(store: Store, view: ProcessRowSource): vscode.Disposable[] {
+  const rowActions = createProcessRowActions(store, view);
+  return [
+    vscode.commands.registerCommand("basilisk.profileProcess", rowActions.profileProcess),
+    vscode.commands.registerCommand("basilisk.memoryTrackProcess", rowActions.memoryTrackProcess),
+    vscode.commands.registerCommand("basilisk.profileCurrentFileCpu", async () => profileCurrentFile("cpu")),
+    vscode.commands.registerCommand("basilisk.trackMemoryCurrentFile", async () => profileCurrentFile("memory")),
+  ];
+}

--- a/vscode-extension/src/profiler-decorations.ts
+++ b/vscode-extension/src/profiler-decorations.ts
@@ -83,6 +83,47 @@ function heatLevelFor(pct: number): HeatLevel | undefined {
   return HEAT_LEVELS.find((h) => pct >= h.minPct);
 }
 
+// ── Applied-decoration ledger ─────────────────────────────────────────────
+// Implements [PROFILE-VIS-HEATMAP] observability: `setDecorations` is
+// write-only in the VS Code API, so the heat map records what it applied and
+// exposes it for e2e assertions (per the VSIX internal-state testing rule).
+
+/** One heat decoration as applied to an open editor. */
+export interface AppliedDecoration {
+  readonly file: string;
+  /** 1-based line the decoration landed on. */
+  readonly line: number;
+  /** Palette color used (e.g. `#e8500a` for critical). */
+  readonly color: string;
+  /** The after-line text shown to the user (bar + % + samples). */
+  readonly contentText: string;
+}
+
+let appliedDecorations: AppliedDecoration[] = [];
+
+/** The heat-map decorations currently applied across visible editors. */
+export function appliedProfileDecorations(): readonly AppliedDecoration[] {
+  return appliedDecorations;
+}
+
+/** Record everything painted for one file, for the applied ledger. */
+export function recordApplied(
+  ledger: AppliedDecoration[],
+  file: string,
+  paintedByColor: ReadonlyMap<string, readonly vscode.DecorationOptions[]>,
+): void {
+  for (const [color, options] of paintedByColor) {
+    for (const option of options) {
+      ledger.push({
+        file,
+        line: option.range.start.line + 1,
+        color,
+        contentText: option.renderOptions?.after?.contentText ?? "",
+      });
+    }
+  }
+}
+
 // ── Decoration types (created lazily, one per heat level) ─────────────────
 
 const decorationTypes = new Map<string, vscode.TextEditorDecorationType>();
@@ -228,6 +269,7 @@ export function applyProfileDecorations(result: ProfileResult): void {
     for (const [color, options] of optionsByColor) {
       editor.setDecorations(getDecorationTypeForColor(color), options);
     }
+    recordApplied(appliedDecorations, filePath, optionsByColor);
   }
 
   const totalLines = result.hotLines.length;
@@ -242,6 +284,7 @@ export function clearProfileDecorations(): void {
       editor.setDecorations(decorationType, []);
     }
   }
+  appliedDecorations = [];
 }
 
 /** Dispose all decoration types (call on extension deactivate). */
@@ -250,4 +293,5 @@ export function disposeProfileDecorations(): void {
     decorationType.dispose();
   }
   decorationTypes.clear();
+  appliedDecorations = [];
 }

--- a/vscode-extension/src/profiler.ts
+++ b/vscode-extension/src/profiler.ts
@@ -96,10 +96,7 @@ export function registerProfiler(
   // "Profile on Launch" — automatically start profiling when a debug session starts.
   disposables.push(
     vscode.debug.onDidStartDebugSession((session) => {
-      const profileOnLaunch = vscode.workspace
-        .getConfiguration("basilisk")
-        .get<boolean>("profiler.profileOnLaunch", false);
-      if (profileOnLaunch && session.type === "basilisk-debug" && activeSessionId === undefined) {
+      if (shouldProfileOnLaunch(session) && activeSessionId === undefined) {
         Logger.info(`Profile on Launch: auto-profiling debug session ${session.id}`);
         // The debuggee PID arrives asynchronously via the DAP `process` event,
         // so wait for it before attaching (avoids a "not ready yet" race).
@@ -123,6 +120,23 @@ export function registerProfiler(
   );
 
   return disposables;
+}
+
+/**
+ * Whether a freshly started debug session should be auto-profiled: either its
+ * launch configuration asked for it (`profileOnLaunch: true`, set by the
+ * metric-explicit "Run & Profile CPU (Current File)" entry point — #82) or the
+ * user enabled the global `basilisk.profiler.profileOnLaunch` setting.
+ * Implements [PROFILE-PROCESSES-LAUNCH-FILE]. Exported for tests.
+ */
+export function shouldProfileOnLaunch(
+  session: Pick<vscode.DebugSession, "type" | "configuration">,
+): boolean {
+  if (session.type !== "basilisk-debug") { return false; }
+  if (session.configuration.profileOnLaunch === true) { return true; }
+  return vscode.workspace
+    .getConfiguration("basilisk")
+    .get<boolean>("profiler.profileOnLaunch", false);
 }
 
 // ── Debuggee PID readiness ─────────────────────────────────────────────────

--- a/vscode-extension/src/profiler.ts
+++ b/vscode-extension/src/profiler.ts
@@ -361,6 +361,16 @@ async function handleProfileAttachToDebug(store: Store): Promise<void> {
 
 // ── Status bar ────────────────────────────────────────────────────────────
 
+/**
+ * The profiler status-bar text, or undefined when idle/hidden. E2e seam for
+ * [PROFILE-NOTIFICATIONS-PROGRESS]: the live progress (samples/duration)
+ * lands here and StatusBarItem state is not readable via the public API.
+ */
+export function profilerStatusText(): string | undefined {
+  if (activeSessionId === undefined) { return undefined; }
+  return profilerStatusBarItem?.text;
+}
+
 function updateProfilerStatusBar(state: "idle" | "profiling"): void {
   if (profilerStatusBarItem === undefined) { return; }
 

--- a/vscode-extension/src/profiler.ts
+++ b/vscode-extension/src/profiler.ts
@@ -251,9 +251,16 @@ async function handleProfileStop(store: Store): Promise<void> {
       applyProfileDecorations(result);
       // Open the V8 .cpuprofile in VS Code's built-in profile viewer (flame
       // chart + bottom-up/left-heavy tables); fall back to the speedscope-style
-      // webview only if the file wasn't produced.
+      // webview only if the file wasn't produced. Open BESIDE the source so
+      // the profiled file (and its inline heat map) stays visible — opening
+      // in the active group hides the file and the visible-editors re-apply
+      // would clear its decorations.
       if (result.cpuProfilePath !== undefined && result.cpuProfilePath !== "") {
-        await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(result.cpuProfilePath));
+        await vscode.commands.executeCommand(
+          "vscode.open",
+          vscode.Uri.file(result.cpuProfilePath),
+          vscode.ViewColumn.Beside,
+        );
       } else {
         openFlamegraphWebview(result);
       }

--- a/vscode-extension/src/test/fixtures/memory_growth.py
+++ b/vscode-extension/src/test/fixtures/memory_growth.py
@@ -1,0 +1,22 @@
+"""Memory profiling e2e fixture: grows a module-level cache in steps."""
+import time
+
+CACHE = []
+
+
+def allocate_chunk():
+    for _i in range(300):
+        CACHE.append("x" * 5000)
+    return len(CACHE)
+
+
+def main():
+    first = allocate_chunk()
+    second = allocate_chunk()
+    third = allocate_chunk()
+    time.sleep(2)
+    print("DONE", first, second, third)
+
+
+if __name__ == "__main__":
+    main()

--- a/vscode-extension/src/test/suite/memory-e2e.test.ts
+++ b/vscode-extension/src/test/suite/memory-e2e.test.ts
@@ -1,0 +1,288 @@
+// Tests for [PROFILE-MEMORY-HOWTO] + [PROFILE-MEMORY-INGEST] + [PROFILE-PROCESSES-LAUNCH-FILE].
+// See docs/specs/LSP-PROFILING-SPEC.md#PROFILE-MEMORY-HOWTO
+//
+// REAL memory-profiling end-to-end: a real debugpy session pauses a real
+// Python program, the editor-as-courier round-trip injects tracemalloc and
+// posts the output back via `basilisk.memory.ingest`, and the assertions
+// cover what the user actually sees — snapshot allocations attributed to the
+// real allocation line, leak suspicion on growth, the purple heat-map track
+// (via the applied-decoration ledger), the `.heapprofile` for VS Code's
+// built-in viewer, and the "Run & Track Memory (Current File)" auto-start.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { currentStoppedFrameId, evaluateInDebugSession } from "../../dap-evaluate";
+import { activeMemorySession } from "../../memory-profiler";
+import { buildProfileLaunchConfig } from "../../process-launch";
+import {
+  applyLeakDecorations,
+  applyMemoryDecorations,
+  appliedMemoryDecorations,
+  clearMemoryDecorations,
+  type MemoryDiffResult,
+  type MemorySnapshotResult,
+} from "../../memory-decorations";
+import {
+  openPythonFile,
+  pollUntilResult,
+  setupLspTestSuite,
+  teardownLspTestSuite,
+  closeAllEditors,
+} from "./test-helpers";
+
+/** The memory fixture, opened from the real fixtures directory. */
+const FIXTURE = path.resolve(__dirname, "../../src/test/fixtures/memory_growth.py");
+/** 1-based allocation site: `CACHE.append("x" * 5000)`. */
+const ALLOC_LINE = 9;
+/** Breakpoints between allocation chunks in main(). */
+const BP_AFTER_CHUNK1 = 15;
+const BP_AFTER_CHUNK2 = 16;
+const BP_AFTER_CHUNK3 = 17;
+/** The memory decoration palette (purple track + leak colors). */
+const MEMORY_PALETTE = ["#c084fc", "#a78bfa", "#8b5cf6", "#7c3aed"];
+const LEAK_PALETTE = ["#ef4444", "#f87171", "#fb923c", "#a78bfa"];
+
+/** Budget for a debug session to start / stop / pause. */
+const SESSION_WAIT_MS = 20_000;
+/** Poll cadence for debug-state changes. */
+const POLL_MS = 100;
+
+// ── Slim debug helpers (local to this suite) ─────────────────────────────
+
+function setBreakpoints(filePath: string, lines: number[]): void {
+  vscode.debug.removeBreakpoints(vscode.debug.breakpoints);
+  vscode.debug.addBreakpoints(
+    lines.map(
+      (line) =>
+        new vscode.SourceBreakpoint(
+          new vscode.Location(vscode.Uri.file(filePath), new vscode.Position(line - 1, 0)),
+        ),
+    ),
+  );
+}
+
+/** Wait until the active debuggee is paused, returning the stopped frame id. */
+async function waitForPause(): Promise<number> {
+  const frameId = await pollUntilResult({
+    fn: async () => currentStoppedFrameId(),
+    predicate: (frame) => frame !== null,
+    timeoutMs: SESSION_WAIT_MS,
+    intervalMs: POLL_MS,
+  });
+  assert.ok(frameId !== null, "debuggee must reach a paused state");
+  return frameId;
+}
+
+/** Resume the debuggee (first stopped thread). */
+async function resume(): Promise<void> {
+  const session = vscode.debug.activeDebugSession;
+  assert.ok(session, "an active debug session is required to resume");
+  const threads = (await session.customRequest("threads")) as { threads?: { id: number }[] };
+  const threadId = threads.threads?.[0]?.id;
+  assert.ok(threadId !== undefined, "the debuggee must report a thread");
+  await session.customRequest("continue", { threadId });
+}
+
+/** Wait for the active debug session to terminate. */
+async function waitForSessionEnd(): Promise<void> {
+  await pollUntilResult({
+    fn: async () => vscode.debug.activeDebugSession,
+    predicate: (session) => session === undefined,
+    timeoutMs: SESSION_WAIT_MS,
+    intervalMs: POLL_MS,
+  });
+}
+
+// ── Courier round-trip (leg 1 → evaluate → leg 2) ────────────────────────
+
+/** One marker-tagged ingest result. */
+interface IngestResult {
+  kind: string;
+  [field: string]: unknown;
+}
+
+/** Run one memory command's full courier round-trip against the paused debuggee. */
+async function memoryRoundTrip<T extends IngestResult>(
+  command: string,
+  memorySessionId: string | undefined,
+  frameId: number,
+): Promise<T> {
+  const leg1 = await vscode.commands.executeCommand<
+    { memorySessionId?: string; script?: string } | null
+  >(command, {
+    ...(memorySessionId === undefined ? { tracebackDepth: 25 } : { memorySessionId }),
+  });
+  const script = leg1?.script;
+  assert.ok(script !== undefined && script !== "", `${command} must return an injection script`);
+
+  const output = await evaluateInDebugSession(script, frameId);
+  assert.ok(output !== null, `${command} script must evaluate in the paused debuggee`);
+
+  const ingested = await vscode.commands.executeCommand<T | null>("basilisk.memory.ingest", {
+    memorySessionId: memorySessionId ?? leg1?.memorySessionId,
+    output,
+  });
+  assert.ok(ingested !== null, "ingest must return a kind-tagged result");
+  return ingested;
+}
+
+/** Assert the snapshot's user-facing surface: heapprofile artifact + purple track. */
+function assertSnapshotSurface(snapshot: MemorySnapshotResult & IngestResult): void {
+  assert.ok(snapshot.currentMemory > 0, "tracemalloc must report live memory");
+  assert.ok(
+    snapshot.topAllocations.some((a) => a.file.endsWith("memory_growth.py") && a.line === ALLOC_LINE),
+    `the real allocation site (line ${ALLOC_LINE}) must be attributed, got: ${ 
+      snapshot.topAllocations.map((a) => `${path.basename(a.file)}:${a.line}`).join(", ")}`,
+  );
+
+  // Native .heapprofile artifact for the built-in viewer ([PROFILE-NATIVE]).
+  const heapProfilePath = snapshot.heapProfilePath;
+  assert.ok(typeof heapProfilePath === "string" && heapProfilePath !== "", "heapProfilePath must be returned");
+  assert.ok(fs.existsSync(heapProfilePath), ".heapprofile must be written to disk");
+  const heapprofile = JSON.parse(fs.readFileSync(heapProfilePath, "utf8")) as {
+    head?: { children?: unknown[]; selfSize?: number };
+  };
+  assert.ok(heapprofile.head !== undefined, ".heapprofile must have a head tree");
+
+  // The purple memory track is really painted ([PROFILE-VIS-HEATMAP]).
+  applyMemoryDecorations(snapshot);
+  const memApplied = appliedMemoryDecorations().filter((entry) => entry.file === FIXTURE);
+  assert.ok(memApplied.length > 0, "snapshot allocations must paint the open fixture");
+  assert.ok(
+    memApplied.some((entry) => entry.line === ALLOC_LINE && MEMORY_PALETTE.includes(entry.color)),
+    `the allocation line must wear a purple-palette decoration, got: ${JSON.stringify(memApplied)}`,
+  );
+  assert.ok(
+    memApplied.some((entry) => /(B|KB|MB|GB) allocated/.test(entry.contentText)),
+    "memory decorations must show allocation sizes",
+  );
+}
+
+/** Assert the diff's user-facing surface: leak suspicion + leak decorations. */
+function assertLeakSurface(diff: MemoryDiffResult & IngestResult): void {
+  assert.ok(diff.totalGrowth > 0, "allocating a chunk between pauses must register growth");
+  assert.ok(
+    diff.suspectedLeaks.some((leak) => leak.file.endsWith("memory_growth.py") && leak.line === ALLOC_LINE),
+    `growth at the allocation site must be a suspected leak, got: ${JSON.stringify(diff.suspectedLeaks)}`,
+  );
+
+  applyLeakDecorations(diff);
+  const leakApplied = appliedMemoryDecorations().filter(
+    (entry) => entry.file === FIXTURE && LEAK_PALETTE.includes(entry.color) && entry.contentText.includes("leak"),
+  );
+  assert.ok(leakApplied.length > 0, "suspected leaks must paint leak decorations with a confidence badge");
+}
+
+ 
+suite("Memory profiling — real end-to-end", () => {
+  let tmpDir = "";
+
+  suiteSetup(async function () {
+    this.timeout(60_000);
+    const result = await setupLspTestSuite("basilisk-mem-e2e-");
+    tmpDir = result.tmpDir;
+    assert.ok(fs.existsSync(FIXTURE), `memory fixture must exist: ${FIXTURE}`);
+  });
+
+  suiteTeardown(async function () {
+    this.timeout(30_000);
+    vscode.debug.removeBreakpoints(vscode.debug.breakpoints);
+    clearMemoryDecorations();
+    await closeAllEditors();
+    teardownLspTestSuite(tmpDir);
+  });
+
+  teardown(async () => {
+    if (vscode.debug.activeDebugSession !== undefined) {
+      await vscode.debug.stopDebugging();
+      await waitForSessionEnd();
+    }
+    await vscode.commands.executeCommand("basilisk.memoryStop");
+  });
+
+  test("courier round-trip: inject tracemalloc, snapshot real allocations, diff growth into leaks, paint the purple track", async function () {
+    this.timeout(90_000);
+    const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(FIXTURE));
+    await vscode.window.showTextDocument(doc, { preview: false });
+
+    setBreakpoints(FIXTURE, [BP_AFTER_CHUNK1, BP_AFTER_CHUNK2, BP_AFTER_CHUNK3]);
+    const started = await vscode.debug.startDebugging(undefined, {
+      name: "Memory E2E",
+      type: "basilisk-debug",
+      request: "launch",
+      program: FIXTURE,
+      stopOnEntry: false,
+      justMyCode: true,
+      console: "internalConsole",
+    });
+    assert.ok(started, "the debug session must launch");
+
+    // Pause 1 (chunk 1 allocated): start tracking + seed the diff baseline.
+    let frameId = await waitForPause();
+    const start = await memoryRoundTrip("basilisk.memory.start", undefined, frameId);
+    assert.strictEqual(start.kind, "ack", "memory.start ingest must acknowledge");
+    const memorySessionId = start.memorySessionId;
+    assert.ok(typeof memorySessionId === "string" && memorySessionId.length > 0, "a memory session must be minted");
+    const seeded = await memoryRoundTrip("basilisk.memory.diff", memorySessionId, frameId);
+    assert.strictEqual(seeded.kind, "diff", "the first diff must self-seed its baseline");
+    await resume();
+
+    // Pause 2 (chunk 2 allocated under tracemalloc): snapshot + diff.
+    frameId = await waitForPause();
+    const snapshot = await memoryRoundTrip<MemorySnapshotResult & IngestResult>(
+      "basilisk.memory.snapshot",
+      memorySessionId,
+      frameId,
+    );
+    assert.strictEqual(snapshot.kind, "snapshot", "snapshot ingest must be kind-tagged");
+    assertSnapshotSurface(snapshot);
+
+    const diff = await memoryRoundTrip<MemoryDiffResult & IngestResult>(
+      "basilisk.memory.diff",
+      memorySessionId,
+      frameId,
+    );
+    assert.strictEqual(diff.kind, "diff", "diff ingest must be kind-tagged");
+    assertLeakSurface(diff);
+    await resume();
+
+    // Pause 3 (chunk 3): consecutive growth keeps the site suspected.
+    frameId = await waitForPause();
+    const diff2 = await memoryRoundTrip<MemoryDiffResult & IngestResult>(
+      "basilisk.memory.diff",
+      memorySessionId,
+      frameId,
+    );
+    assert.ok(diff2.totalGrowth > 0, "the third chunk must register growth too");
+    assert.ok(diff2.suspectedLeaks.length > 0, "consecutive growth must keep the leak suspected");
+
+    await resume();
+    await waitForSessionEnd();
+  });
+
+  test("Run & Track Memory (Current File): stop-on-entry inject, auto-resume, program completes (#82)", async function () {
+    this.timeout(60_000);
+    vscode.debug.removeBreakpoints(vscode.debug.breakpoints);
+    await openPythonFile(tmpDir, "noop.py", "x = 1\n");
+
+    const started = await vscode.debug.startDebugging(
+      undefined,
+      buildProfileLaunchConfig("memory", FIXTURE),
+    );
+    assert.ok(started, "the metric-explicit memory launch must start");
+
+    // The auto-flow must mint a memory session at the entry pause…
+    await pollUntilResult({
+      fn: async () => activeMemorySession(),
+      predicate: (sessionId) => sessionId !== undefined,
+      timeoutMs: SESSION_WAIT_MS,
+      intervalMs: POLL_MS,
+    });
+
+    // …and resume the debuggee so the program actually runs to completion.
+    await waitForSessionEnd();
+    assert.ok(activeMemorySession() !== undefined, "tracking must survive until explicitly stopped");
+  });
+});

--- a/vscode-extension/src/test/suite/process-explorer.test.ts
+++ b/vscode-extension/src/test/suite/process-explorer.test.ts
@@ -10,6 +10,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { type LanguageClient } from "vscode-languageclient/node";
 import { PythonProcessesProvider, type ProcessInfo } from "../../process-explorer";
+import { createProcessRowActions } from "../../process-launch";
 import { createStore, type Store } from "../../store";
 
 const MB = 1024 * 1024;
@@ -33,16 +34,40 @@ const STUB_PROCESSES: readonly ProcessInfo[] = [
   },
 ];
 
-/** Build a Store whose LSP client returns the given process table. */
-function storeWith(processes: readonly ProcessInfo[]): Store {
+/** One `workspace/executeCommand` request captured by the recording client. */
+interface RecordedRequest {
+  readonly command: string;
+  readonly arguments: readonly unknown[];
+}
+
+/**
+ * Build a Store whose LSP client returns the given process table and records
+ * every executeCommand request so tests can assert what was sent (e.g. that an
+ * inline action really issued `basilisk.profiler.start` with the row's PID).
+ */
+function storeWith(processes: readonly ProcessInfo[], requests?: RecordedRequest[]): Store {
   const store = createStore();
   const client = {
     isRunning: (): boolean => true,
     onDidChangeState: (): vscode.Disposable => ({ dispose: (): undefined => undefined }),
-    sendRequest: async (): Promise<{ processes: readonly ProcessInfo[] }> => ({ processes }),
+    sendRequest: async (_method: string, param?: RecordedRequest): Promise<unknown> => {
+      if (param !== undefined) { requests?.push(param); }
+      if (param?.command === "basilisk.profiler.start") { return undefined; }
+      return { processes };
+    },
   } as unknown as LanguageClient;
   store.setClient({ subscriptions: [] } as unknown as vscode.ExtensionContext, client);
   return store;
+}
+
+/** The `basilisk.profiler.start` requests among the recorded ones. */
+function profilerStarts(requests: readonly RecordedRequest[]): RecordedRequest[] {
+  return requests.filter((req) => req.command === "basilisk.profiler.start");
+}
+
+/** The pid argument of a recorded `basilisk.profiler.start` request. */
+function startPid(request: RecordedRequest): unknown {
+  return (request.arguments[0] as { pid?: unknown } | undefined)?.pid;
 }
 
 /** Read the PID a process row carries (the arg passed to inline commands). */
@@ -138,6 +163,104 @@ suite("Python Processes Panel", () => {
     const eleven = groups.find((g) => labelText(g) === "3.11.7");
     assert.ok(eleven, "3.11.7 group must exist");
     assert.deepStrictEqual(membersOf(eleven).map((p) => p.pid), [200]);
+  });
+});
+
+// Tests for [PROFILE-PROCESSES-LAUNCH] issue #79: the inline flame/database
+// buttons arrive with `item === undefined` at runtime and must still profile
+// the row the user clicked instead of warning "Select a Python process".
+suite("Python Processes Panel — inline launch actions (#79)", () => {
+  let provider: PythonProcessesProvider;
+
+  teardown(() => {
+    provider.dispose();
+  });
+
+  test("rows keep a stable id across refreshes so inline buttons survive the auto-refresh", async () => {
+    provider = new PythonProcessesProvider(storeWith(STUB_PROCESSES));
+    const before = await provider.getChildren();
+    provider.refresh();
+    const after = await provider.getChildren();
+
+    const beforeRow = before.find((row) => pidOf(row) === 200);
+    const afterRow = after.find((row) => pidOf(row) === 200);
+    assert.ok(beforeRow !== undefined && afterRow !== undefined, "PID 200 row must exist in both passes");
+    assert.ok(
+      typeof beforeRow.id === "string" && beforeRow.id.length > 0,
+      "process rows must carry a stable TreeItem.id so VS Code can map an inline click " +
+        `back to the element after a 2s auto-refresh (#79); got: ${String(beforeRow.id)}`,
+    );
+    assert.strictEqual(beforeRow.id, afterRow.id, "the id must be identical across refreshes");
+  });
+
+  test("inline Profile CPU invoked without an argument profiles the selected row", async () => {
+    const requests: RecordedRequest[] = [];
+    const store = storeWith(STUB_PROCESSES, requests);
+    provider = new PythonProcessesProvider(store);
+    const rows = await provider.getChildren();
+    const selectedRow = rows.find((row) => pidOf(row) === 200);
+    assert.ok(selectedRow !== undefined, "PID 200 row must exist");
+
+    const actions = createProcessRowActions(store, { selection: [selectedRow] });
+    // VS Code passed no argument — the runtime shape of issue #79.
+    await actions.profileProcess(undefined);
+
+    const starts = profilerStarts(requests);
+    assert.strictEqual(
+      starts.length,
+      1,
+      "clicking the inline flame button must start profiling (not warn) when a row is selected (#79)",
+    );
+    assert.strictEqual(startPid(starts[0]), 200, "profiling must target the selected row's PID");
+  });
+
+  test("inline Track Memory invoked without an argument targets the selected row", async () => {
+    const requests: RecordedRequest[] = [];
+    const store = storeWith(STUB_PROCESSES, requests);
+    provider = new PythonProcessesProvider(store);
+    const rows = await provider.getChildren();
+    const selectedRow = rows.find((row) => pidOf(row) === 100);
+    assert.ok(selectedRow !== undefined, "PID 100 row must exist");
+
+    const actions = createProcessRowActions(store, { selection: [selectedRow] });
+    await actions.memoryTrackProcess(undefined);
+
+    const starts = profilerStarts(requests);
+    assert.strictEqual(starts.length, 1, "Track Memory must start for the selected row (#79)");
+    assert.strictEqual(startPid(starts[0]), 100, "memory tracking must target the selected row's PID");
+  });
+
+  test("an explicitly passed row wins over a different selection", async () => {
+    const requests: RecordedRequest[] = [];
+    const store = storeWith(STUB_PROCESSES, requests);
+    provider = new PythonProcessesProvider(store);
+    const rows = await provider.getChildren();
+    const clicked = rows.find((row) => pidOf(row) === 300);
+    const selected = rows.find((row) => pidOf(row) === 200);
+    assert.ok(clicked !== undefined && selected !== undefined, "both rows must exist");
+
+    const actions = createProcessRowActions(store, { selection: [selected] });
+    await actions.profileProcess(clicked);
+
+    const starts = profilerStarts(requests);
+    assert.strictEqual(starts.length, 1, "the clicked row must be profiled");
+    assert.strictEqual(startPid(starts[0]), 300, "the explicit item must win over the selection");
+  });
+
+  test("with no item and no selection, nothing is profiled", async () => {
+    const requests: RecordedRequest[] = [];
+    const store = storeWith(STUB_PROCESSES, requests);
+    provider = new PythonProcessesProvider(store);
+    await provider.getChildren();
+
+    const actions = createProcessRowActions(store, { selection: [] });
+    await actions.profileProcess(undefined);
+
+    assert.strictEqual(
+      profilerStarts(requests).length,
+      0,
+      "without any resolvable target the action must not fire a profiler.start",
+    );
   });
 });
 

--- a/vscode-extension/src/test/suite/profiler-cpu-e2e.test.ts
+++ b/vscode-extension/src/test/suite/profiler-cpu-e2e.test.ts
@@ -1,0 +1,335 @@
+// Tests for [PROFILE-VIS-HEATMAP] + [PROFILE-NATIVE] + [PROFILE-NOTIFICATIONS-PROGRESS].
+// See docs/specs/LSP-PROFILING-SPEC.md#PROFILE-VIS-HEATMAP
+//
+// REAL CPU-profiling end-to-end: spawn an actual CPU-bound Python process,
+// attach through the real LSP, and assert the artifacts the user actually
+// sees — the inline heat map (via the applied-decoration ledger), the live
+// status-bar progress, the hot-function attribution, the `.cpuprofile` for
+// VS Code's built-in viewer, the speedscope JSON, and the flamegraph webview
+// HTML. Attach assertions are Linux-gated (CI runs ubuntu; macOS requires
+// root for py-spy), and every platform asserts the actionable #81 error path.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import { execFileSync, spawn, type ChildProcess } from "child_process";
+import { getStore } from "../../extension";
+import { profilerStatusText, startProfilingForPid } from "../../profiler";
+import {
+  applyProfileDecorations,
+  clearProfileDecorations,
+  appliedProfileDecorations,
+  type ProfileResult,
+} from "../../profiler-decorations";
+import { buildFlamegraphHtml } from "../../profiler-flamegraph-html";
+import {
+  openPythonFile,
+  pollUntilResult,
+  setupLspTestSuite,
+  teardownLspTestSuite,
+  closeAllEditors,
+} from "./test-helpers";
+
+/** How long the burner keeps spinning (covers the whole suite). */
+const BURNER_LIFETIME_SECS = 120;
+/** Sampling window before stopping a profile. */
+const SAMPLE_WINDOW_MS = 2_500;
+/** Budget for the LSP attach + first progress notification. */
+const PROGRESS_WAIT_MS = 10_000;
+/** Budget for profiler diagnostics to be published after stop. */
+const DIAGNOSTICS_WAIT_MS = 10_000;
+/** The CPU heat-map palette ([PROFILE-VIS-PALETTE]). */
+const HEAT_PALETTE = ["#e8500a", "#f97316", "#fbbf24", "#4a5468"];
+
+/** 1-based line of `def hot_function` in the burner source below. */
+const HOT_FUNCTION_DEF_LINE = 12;
+
+/**
+ * CPU burner: ~all samples land in hot_function. `PR_SET_PTRACER_ANY` lets a
+ * non-ancestor LSP attach under Linux Yama ptrace_scope=1 (same trick as the
+ * Rust e2e suites).
+ */
+const BURNER_SOURCE = `import sys
+import time
+
+try:
+    import ctypes
+    _libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    _libc.prctl(0x59616D61, ctypes.c_ulong(0xFFFFFFFFFFFFFFFF), 0, 0, 0)
+except Exception:
+    pass
+
+
+def hot_function():
+    total = 0
+    for i in range(1_000_000):
+        total += i * i
+    return total
+
+
+def main():
+    print("READY", flush=True)
+    deadline = time.time() + ${BURNER_LIFETIME_SECS}
+    while time.time() < deadline:
+        hot_function()
+
+
+if __name__ == "__main__":
+    main()
+`;
+
+/** The python interpreter for spawning helper processes. */
+const PYTHON = process.platform === "win32" ? "python" : "python3";
+
+/** Spawn the burner and resolve once it prints READY. */
+async function spawnBurner(scriptPath: string): Promise<ChildProcess> {
+  const child = spawn(PYTHON, [scriptPath], { stdio: ["ignore", "pipe", "ignore"] });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("burner never printed READY")), PROGRESS_WAIT_MS);
+    child.stdout?.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("READY")) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on("exit", () => reject(new Error("burner exited before READY")));
+  });
+  return child;
+}
+
+/** The shape `basilisk.profiler.start` resolves to. */
+interface StartResult {
+  sessionId: string;
+  pid: number;
+  pythonVersion: string;
+}
+
+/** Stop any session left behind so suites stay independent. */
+async function stopAllProfilerSessions(): Promise<void> {
+  const list = await vscode.commands.executeCommand<{ sessions?: { sessionId: string }[] }>(
+    "basilisk.profiler.list",
+  );
+  for (const session of list?.sessions ?? []) {
+    try {
+      await vscode.commands.executeCommand("basilisk.profiler.stop", { sessionId: session.sessionId });
+    } catch {
+      // already gone
+    }
+  }
+}
+
+/** Assert the speedscope JSON artifact exists and attributes hot_function. */
+function assertSpeedscopeArtifact(outputFile: string): void {
+  assert.ok(fs.existsSync(outputFile), `speedscope file must exist: ${outputFile}`);
+  const speedscope = JSON.parse(fs.readFileSync(outputFile, "utf8")) as {
+    shared?: { frames?: { name: string }[] };
+    profiles?: unknown[];
+  };
+  assert.ok(
+    speedscope.shared?.frames?.some((frame) => frame.name === "hot_function"),
+    "speedscope frames must include hot_function",
+  );
+  assert.ok((speedscope.profiles?.length ?? 0) > 0, "speedscope must contain at least one profile");
+}
+
+/** Assert the V8 `.cpuprofile` exists and opens as a valid call tree ([PROFILE-NATIVE]). */
+function assertCpuProfileArtifact(cpuProfilePath: string | undefined): void {
+  assert.ok(typeof cpuProfilePath === "string" && cpuProfilePath !== "", "cpuProfilePath returned");
+  assert.ok(fs.existsSync(cpuProfilePath), ".cpuprofile must be written to disk");
+  const cpuprofile = JSON.parse(fs.readFileSync(cpuProfilePath, "utf8")) as {
+    nodes?: { callFrame?: { functionName?: string } }[];
+    samples?: number[];
+    timeDeltas?: number[];
+  };
+  assert.ok((cpuprofile.nodes?.length ?? 0) > 0, ".cpuprofile must have a call tree");
+  assert.ok((cpuprofile.samples?.length ?? 0) > 0, ".cpuprofile must have samples");
+  assert.strictEqual(
+    cpuprofile.samples?.length,
+    cpuprofile.timeDeltas?.length,
+    ".cpuprofile samples and timeDeltas must be parallel arrays",
+  );
+  assert.ok(
+    cpuprofile.nodes?.some((node) => node.callFrame?.functionName === "hot_function"),
+    ".cpuprofile call tree must include hot_function",
+  );
+}
+
+/** Assert the hottest line wears the correctly-tiered palette color. */
+function assertHottestLineTier(result: ProfileResult, burnerPath: string): void {
+  applyProfileDecorations(result);
+  const applied = appliedProfileDecorations().filter((entry) => entry.file === burnerPath);
+  assert.ok(applied.length > 0, "real profile data must paint the open hot file");
+  const topLine = [...result.hotLines].sort((a, b) => b.percentage - a.percentage)[0];
+  const expectedColor =
+    topLine.percentage >= 20 ? "#e8500a"
+    : topLine.percentage >= 10 ? "#f97316"
+    : topLine.percentage >= 5 ? "#fbbf24"
+    : "#4a5468";
+  assert.ok(
+    applied.some((entry) => entry.line === topLine.line && entry.color === expectedColor),
+    `hottest line ${topLine.line} (${topLine.percentage.toFixed(1)}%) must wear ${expectedColor}`,
+  );
+}
+
+/** Assert the heat map painted on the burner with palette colors and % text. */
+function assertHeatMapPainted(burnerPath: string): void {
+  const applied = appliedProfileDecorations().filter((entry) => entry.file === burnerPath);
+  assert.ok(applied.length > 0, "stopping must paint heat decorations on the open hot file");
+  for (const decoration of applied) {
+    assert.ok(
+      HEAT_PALETTE.includes(decoration.color),
+      `heat colors must come from the brand palette, got ${decoration.color}`,
+    );
+  }
+  assert.ok(
+    applied.some((entry) => /\d+(\.\d+)?%/.test(entry.contentText)),
+    `decorations must show CPU percentages, got: ${applied.map((entry) => entry.contentText).join(" | ")}`,
+  );
+  assert.ok(
+    applied.some((entry) => entry.line >= HOT_FUNCTION_DEF_LINE),
+    "the hot_function body must carry heat decorations",
+  );
+}
+
+ 
+suite("CPU profiling — real end-to-end", () => {
+  let tmpDir = "";
+  let burner: ChildProcess | undefined;
+  let burnerPath = "";
+  let burnerUri: vscode.Uri | undefined;
+
+  suiteSetup(async function () {
+    this.timeout(60_000);
+    const result = await setupLspTestSuite("basilisk-cpu-e2e-");
+    tmpDir = result.tmpDir;
+    burnerPath = path.join(tmpDir, "burner.py");
+    const opened = await openPythonFile(tmpDir, "burner.py", BURNER_SOURCE);
+    burnerUri = opened.uri;
+    burner = await spawnBurner(burnerPath);
+  });
+
+  suiteTeardown(async function () {
+    this.timeout(30_000);
+    await stopAllProfilerSessions();
+    burner?.kill("SIGKILL");
+    clearProfileDecorations();
+    await closeAllEditors();
+    teardownLspTestSuite(tmpDir);
+  });
+
+  test("panel one-click flow: attach → live progress in status bar → stop paints the heat map", async function () {
+    if (process.platform !== "linux") { this.skip(); }
+    this.timeout(40_000);
+    const store = getStore();
+    assert.ok(store, "store must be initialized");
+    const pid = burner?.pid;
+    assert.ok(pid !== undefined && pid > 0, "burner must be running");
+
+    await startProfilingForPid(store, pid, "default");
+    assert.ok(profilerStatusText() !== undefined, "status bar must show a profiling state after start");
+
+    // [PROFILE-NOTIFICATIONS-PROGRESS]: live sample counts reach the status bar.
+    await pollUntilResult({
+      fn: async () => profilerStatusText() ?? "",
+      predicate: (text) => text.includes("samples"),
+      timeoutMs: PROGRESS_WAIT_MS,
+    });
+
+    await new Promise<void>((resolve) => setTimeout(resolve, SAMPLE_WINDOW_MS));
+    await vscode.commands.executeCommand("basilisk.profileStop");
+
+    assertHeatMapPainted(burnerPath);
+
+    // [PROFILE-NOTIFICATIONS-DIAG]: hint diagnostics from source basilisk-profiler.
+    const uri = burnerUri;
+    assert.ok(uri, "burner uri must exist");
+    const diagnostics = await pollUntilResult({
+      fn: async () => vscode.languages.getDiagnostics(uri),
+      predicate: (diags) => diags.some((diag) => diag.source === "basilisk-profiler"),
+      timeoutMs: DIAGNOSTICS_WAIT_MS,
+    });
+    const profDiag = diagnostics.find((diag) => diag.source === "basilisk-profiler");
+    assert.ok(profDiag, "profiler diagnostics must be published for the hot file");
+    assert.strictEqual(profDiag.severity, vscode.DiagnosticSeverity.Hint, "profiler diagnostics are Hints");
+  });
+
+  test("raw pipeline: hot function attributed, speedscope + .cpuprofile artifacts written and parseable", async function () {
+    if (process.platform !== "linux") { this.skip(); }
+    this.timeout(40_000);
+    const pid = burner?.pid;
+    assert.ok(pid !== undefined && pid > 0, "burner must be running");
+
+    const started = await vscode.commands.executeCommand<StartResult>("basilisk.profiler.start", {
+      pid,
+      sampleRate: 200,
+    });
+    assert.ok(started.sessionId.length > 0, "start must mint a session");
+    assert.ok(started.pythonVersion.startsWith("3."), `expected Python 3.x, got ${started.pythonVersion}`);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, SAMPLE_WINDOW_MS));
+
+    const result = await vscode.commands.executeCommand<ProfileResult>("basilisk.profiler.stop", {
+      sessionId: started.sessionId,
+      format: "speedscope",
+    });
+
+    assert.ok(result.totalSamples > 0, "real sampling must collect samples");
+    assert.ok(
+      result.hotFunctions.some((fn) => fn.name === "hot_function"),
+      `hot_function must be attributed, got: ${result.hotFunctions.map((fn) => fn.name).join(", ")}`,
+    );
+    assert.ok(result.hotLines.length > 0, "hot lines must be detected");
+
+    assertSpeedscopeArtifact(result.outputFile);
+    assertCpuProfileArtifact(result.cpuProfilePath);
+    assertHottestLineTier(result, burnerPath);
+  });
+
+  test("attaching to an exited process fails with a distinct, classified cause (#81)", async function () {
+    this.timeout(40_000);
+    // A guaranteed-dead PID exercises the classified failure path on every
+    // platform WITHOUT touching the macOS osascript elevation prompt — a GUI
+    // dialog no automated suite may trigger (the live-target helper paths are
+    // covered by the Rust profiler_helper_socket e2e suite).
+    const deadPid = Number(
+      execFileSync(PYTHON, ["-c", "import os; print(os.getpid())"], { encoding: "utf8" }).trim(),
+    );
+    assert.ok(deadPid > 0, "must obtain a freshly exited PID");
+
+    let message = "";
+    try {
+      await vscode.commands.executeCommand("basilisk.profiler.start", { pid: deadPid });
+      assert.fail("attach to an exited process must fail");
+    } catch (err: unknown) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    assert.ok(
+      /not found|No such process|py-spy attach failed/i.test(message),
+      `the failure must name the real cause distinctly (#81), got: ${message}`,
+    );
+    assert.ok(
+      !message.trim().endsWith("helper closed the connection before confirming attach"),
+      `the bare EOF message must never be the whole story (#81): ${message}`,
+    );
+  });
+
+  test("flamegraph webview HTML renders the dashboard from a profile result", () => {
+    const result: ProfileResult = {
+      sessionId: "s-test",
+      duration: 3,
+      totalSamples: 600,
+      outputFile: "/tmp/profile.speedscope.json",
+      hotFunctions: [
+        { name: "hot_function", file: burnerPath, line: HOT_FUNCTION_DEF_LINE, samples: 540, percentage: 90, selfPercentage: 85 },
+      ],
+      hotLines: [{ file: burnerPath, line: HOT_FUNCTION_DEF_LINE + 2, samples: 500, percentage: 83 }],
+    };
+    const html = buildFlamegraphHtml(result);
+    assert.ok(html.includes("hot_function"), "the profile data (hot functions) must be embedded");
+    assert.ok(html.toLowerCase().includes("#e8500a"), "the Basilisk orange palette must be used");
+    assert.ok(html.includes("navigateToSource"), "rows must navigate to source");
+    assert.ok(html.includes("fn-body"), "the hot-functions table must render");
+    assert.ok(html.includes(String(result.totalSamples)), "the summary must show the real sample count");
+  });
+});

--- a/vscode-extension/src/test/suite/profiler-cpu-e2e.test.ts
+++ b/vscode-extension/src/test/suite/profiler-cpu-e2e.test.ts
@@ -172,10 +172,28 @@ function assertHottestLineTier(result: ProfileResult, burnerPath: string): void 
   );
 }
 
+/** Assert [PROFILE-NOTIFICATIONS-DIAG]: Hint diagnostics from basilisk-profiler. */
+async function assertProfilerDiagnosticsPublished(uri: vscode.Uri): Promise<void> {
+  const diagnostics = await pollUntilResult({
+    fn: async () => vscode.languages.getDiagnostics(uri),
+    predicate: (diags) => diags.some((diag) => diag.source === "basilisk-profiler"),
+    timeoutMs: DIAGNOSTICS_WAIT_MS,
+  });
+  const profDiag = diagnostics.find((diag) => diag.source === "basilisk-profiler");
+  assert.ok(profDiag, "profiler diagnostics must be published for the hot file");
+  assert.strictEqual(profDiag.severity, vscode.DiagnosticSeverity.Hint, "profiler diagnostics are Hints");
+}
+
 /** Assert the heat map painted on the burner with palette colors and % text. */
 function assertHeatMapPainted(burnerPath: string): void {
   const applied = appliedProfileDecorations().filter((entry) => entry.file === burnerPath);
-  assert.ok(applied.length > 0, "stopping must paint heat decorations on the open hot file");
+  const visible = vscode.window.visibleTextEditors.map((e) => e.document.uri.fsPath).join(", ");
+  assert.ok(
+    applied.length > 0,
+    `stopping must paint heat decorations on the open hot file ${burnerPath}; ` +
+      `ledger: ${JSON.stringify(appliedProfileDecorations())}; visible editors: [${visible}]; ` +
+      `status: ${String(profilerStatusText())}`,
+  );
   for (const decoration of applied) {
     assert.ok(
       HEAT_PALETTE.includes(decoration.color),
@@ -218,42 +236,9 @@ suite("CPU profiling — real end-to-end", () => {
     teardownLspTestSuite(tmpDir);
   });
 
-  test("panel one-click flow: attach → live progress in status bar → stop paints the heat map", async function () {
-    if (process.platform !== "linux") { this.skip(); }
-    this.timeout(40_000);
-    const store = getStore();
-    assert.ok(store, "store must be initialized");
-    const pid = burner?.pid;
-    assert.ok(pid !== undefined && pid > 0, "burner must be running");
-
-    await startProfilingForPid(store, pid, "default");
-    assert.ok(profilerStatusText() !== undefined, "status bar must show a profiling state after start");
-
-    // [PROFILE-NOTIFICATIONS-PROGRESS]: live sample counts reach the status bar.
-    await pollUntilResult({
-      fn: async () => profilerStatusText() ?? "",
-      predicate: (text) => text.includes("samples"),
-      timeoutMs: PROGRESS_WAIT_MS,
-    });
-
-    await new Promise<void>((resolve) => setTimeout(resolve, SAMPLE_WINDOW_MS));
-    await vscode.commands.executeCommand("basilisk.profileStop");
-
-    assertHeatMapPainted(burnerPath);
-
-    // [PROFILE-NOTIFICATIONS-DIAG]: hint diagnostics from source basilisk-profiler.
-    const uri = burnerUri;
-    assert.ok(uri, "burner uri must exist");
-    const diagnostics = await pollUntilResult({
-      fn: async () => vscode.languages.getDiagnostics(uri),
-      predicate: (diags) => diags.some((diag) => diag.source === "basilisk-profiler"),
-      timeoutMs: DIAGNOSTICS_WAIT_MS,
-    });
-    const profDiag = diagnostics.find((diag) => diag.source === "basilisk-profiler");
-    assert.ok(profDiag, "profiler diagnostics must be published for the hot file");
-    assert.strictEqual(profDiag.severity, vscode.DiagnosticSeverity.Hint, "profiler diagnostics are Hints");
-  });
-
+  // Runs FIRST (the suite is fail-fast): it asserts the raw data, so a
+  // sampling failure surfaces with the profile contents instead of a bare
+  // "no decorations" from the UI-flow test below.
   test("raw pipeline: hot function attributed, speedscope + .cpuprofile artifacts written and parseable", async function () {
     if (process.platform !== "linux") { this.skip(); }
     this.timeout(40_000);
@@ -277,13 +262,50 @@ suite("CPU profiling — real end-to-end", () => {
     assert.ok(result.totalSamples > 0, "real sampling must collect samples");
     assert.ok(
       result.hotFunctions.some((fn) => fn.name === "hot_function"),
-      `hot_function must be attributed, got: ${result.hotFunctions.map((fn) => fn.name).join(", ")}`,
+      `hot_function must be attributed, got: ${JSON.stringify(result.hotFunctions)}`,
     );
-    assert.ok(result.hotLines.length > 0, "hot lines must be detected");
+    assert.ok(
+      result.hotLines.length > 0,
+      `hot lines must be detected; result: ${JSON.stringify(result)}`,
+    );
+    assert.ok(
+      result.hotLines.some((line) => line.file === burnerPath),
+      `hot lines must carry the editor's exact path ${burnerPath}, got: ${ 
+        JSON.stringify(result.hotLines.map((line) => line.file))}`,
+    );
 
     assertSpeedscopeArtifact(result.outputFile);
     assertCpuProfileArtifact(result.cpuProfilePath);
     assertHottestLineTier(result, burnerPath);
+  });
+
+  test("panel one-click flow: attach → live progress in status bar → stop paints the heat map", async function () {
+    if (process.platform !== "linux") { this.skip(); }
+    this.timeout(40_000);
+    const store = getStore();
+    assert.ok(store, "store must be initialized");
+    const pid = burner?.pid;
+    assert.ok(pid !== undefined && pid > 0, "burner must be running");
+
+    await startProfilingForPid(store, pid, "default");
+    assert.ok(profilerStatusText() !== undefined, "status bar must show a profiling state after start");
+
+    // [PROFILE-NOTIFICATIONS-PROGRESS]: a NON-ZERO live sample count reaches
+    // the status bar — "0 samples" would mean sampling is silently broken.
+    await pollUntilResult({
+      fn: async () => profilerStatusText() ?? "",
+      predicate: (text) => /[1-9][\d.]* ?K? samples/.test(text),
+      timeoutMs: PROGRESS_WAIT_MS,
+    });
+
+    await new Promise<void>((resolve) => setTimeout(resolve, SAMPLE_WINDOW_MS));
+    await vscode.commands.executeCommand("basilisk.profileStop");
+
+    assertHeatMapPainted(burnerPath);
+
+    const uri = burnerUri;
+    assert.ok(uri, "burner uri must exist");
+    await assertProfilerDiagnosticsPublished(uri);
   });
 
   test("attaching to an exited process fails with a distinct, classified cause (#81)", async function () {

--- a/vscode-extension/src/test/suite/profiler-entrypoints.test.ts
+++ b/vscode-extension/src/test/suite/profiler-entrypoints.test.ts
@@ -1,0 +1,196 @@
+// Tests for [PROFILE-PROCESSES-LAUNCH-FILE]. See
+// docs/specs/LSP-PROFILING-SPEC.md#PROFILE-PROCESSES-LAUNCH-FILE
+//
+// Issue #82: the PYTHON PROCESSES title-bar entry point must state WHAT it
+// profiles (CPU vs memory) and let the user choose either metric, with icons
+// and labels consistent with the per-row inline actions ("Profile CPU" 🔥 /
+// "Track Memory" 🗄️). These tests assert the declarative VSIX surface in
+// package.json — the same panel must speak one language at the row level and
+// the title level.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { buildProfileLaunchConfig } from "../../process-launch";
+import { shouldProfileOnLaunch } from "../../profiler";
+import {
+  getPackageJsonCommands,
+  getPackageJsonMenu,
+  getPackageJsonViewsWelcome,
+  type PackageJsonCommandEntry,
+} from "./profiler-test-constants";
+
+/** The metric-explicit run-and-profile entry points (#82). */
+const CPU_LAUNCH_COMMAND = "basilisk.profileCurrentFileCpu";
+const MEMORY_LAUNCH_COMMAND = "basilisk.trackMemoryCurrentFile";
+/** The ambiguous, metric-less command issue #82 retires. */
+const AMBIGUOUS_LAUNCH_COMMAND = "basilisk.profileCurrentFile";
+
+/** The view/title entries scoped to the Python Processes panel. */
+function pythonProcessesTitleCommands(): string[] {
+  return getPackageJsonMenu("view/title")
+    .filter((entry) => entry.when?.includes("basilisk.pythonProcesses") === true)
+    .map((entry) => entry.command);
+}
+
+/** Look up a command's declaration, asserting it exists. */
+function commandEntry(commandId: string): PackageJsonCommandEntry {
+  const entry = getPackageJsonCommands().find((cmd) => cmd.command === commandId);
+  assert.ok(entry, `command "${commandId}" must be declared in package.json`);
+  return entry;
+}
+
+suite("Python Processes — title-bar entry points state their metric (#82)", () => {
+  test("the title bar offers a CPU launch and a memory launch, not one ambiguous button", () => {
+    const titleCommands = pythonProcessesTitleCommands();
+    assert.ok(
+      titleCommands.includes(CPU_LAUNCH_COMMAND),
+      `the title bar must offer a CPU-explicit launch (#82); got: ${titleCommands.join(", ")}`,
+    );
+    assert.ok(
+      titleCommands.includes(MEMORY_LAUNCH_COMMAND),
+      `the title bar must offer a memory-explicit launch (#82); got: ${titleCommands.join(", ")}`,
+    );
+    assert.ok(
+      !titleCommands.includes(AMBIGUOUS_LAUNCH_COMMAND),
+      "the metric-less 'Run & Profile Current File' button must be gone (#82)",
+    );
+  });
+
+  test("the CPU launch is labelled CPU and wears the flame icon, matching the row action", () => {
+    const cpu = commandEntry(CPU_LAUNCH_COMMAND);
+    assert.ok(
+      cpu.title?.includes("CPU") === true,
+      `the CPU launch title must say CPU (#82); got: ${String(cpu.title)}`,
+    );
+    assert.strictEqual(cpu.icon, "$(flame)", "the CPU launch must reuse the Profile CPU row icon");
+  });
+
+  test("the memory launch is labelled Memory and wears the database icon, matching the row action", () => {
+    const memory = commandEntry(MEMORY_LAUNCH_COMMAND);
+    assert.ok(
+      memory.title?.includes("Memory") === true,
+      `the memory launch title must say Memory (#82); got: ${String(memory.title)}`,
+    );
+    assert.strictEqual(
+      memory.icon,
+      "$(database)",
+      "the memory launch must reuse the Track Memory row icon",
+    );
+  });
+
+  test("the empty-state welcome offers both metric-explicit launches", () => {
+    const welcome = getPackageJsonViewsWelcome().find(
+      (entry) => entry.view === "basilisk.pythonProcesses",
+    );
+    assert.ok(welcome, "the Python Processes panel must declare an empty state");
+    assert.ok(
+      welcome.contents.includes(`command:${CPU_LAUNCH_COMMAND}`),
+      `the welcome view must link the CPU launch (#82); got: ${welcome.contents}`,
+    );
+    assert.ok(
+      welcome.contents.includes(`command:${MEMORY_LAUNCH_COMMAND}`),
+      `the welcome view must link the memory launch (#82); got: ${welcome.contents}`,
+    );
+    // Anchored with the markdown link's closing paren — `…CurrentFileCpu`
+    // legitimately contains `…CurrentFile` as a prefix.
+    assert.ok(
+      !welcome.contents.includes(`command:${AMBIGUOUS_LAUNCH_COMMAND})`),
+      "the welcome view must not link the retired ambiguous command (#82)",
+    );
+  });
+
+  test("both launches stay palette-gated behind the profiling UI switch", () => {
+    const palette = getPackageJsonMenu("commandPalette");
+    for (const command of [CPU_LAUNCH_COMMAND, MEMORY_LAUNCH_COMMAND]) {
+      const entry = palette.find((item) => item.command === command);
+      assert.ok(entry, `${command} must have a commandPalette entry`);
+      assert.strictEqual(
+        entry.when,
+        "basilisk.profilingEnabled",
+        `${command} must stay behind the [PROFILE-UI-GATE] context key`,
+      );
+    }
+  });
+});
+
+suite("Run & Profile registered commands (#82)", () => {
+  test("both registered launches refuse to start a session without a Python file open", async () => {
+    await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    // Driving the REAL registered commands end-to-end: each must exist (or
+    // executeCommand rejects) and must decline to launch with no active
+    // Python editor instead of starting a broken session.
+    await vscode.commands.executeCommand("basilisk.profileCurrentFileCpu");
+    await vscode.commands.executeCommand("basilisk.trackMemoryCurrentFile");
+    assert.strictEqual(
+      vscode.debug.activeDebugSession,
+      undefined,
+      "no debug session may start when no Python file is open",
+    );
+  });
+});
+
+suite("Run & Profile launch configurations (#82)", () => {
+  test("the CPU launch asks for profiling on launch and names its metric", () => {
+    const config = buildProfileLaunchConfig("cpu", "/work/app.py");
+    assert.strictEqual(config.type, "basilisk-debug");
+    assert.strictEqual(config.request, "launch");
+    assert.strictEqual(config.program, "/work/app.py");
+    assert.strictEqual(
+      config.profileOnLaunch,
+      true,
+      "the CPU launch must actually start the profiler, not just run the file",
+    );
+    assert.ok(config.name.includes("CPU"), `the session name must state the metric: ${config.name}`);
+  });
+
+  test("the memory launch stops on entry so tracemalloc can be injected, then tracked", () => {
+    const config = buildProfileLaunchConfig("memory", "/work/app.py");
+    assert.strictEqual(config.program, "/work/app.py");
+    assert.strictEqual(
+      config.stopOnEntry,
+      true,
+      "memory tracking injects tracemalloc via DAP evaluate, which needs a paused debuggee",
+    );
+    assert.strictEqual(
+      config.memoryTrackOnLaunch,
+      true,
+      "memory-profiler.ts keys its auto-start flow off this flag",
+    );
+    assert.ok(config.name.includes("Memory"), `the session name must state the metric: ${config.name}`);
+  });
+
+  test("a launch config requesting profileOnLaunch is honoured even with the global setting off", async () => {
+    const cfg = vscode.workspace.getConfiguration("basilisk");
+    await cfg.update("profiler.profileOnLaunch", undefined, vscode.ConfigurationTarget.Global);
+
+    const fromEntryPoint = {
+      type: "basilisk-debug",
+      configuration: buildProfileLaunchConfig("cpu", "/work/app.py"),
+    };
+    assert.strictEqual(
+      shouldProfileOnLaunch(fromEntryPoint),
+      true,
+      "the 'Run & Profile CPU' launch must auto-profile without requiring the global setting (#82)",
+    );
+
+    const plainLaunch = {
+      type: "basilisk-debug",
+      configuration: { type: "basilisk-debug", request: "launch", name: "plain" },
+    };
+    assert.strictEqual(
+      shouldProfileOnLaunch(plainLaunch),
+      false,
+      "a plain debug session must not be auto-profiled by default",
+    );
+
+    const foreignSession = {
+      type: "node",
+      configuration: buildProfileLaunchConfig("cpu", "/work/app.py"),
+    };
+    assert.strictEqual(
+      shouldProfileOnLaunch(foreignSession),
+      false,
+      "non-Basilisk sessions are never auto-profiled",
+    );
+  });
+});

--- a/vscode-extension/src/test/suite/profiler-test-constants.ts
+++ b/vscode-extension/src/test/suite/profiler-test-constants.ts
@@ -55,6 +55,20 @@ export interface PackageJsonCommandEntry {
     command: string;
     title?: string;
     category?: string;
+    icon?: string;
+}
+
+/** Shape of a menu contribution entry in package.json contributes.menus. */
+export interface PackageJsonMenuEntry {
+    command: string;
+    when?: string;
+    group?: string;
+}
+
+/** Shape of a viewsWelcome entry in package.json contributes.viewsWelcome. */
+export interface PackageJsonViewsWelcomeEntry {
+    view: string;
+    contents: string;
 }
 
 /** Shape of a keybinding entry in package.json contributes.keybindings. */
@@ -75,6 +89,8 @@ interface PackageJson {
         };
         commands?: PackageJsonCommandEntry[];
         keybindings?: PackageJsonKeybinding[];
+        menus?: Record<string, PackageJsonMenuEntry[]>;
+        viewsWelcome?: PackageJsonViewsWelcomeEntry[];
     };
 }
 
@@ -98,4 +114,25 @@ export function getPackageJsonCommands(): PackageJsonCommandEntry[] {
     assert.ok(extension, 'Extension should be found');
     const packageJson = extension.packageJSON as PackageJson;
     return packageJson.contributes?.commands ?? [];
+}
+
+/**
+ * Retrieve a menu's contribution entries from the extension's package.json
+ * (e.g. `view/title`, `view/item/context`).
+ */
+export function getPackageJsonMenu(menuId: string): PackageJsonMenuEntry[] {
+    const extension = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(extension, 'Extension should be found');
+    const packageJson = extension.packageJSON as PackageJson;
+    return packageJson.contributes?.menus?.[menuId] ?? [];
+}
+
+/**
+ * Retrieve the viewsWelcome entries from the extension's package.json.
+ */
+export function getPackageJsonViewsWelcome(): PackageJsonViewsWelcomeEntry[] {
+    const extension = vscode.extensions.getExtension(EXTENSION_ID);
+    assert.ok(extension, 'Extension should be found');
+    const packageJson = extension.packageJSON as PackageJson;
+    return packageJson.contributes?.viewsWelcome ?? [];
 }


### PR DESCRIPTION
Closes #79, closes #81, closes #82.

## Fixes
- **#79** — Inline "Profile CPU" / "Track Memory" row buttons: stable `TreeItem.id`s survive the panel's 2s auto-refresh, and the handlers fall back to the panel selection when VS Code invokes them with no argument.
- **#81** — Helper attach failures are now diagnosable end to end: a structured `error` frame in the wire protocol (`AttachErrorKind`, shared classifier with the in-process sampler), a liveness probe splitting target-gone from permission-denied, and exit-status + stderr surfacing for bare EOFs and timeouts (including osascript elevation cancellations).
- **#82** — The ambiguous "Run & Profile Current File" title button is replaced by metric-explicit 🔥 **Run & Profile CPU (Current File)** and 🗄️ **Run & Track Memory (Current File)**; the launch-config `profileOnLaunch` flag is now honoured, and the memory launch stops on entry, injects tracemalloc, and auto-resumes.
- **Linux ptrace precheck** — `ptrace_scope=1` (default Ubuntu) no longer denies upfront: Yama grants ancestors (debug-session debuggees) and `PR_SET_PTRACER` opt-ins the precheck cannot see, so the attach is attempted and a real `EPERM` carries the remedies.

## New e2e coverage (real processes, no mocks)
- **CPU**: real burner process → real LSP attach → live status-bar progress → stop paints the inline heat map with tier-correct palette colors (observable via a new applied-decoration ledger) → hint diagnostics published → speedscope + `.cpuprofile` artifacts parse on disk → flamegraph webview HTML. Attach legs run on the ubuntu CI runners.
- **Memory**: real debugpy session → editor-as-courier round-trip (start/snapshot/diff/ingest) → real allocation line attributed → growth becomes suspected leaks → purple/leak decorations painted → `.heapprofile` parses → "Run & Track Memory" auto-start verified end to end.
- Rust: helper-socket error-path e2e (structured error frame, exited-target classification, exit-status + stderr surfacing), protocol round-trips, ptrace-scope policy pinned by tests.

Specs updated and cross-referenced: `[PROFILE-HELPER-PROTOCOL-ERRORS]`, `[PROFILE-PROCESSES-LAUNCH-FILE]`, `[PROFILE-PERMISSIONS-LINUX]`, `[PROFILE-PROCESSES-PANEL]`.

The `[PROFILE-UI-GATE]` is intentionally untouched — flipping it on is a one-line product decision once this is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)