### PR TITLE
Profiling: tests fail when the profile report doesn't load; fix unloadable exports and broken viewer flow

### DIFF
--- a/basilisk.nvim/lua/basilisk/profiling.lua
+++ b/basilisk.nvim/lua/basilisk/profiling.lua
@@ -177,25 +177,31 @@ function M.apply_heat_map(hot_functions)
   end
 end
 
---- Export results to speedscope JSON and open in browser.
----@param result? table Profiling results from the LSP server.
+--- Open the flamegraph SVG exported by the LSP server in the browser.
+--- Implements [PROFILE-VIEWER-DELIVERY]: speedscope.app can NEVER fetch a
+--- `file://` profileURL (an https page may not read local files), so we open
+--- the local self-contained SVG instead and log the speedscope JSON path for
+--- manual import at https://www.speedscope.app.
+---@param result? table Profiling results from the LSP `profiler.stop` response.
 function M.export_flamegraph(result)
-  if not result or not result.speedscopeJson then
-    log.warn("no speedscope data available")
+  if not result or not result.flamegraphPath then
+    local reason = result and result.exportError or "no flamegraph available"
+    log.warn("flamegraph export unavailable: %s", reason)
+    return
+  end
+  if vim.fn.filereadable(result.flamegraphPath) == 0 then
+    log.error("flamegraph file missing: %s", result.flamegraphPath)
     return
   end
 
-  local tmpfile = vim.fn.tempname() .. ".speedscope.json"
-  local fh = io.open(tmpfile, "w")
-  if not fh then
-    log.error("failed to create temp file: %s", tmpfile)
-    return
+  vim.ui.open("file://" .. result.flamegraphPath)
+  log.info("flamegraph opened: %s", result.flamegraphPath)
+  if result.outputFile then
+    log.info(
+      "speedscope JSON: %s (import manually at https://www.speedscope.app)",
+      result.outputFile
+    )
   end
-  fh:write(result.speedscopeJson)
-  fh:close()
-
-  vim.ui.open("https://www.speedscope.app/#profileURL=file://" .. tmpfile)
-  log.info("flamegraph exported: %s", tmpfile)
 end
 
 return M

--- a/basilisk.nvim/tests/basilisk/profiling_spec.lua
+++ b/basilisk.nvim/tests/basilisk/profiling_spec.lua
@@ -391,15 +391,21 @@ describe("basilisk.profiling", function()
       end)
     end)
 
-    it("handles result without speedscopeJson field", function()
+    it("handles result without flamegraphPath field", function()
       assert.has_no.errors(function()
         profiling.export_flamegraph({})
       end)
     end)
 
-    it("writes speedscope JSON to temp file", function()
-      local json_data = '{"$schema":"test","profiles":[]}'
-      local result = { speedscopeJson = json_data }
+    it("opens the LSP-exported flamegraph SVG as a local file", function()
+      local tmpfile = vim.fn.tempname() .. ".flamegraph.svg"
+      local fh = assert(io.open(tmpfile, "w"))
+      fh:write('<svg xmlns="http://www.w3.org/2000/svg"><text>hot_fn</text></svg>')
+      fh:close()
+      local result = {
+        flamegraphPath = tmpfile,
+        outputFile = "/tmp/basilisk-x.speedscope.json",
+      }
 
       -- Mock vim.ui.open to prevent browser launch.
       local original_open = vim.ui.open
@@ -412,9 +418,52 @@ describe("basilisk.profiling", function()
 
       -- Restore.
       vim.ui.open = original_open
+      os.remove(tmpfile)
 
-      assert.truthy(opened_url, "should attempt to open speedscope URL")
-      assert.truthy(opened_url:find("speedscope.app"), "URL should point to speedscope.app")
+      assert.equals("file://" .. tmpfile, opened_url, "must open the local SVG directly")
+    end)
+
+    it("does not open anything when the flamegraph file is missing", function()
+      local original_open = vim.ui.open
+      local opened_url = nil
+      vim.ui.open = function(url)
+        opened_url = url
+      end
+
+      profiling.export_flamegraph({ flamegraphPath = "/nonexistent/basilisk.flamegraph.svg" })
+
+      vim.ui.open = original_open
+      assert.is_nil(opened_url, "missing file must not be handed to the browser")
+    end)
+
+    -- [PROFILE-VIEWER-DELIVERY] regression: speedscope.app cannot fetch
+    -- file:// URLs — an https page may not read local files, so a
+    -- speedscope.app/#profileURL=file://... link ALWAYS fails with
+    -- "Something went wrong". The plugin must never construct one.
+    it("never hands speedscope.app a file:// profileURL", function()
+      local tmpfile = vim.fn.tempname() .. ".flamegraph.svg"
+      local fh = assert(io.open(tmpfile, "w"))
+      fh:write("<svg></svg>")
+      fh:close()
+
+      local original_open = vim.ui.open
+      local opened_urls = {}
+      vim.ui.open = function(url)
+        table.insert(opened_urls, url)
+      end
+
+      profiling.export_flamegraph({ flamegraphPath = tmpfile })
+      profiling.export_flamegraph({ speedscopeJson = '{"profiles":[]}' })
+
+      vim.ui.open = original_open
+      os.remove(tmpfile)
+
+      for _, url in ipairs(opened_urls) do
+        assert.is_nil(
+          url:find("speedscope.app", 1, true),
+          "no opened URL may point at speedscope.app with local data: " .. url
+        )
+      end
     end)
   end)
 

--- a/basilisk.nvim/tests/run_coverage.lua
+++ b/basilisk.nvim/tests/run_coverage.lua
@@ -261,10 +261,20 @@ prof.start()
 prof.start(1234)
 prof.stop()
 prof.snapshot()
--- export_flamegraph: nil, no speedscopeJson, with data
+-- export_flamegraph: nil, no flamegraphPath, missing file, real file
 prof.export_flamegraph(nil)
 prof.export_flamegraph({})
-prof.export_flamegraph({ speedscopeJson = '{"version":"0.0.1"}' })
+prof.export_flamegraph({ exportError = "no samples were collected" })
+prof.export_flamegraph({ flamegraphPath = "/nonexistent/basilisk.flamegraph.svg" })
+local cov_svg = vim.fn.tempname() .. ".flamegraph.svg"
+local cov_fh = assert(io.open(cov_svg, "w"))
+cov_fh:write("<svg></svg>")
+cov_fh:close()
+local cov_ui_open = vim.ui.open
+vim.ui.open = function() end
+prof.export_flamegraph({ flamegraphPath = cov_svg, outputFile = "/tmp/x.speedscope.json" })
+vim.ui.open = cov_ui_open
+os.remove(cov_svg)
 
 -- ============================================================
 -- 8. testing.lua — parser, tree, panel, run, debug, coverage

--- a/crates/basilisk-lsp/src/profiler/export.rs
+++ b/crates/basilisk-lsp/src/profiler/export.rs
@@ -74,13 +74,63 @@ struct SpeedscopeProfile {
     weights: Vec<f64>,
 }
 
+/// Validate that `data` can be rendered by external viewers.
+///
+/// Implements [PROFILE-SPEEDSCOPE-VALIDATE]: speedscope.app indexes
+/// `shared.frames` by every sample entry, walks parallel `samples`/`weights`
+/// arrays, and reads `profiles[activeProfileIndex]` — a file violating any of
+/// those invariants loads as "Something went wrong" in the browser. Refuse to
+/// write such a file and surface an actionable error instead.
+///
+/// # Errors
+///
+/// Returns an error string describing the first violated invariant.
+fn validate_exportable(data: &ProfileData) -> Result<(), String> {
+    let sample_count: usize = data.thread_stacks.values().map(Vec::len).sum();
+    if sample_count == 0 {
+        return Err("no samples were collected — nothing to export".to_owned());
+    }
+    for (tid, stacks) in &data.thread_stacks {
+        validate_thread(data, *tid, stacks)?;
+    }
+    Ok(())
+}
+
+/// Validate one thread's stacks and weights ([PROFILE-SPEEDSCOPE-VALIDATE]).
+fn validate_thread(data: &ProfileData, tid: u64, stacks: &[Vec<usize>]) -> Result<(), String> {
+    let empty: &[f64] = &[];
+    let weights = data.thread_weights.get(&tid).map_or(empty, Vec::as_slice);
+    if stacks.len() != weights.len() {
+        return Err(format!(
+            "thread {tid}: {} samples but {} weights — counts must match",
+            stacks.len(),
+            weights.len()
+        ));
+    }
+    if let Some(bad) = weights.iter().find(|w| !w.is_finite() || **w < 0.0) {
+        return Err(format!(
+            "thread {tid}: weights must be finite and non-negative, got {bad}"
+        ));
+    }
+    let frame_count = data.frames.len();
+    for stack in stacks {
+        if let Some(idx) = stack.iter().find(|&&idx| idx >= frame_count) {
+            return Err(format!(
+                "thread {tid}: frame index {idx} out of bounds ({frame_count} frames)"
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Export `ProfileData` to speedscope JSON format.
 ///
 /// Writes the file to `output_dir` and returns the path.
 ///
 /// # Errors
 ///
-/// Returns an error string if serialization or file writing fails.
+/// Returns an error string if the data is not viewer-loadable
+/// ([PROFILE-SPEEDSCOPE-VALIDATE]) or serialization/file writing fails.
 pub fn export_speedscope(
     data: &ProfileData,
     session_id: &str,
@@ -88,6 +138,8 @@ pub fn export_speedscope(
     duration_secs: f64,
     output_dir: &Path,
 ) -> Result<ExportResult, String> {
+    validate_exportable(data)?;
+
     let frames: Vec<SpeedscopeFrameRef> = data
         .frames
         .iter()
@@ -160,12 +212,15 @@ pub fn export_speedscope(
 ///
 /// # Errors
 ///
-/// Returns an error string if rendering or file writing fails.
+/// Returns an error string if the data is not viewer-loadable
+/// ([PROFILE-SPEEDSCOPE-VALIDATE]) or rendering/file writing fails.
 pub fn export_flamegraph(
     data: &ProfileData,
     session_id: &str,
     output_dir: &Path,
 ) -> Result<ExportResult, String> {
+    validate_exportable(data)?;
+
     // Build collapsed stacks: "root;caller;leaf count\n"
     let collapsed = build_collapsed_stacks(data);
 
@@ -246,6 +301,88 @@ pub fn export(
             export_speedscope(data, session_id, pid, duration_secs, output_dir)
         }
         ExportFormat::Flamegraph => export_flamegraph(data, session_id, output_dir),
+    }
+}
+
+// ── Stop artifacts ───────────────────────────────────────────────────────────
+
+/// Files written when a profiling session stops ([PROFILE-REQUESTS-STOP]).
+#[derive(Debug, Clone)]
+pub struct StopArtifacts {
+    /// Path of the artifact in the requested format (`None` for `summary`).
+    pub output_file: Option<String>,
+    /// Local self-contained flamegraph SVG — always attempted so every editor
+    /// has a viewer that needs no network access ([PROFILE-FLAMEGRAPH]).
+    pub flamegraph_path: Option<String>,
+    /// V8 `.cpuprofile` for VS Code's built-in viewer ([PROFILE-NATIVE]).
+    pub cpu_profile_path: Option<String>,
+    /// Why any export was skipped — surfaced to the editor so a failed export
+    /// is never silent ([PROFILE-SPEEDSCOPE-VALIDATE]).
+    pub export_error: Option<String>,
+}
+
+/// Export all stop artifacts, collecting errors instead of swallowing them.
+///
+/// `format_str` is the editor-requested format: `"speedscope"` (default),
+/// `"flamegraph"`, or `"summary"` (no format artifact).
+#[must_use]
+pub fn export_stop_artifacts(
+    data: &ProfileData,
+    session_id: &str,
+    duration_secs: f64,
+    sample_rate: u64,
+    format_str: &str,
+    output_dir: &Path,
+) -> StopArtifacts {
+    let mut errors: Vec<String> = Vec::new();
+    let mut record = |err: String| {
+        tracing::error!(err = %err, "profile export failed");
+        if !errors.contains(&err) {
+            errors.push(err);
+        }
+    };
+
+    let output_file = if format_str == "summary" {
+        None
+    } else {
+        let export_format = if format_str == "flamegraph" {
+            ExportFormat::Flamegraph
+        } else {
+            ExportFormat::Speedscope
+        };
+        export(
+            data,
+            export_format,
+            session_id,
+            0,
+            duration_secs,
+            output_dir,
+        )
+        .map(|export_result| export_result.path.display().to_string())
+        .map_err(&mut record)
+        .ok()
+    };
+
+    let flamegraph_path = if format_str == "flamegraph" {
+        output_file.clone()
+    } else {
+        export_flamegraph(data, session_id, output_dir)
+            .map(|export_result| export_result.path.display().to_string())
+            .map_err(&mut record)
+            .ok()
+    };
+
+    let cpu_profile_path =
+        super::cpuprofile::export_cpuprofile(data, session_id, sample_rate, output_dir)
+            .map(|path| path.display().to_string())
+            .map_err(&mut record)
+            .ok();
+
+    StopArtifacts {
+        output_file,
+        flamegraph_path,
+        cpu_profile_path,
+        export_error: (!errors.is_empty()).then(|| errors.join("; ")),
     }
 }
 

--- a/crates/basilisk-lsp/src/server/profiler_handlers.rs
+++ b/crates/basilisk-lsp/src/server/profiler_handlers.rs
@@ -138,43 +138,7 @@ pub(super) async fn execute_profiler_stop(
 
     match server.profiler_manager.stop(session_id).await {
         Ok(result) => {
-            // Export to file.
-            let output_dir = std::env::temp_dir();
-            let export_format = match format_str {
-                "flamegraph" => crate::profiler::export::ExportFormat::Flamegraph,
-                _ => crate::profiler::export::ExportFormat::Speedscope,
-            };
-
-            let output_file = if format_str == "summary" {
-                None
-            } else {
-                match crate::profiler::export::export(
-                    &result.data,
-                    export_format,
-                    &result.session_id,
-                    0, // PID not stored on StopResult, use 0
-                    result.duration,
-                    &output_dir,
-                ) {
-                    Ok(export_result) => Some(export_result.path.display().to_string()),
-                    Err(err) => {
-                        error!(%err, "failed to export profile data");
-                        None
-                    }
-                }
-            };
-
-            // Always export a V8 `.cpuprofile` too, so the editor can open it in
-            // VS Code's built-in profile viewer (flame chart + tables).
-            let cpu_profile_path = crate::profiler::cpuprofile::export_cpuprofile(
-                &result.data,
-                &result.session_id,
-                result.sample_rate,
-                &output_dir,
-            )
-            .map_err(|err| error!(%err, "failed to export cpuprofile"))
-            .ok()
-            .map(|path| path.display().to_string());
+            let artifacts = export_stop_artifacts(&result, format_str);
 
             publish_profiler_diagnostics(server, &result.data, &result.hotspot_config).await;
 
@@ -196,8 +160,10 @@ pub(super) async fn execute_profiler_stop(
                 "sessionId": result.session_id,
                 "duration": result.duration,
                 "totalSamples": result.total_samples,
-                "outputFile": output_file,
-                "cpuProfilePath": cpu_profile_path,
+                "outputFile": artifacts.output_file,
+                "flamegraphPath": artifacts.flamegraph_path,
+                "cpuProfilePath": artifacts.cpu_profile_path,
+                "exportError": artifacts.export_error,
                 "hotFunctions": hot_funcs_json,
                 "hotLines": hot_lines_json,
             })))
@@ -208,6 +174,21 @@ pub(super) async fn execute_profiler_stop(
             Err(profiler_error(code, err.to_string()))
         }
     }
+}
+
+/// Export all stop artifacts to the temp dir ([PROFILE-REQUESTS-STOP]).
+fn export_stop_artifacts(
+    result: &crate::profiler::StopResult,
+    format_str: &str,
+) -> crate::profiler::export::StopArtifacts {
+    crate::profiler::export::export_stop_artifacts(
+        &result.data,
+        &result.session_id,
+        result.duration,
+        result.sample_rate,
+        format_str,
+        &std::env::temp_dir(),
+    )
 }
 
 /// Handle `basilisk.profiler.snapshot` — take a point-in-time snapshot.

--- a/crates/basilisk-lsp/tests/profiler_tests.rs
+++ b/crates/basilisk-lsp/tests/profiler_tests.rs
@@ -511,6 +511,10 @@ fn speedscope_export_produces_valid_json() {
     let weights = profile.get("weights").unwrap().as_array().unwrap();
     assert_eq!(weights.len(), 2, "should have 2 weights");
 
+    // The file must satisfy every speedscope importer invariant, not just
+    // have the right key names.
+    assert_speedscope_loadable(&json);
+
     // Clean up.
     let _ = std::fs::remove_file(&export_result.path);
 }
@@ -530,7 +534,16 @@ fn flamegraph_export_produces_svg() {
     let contents = std::fs::read_to_string(&export_result.path).unwrap();
     assert!(contents.contains("<svg"), "output should be SVG");
     assert!(contents.contains("</svg>"), "SVG should be complete");
-    assert!(contents.len() > 100, "SVG should have substantial content");
+    // A real flamegraph names the profiled functions — a structurally valid
+    // but empty SVG must not pass.
+    assert!(
+        contents.contains("process"),
+        "SVG should contain the 'process' frame"
+    );
+    assert!(
+        contents.contains("parse"),
+        "SVG should contain the 'parse' frame"
+    );
 
     // Clean up.
     let _ = std::fs::remove_file(&export_result.path);
@@ -574,31 +587,314 @@ fn export_dispatches_to_correct_format() {
     let _ = std::fs::remove_file(&fr.path);
 }
 
+// ── Speedscope loadability validation [PROFILE-SPEEDSCOPE-VALIDATE] ──────
+//
+// speedscope.app does not merely parse the JSON — its importer indexes
+// `shared.frames` by every sample entry, reads `profiles[activeProfileIndex]`,
+// and walks parallel `samples`/`weights` arrays. A file that violates any of
+// those invariants loads as "Something went wrong" in the browser. These
+// checks assert what the importer actually requires, not just key presence.
+
+/// Speedscope's allowed `unit` strings (file-format-schema.json).
+const SPEEDSCOPE_UNITS: [&str; 6] = [
+    "bytes",
+    "microseconds",
+    "milliseconds",
+    "nanoseconds",
+    "none",
+    "seconds",
+];
+
+/// Assert one exported speedscope JSON document satisfies every invariant
+/// the speedscope.app importer enforces.
+fn assert_speedscope_loadable(json: &serde_json::Value) {
+    let frames = json["shared"]["frames"]
+        .as_array()
+        .expect("shared.frames must be an array");
+    for (idx, frame) in frames.iter().enumerate() {
+        assert!(
+            frame["name"].as_str().is_some_and(|n| !n.is_empty()),
+            "frame {idx} must have a non-empty name"
+        );
+    }
+
+    let profiles = json["profiles"]
+        .as_array()
+        .expect("profiles must be an array");
+    assert!(
+        !profiles.is_empty(),
+        "profiles must be non-empty — speedscope cannot open a file with no profiles"
+    );
+
+    let active = usize::try_from(
+        json["activeProfileIndex"]
+            .as_u64()
+            .expect("activeProfileIndex must be a number"),
+    )
+    .expect("activeProfileIndex must fit in usize");
+    assert!(
+        active < profiles.len(),
+        "activeProfileIndex {active} out of bounds for {} profiles",
+        profiles.len()
+    );
+
+    for (idx, profile) in profiles.iter().enumerate() {
+        assert_profile_loadable(idx, profile, frames.len());
+    }
+}
+
+/// Assert a single speedscope profile entry is importable.
+fn assert_profile_loadable(idx: usize, profile: &serde_json::Value, frame_count: usize) {
+    assert_eq!(
+        profile["type"].as_str(),
+        Some("sampled"),
+        "profile {idx}: type must be 'sampled'"
+    );
+    let unit = profile["unit"].as_str().unwrap_or_default();
+    assert!(
+        SPEEDSCOPE_UNITS.contains(&unit),
+        "profile {idx}: unit '{unit}' is not a speedscope unit"
+    );
+
+    // serde_json serializes NaN/Infinity as null — as_f64() returning None
+    // catches both missing and non-finite values.
+    let start = profile["startValue"]
+        .as_f64()
+        .expect("startValue must be a finite number");
+    let end = profile["endValue"]
+        .as_f64()
+        .expect("endValue must be a finite number");
+    assert!(
+        start <= end,
+        "profile {idx}: startValue {start} must be <= endValue {end}"
+    );
+
+    let samples = profile["samples"]
+        .as_array()
+        .expect("samples must be an array");
+    let weights = profile["weights"]
+        .as_array()
+        .expect("weights must be an array");
+    assert_eq!(
+        samples.len(),
+        weights.len(),
+        "profile {idx}: samples/weights length mismatch"
+    );
+
+    let mut weight_sum = 0.0_f64;
+    for weight in weights {
+        let w = weight.as_f64().expect("every weight must be finite");
+        assert!(w >= 0.0, "profile {idx}: negative weight {w}");
+        weight_sum += w;
+    }
+    assert!(
+        (weight_sum - (end - start)).abs() <= 1e-9 + weight_sum * 1e-9,
+        "profile {idx}: endValue-startValue {} must equal the weight sum {weight_sum}",
+        end - start
+    );
+
+    for stack in samples {
+        for entry in stack.as_array().expect("each sample must be a stack array") {
+            let frame_idx =
+                usize::try_from(entry.as_u64().expect("frame index must be an integer"))
+                    .expect("frame index must fit in usize");
+            assert!(
+                frame_idx < frame_count,
+                "profile {idx}: frame index {frame_idx} out of bounds ({frame_count} frames)"
+            );
+        }
+    }
+}
+
 #[test]
-fn speedscope_export_with_empty_data() {
-    let data = ProfileData::default();
+fn exported_speedscope_passes_loadability_validation() {
+    let data = make_test_profile_data();
     let dir = std::env::temp_dir();
 
-    let result = export::export_speedscope(&data, "empty-001", 0, 0.0, &dir);
-    assert!(result.is_ok(), "empty data export should succeed");
-
-    let export_result = result.unwrap();
+    let export_result = export::export_speedscope(&data, "loadable-001", 12345, 5.2, &dir)
+        .expect("export should succeed for populated data");
     let contents = std::fs::read_to_string(&export_result.path).unwrap();
     let json: serde_json::Value = serde_json::from_str(&contents).unwrap();
 
-    // Empty data should still produce valid structure.
-    assert!(json.get("$schema").is_some());
-    assert!(json.get("shared").is_some());
-    let frames = json
-        .get("shared")
-        .unwrap()
-        .get("frames")
-        .unwrap()
-        .as_array()
-        .unwrap();
-    assert_eq!(frames.len(), 0, "empty data should have 0 frames");
+    assert_speedscope_loadable(&json);
 
     let _ = std::fs::remove_file(&export_result.path);
+}
+
+#[test]
+fn speedscope_export_with_empty_data() {
+    // A session that captured zero samples must NOT produce a file:
+    // `profiles: []` with `activeProfileIndex: 0` crashes speedscope.app's
+    // importer. The exporter must refuse with an actionable error instead.
+    let data = ProfileData::default();
+    let dir = std::env::temp_dir();
+    let _ = std::fs::remove_file(dir.join("basilisk-empty-001.speedscope.json"));
+
+    let result = export::export_speedscope(&data, "empty-001", 0, 0.0, &dir);
+    let err = result.expect_err("empty-session export must be rejected");
+    assert!(
+        err.contains("no samples"),
+        "error should say no samples were collected, got: {err}"
+    );
+    assert!(
+        !dir.join("basilisk-empty-001.speedscope.json").exists(),
+        "no file may be written for an empty session"
+    );
+}
+
+#[test]
+fn speedscope_export_rejects_non_finite_weights() {
+    // serde_json writes f64::INFINITY/NAN as null, which speedscope cannot
+    // import. The exporter must reject the data instead of writing the file.
+    let mut data = make_test_profile_data();
+    let _ = data.thread_weights.insert(1, vec![0.01, f64::INFINITY]);
+    let dir = std::env::temp_dir();
+
+    let result = export::export_speedscope(&data, "nonfinite-001", 1, 1.0, &dir);
+    let err = result.expect_err("non-finite weights must be rejected");
+    assert!(
+        err.contains("finite"),
+        "error should mention non-finite weights, got: {err}"
+    );
+}
+
+#[test]
+fn speedscope_export_rejects_out_of_bounds_frame_indices() {
+    // Sample stacks index into shared.frames; an out-of-bounds index makes
+    // speedscope's importer throw. The exporter must reject such data.
+    let mut data = make_test_profile_data();
+    let _ = data.thread_stacks.insert(1, vec![vec![0, 1], vec![0, 7]]);
+    let dir = std::env::temp_dir();
+
+    let result = export::export_speedscope(&data, "oob-001", 1, 1.0, &dir);
+    let err = result.expect_err("out-of-bounds frame indices must be rejected");
+    assert!(
+        err.contains("frame index"),
+        "error should mention the bad frame index, got: {err}"
+    );
+}
+
+#[test]
+fn speedscope_export_rejects_sample_weight_length_mismatch() {
+    let mut data = make_test_profile_data();
+    let _ = data.thread_weights.insert(1, vec![0.01]);
+    let dir = std::env::temp_dir();
+
+    let result = export::export_speedscope(&data, "mismatch-001", 1, 1.0, &dir);
+    let err = result.expect_err("samples/weights length mismatch must be rejected");
+    assert!(
+        err.contains("weights"),
+        "error should mention the weights mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn stop_artifacts_surface_export_errors_for_empty_session() {
+    // A stop on a session with zero samples must not silently return null
+    // paths — the editor needs the reason ([PROFILE-REQUESTS-STOP]).
+    let data = ProfileData::default();
+    let dir = std::env::temp_dir();
+
+    let artifacts =
+        export::export_stop_artifacts(&data, "stop-empty-001", 0.0, 100, "speedscope", &dir);
+
+    assert!(
+        artifacts.output_file.is_none(),
+        "no speedscope file for empty session"
+    );
+    assert!(
+        artifacts.flamegraph_path.is_none(),
+        "no flamegraph for empty session"
+    );
+    let err = artifacts
+        .export_error
+        .expect("export failure must be surfaced");
+    assert!(
+        err.contains("no samples"),
+        "exportError should explain that no samples were collected, got: {err}"
+    );
+}
+
+#[test]
+fn stop_artifacts_export_all_formats_for_populated_session() {
+    let data = make_test_profile_data();
+    let dir = std::env::temp_dir();
+
+    let artifacts =
+        export::export_stop_artifacts(&data, "stop-full-001", 5.0, 100, "speedscope", &dir);
+
+    assert!(
+        artifacts.export_error.is_none(),
+        "no errors expected: {:?}",
+        artifacts.export_error
+    );
+
+    let speedscope_path = artifacts
+        .output_file
+        .expect("speedscope file must be written");
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&speedscope_path).unwrap()).unwrap();
+    assert_speedscope_loadable(&json);
+
+    let flamegraph_path = artifacts
+        .flamegraph_path
+        .expect("flamegraph must always be written");
+    let svg = std::fs::read_to_string(&flamegraph_path).unwrap();
+    assert!(
+        svg.contains("<svg") && svg.contains("process"),
+        "flamegraph must render frames"
+    );
+
+    let cpu_path = artifacts
+        .cpu_profile_path
+        .expect("cpuprofile must be written");
+    assert!(
+        std::path::Path::new(&cpu_path).exists(),
+        "cpuprofile file must exist"
+    );
+
+    for path in [speedscope_path, flamegraph_path, cpu_path] {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[test]
+fn stop_artifacts_flamegraph_format_reuses_single_export() {
+    let data = make_test_profile_data();
+    let dir = std::env::temp_dir();
+
+    let artifacts =
+        export::export_stop_artifacts(&data, "stop-fg-001", 5.0, 100, "flamegraph", &dir);
+
+    let output = artifacts
+        .output_file
+        .expect("flamegraph format writes outputFile");
+    let flamegraph = artifacts
+        .flamegraph_path
+        .expect("flamegraphPath must be set");
+    assert_eq!(
+        output, flamegraph,
+        "flamegraph format must not export the SVG twice"
+    );
+
+    let _ = std::fs::remove_file(output);
+    if let Some(cpu) = artifacts.cpu_profile_path {
+        let _ = std::fs::remove_file(cpu);
+    }
+}
+
+#[test]
+fn flamegraph_export_with_empty_data_is_rejected() {
+    // An empty flamegraph SVG renders as a blank page — refuse instead.
+    let data = ProfileData::default();
+    let dir = std::env::temp_dir();
+
+    let result = export::export_flamegraph(&data, "empty-fg-001", &dir);
+    let err = result.expect_err("empty-session flamegraph must be rejected");
+    assert!(
+        err.contains("no samples"),
+        "error should say no samples were collected, got: {err}"
+    );
 }
 
 // ── Memory snapshot parsing tests ────────────────────────────────────────
@@ -1206,6 +1502,8 @@ fn verify_exports(data: &ProfileData, output_dir: &std::path::Path) {
         &std::fs::read_to_string(&speedscope_export.path).expect("read speedscope"),
     )
     .expect("parse speedscope JSON");
+
+    assert_speedscope_loadable(&speedscope_json);
 
     assert!(
         speedscope_json.get("$schema").is_some(),

--- a/docs/specs/LSP-PROFILING-SPEC.md
+++ b/docs/specs/LSP-PROFILING-SPEC.md
@@ -131,7 +131,14 @@ Stop profiling and return results.
 | `sessionId` | `string` | Yes | Session to stop |
 | `format` | `string` | No | `"speedscope"` (default), `"flamegraph"` (SVG), `"summary"` (text) |
 
-**Response fields:** `sessionId`, `duration`, `totalSamples`, `outputFile`, `hotFunctions[]` (name, file, line, samples, percentage, selfPercentage), `hotLines[]` (file, line, samples, percentage).
+**Response fields:** `sessionId`, `duration`, `totalSamples`, `outputFile`, `flamegraphPath`, `cpuProfilePath`, `exportError`, `hotFunctions[]` (name, file, line, samples, percentage, selfPercentage), `hotLines[]` (file, line, samples, percentage).
+
+- `flamegraphPath` — the local self-contained flamegraph SVG, always attempted
+  regardless of `format` so every editor has a viewer that needs no network
+  access ([PROFILE-FLAMEGRAPH]).
+- `exportError` — set when any export was refused or failed
+  ([PROFILE-SPEEDSCOPE-VALIDATE]); a failed export is never silent. Editors
+  must surface it to the user.
 
 #### basilisk/profiler/snapshot {#PROFILE-REQUESTS-SNAPSHOT}
 
@@ -313,6 +320,35 @@ Output conforms to the [speedscope file format schema](https://www.speedscope.ap
 | Frames deduplicated by `(name, filename, line)` | Index into `shared.frames` |
 
 Stacks in speedscope are root-first (callers before callees). py-spy returns leaf-first. Reverse the frame order when building `samples` entries.
+
+### Export Validation {#PROFILE-SPEEDSCOPE-VALIDATE}
+
+speedscope.app's importer indexes `shared.frames` by every sample entry, walks
+parallel `samples`/`weights` arrays, and reads `profiles[activeProfileIndex]`.
+A file violating any of those invariants loads as "Something went wrong" in
+the browser. The exporter therefore **refuses to write** (returns an error
+instead) when:
+
+- the session captured **zero samples** (`profiles: []` with
+  `activeProfileIndex: 0` is unloadable);
+- any weight is **non-finite or negative** (serde serializes NaN/∞ as `null`,
+  which the importer rejects);
+- any sample's **frame index is out of bounds** for `shared.frames`;
+- a thread's `samples` and `weights` **lengths differ**.
+
+The same validation guards the flamegraph SVG export. Tests assert the full
+invariant set on every exported file, not just key presence
+(`profiler_tests.rs::assert_speedscope_loadable`).
+
+### Viewer Delivery {#PROFILE-VIEWER-DELIVERY}
+
+`https://www.speedscope.app/#profileURL=<url>` only works for http(s) URLs the
+browser may fetch from that origin. An https page can **never** read
+`file://` URLs, so editors must never construct a speedscope.app link to a
+local file — it always fails with "Something went wrong". Until profiles are
+served over localhost HTTP with CORS, editors open the local flamegraph SVG
+(`flamegraphPath`) directly and tell the user where the speedscope JSON lives
+for manual import (drag-and-drop at speedscope.app).
 
 ## Flamegraph SVG Export {#PROFILE-FLAMEGRAPH}
 


### PR DESCRIPTION
## Summary

The profiling tests asserted that export commands ran — not that the produced report actually loads in a viewer. A real session could (and did) produce files that speedscope.app rejects with "Something went wrong", and the Neovim viewer flow was structurally incapable of ever working. This PR makes the test suite fail whenever the profile report doesn't work, and fixes everything those new tests caught.

## Bugs the new tests caught (all fixed)

1. **Empty sessions wrote unloadable files**: `profiles: []` with `activeProfileIndex: 0` crashes speedscope's importer. The exporter now refuses with `"no samples were collected — nothing to export"`.
2. **Non-finite weights serialized as `null`** (serde_json writes NaN/∞ as null) — rejected now.
3. **Out-of-bounds frame indices and samples/weights length mismatches** silently produced corrupt files — rejected now.
4. **Export failures were swallowed** (`outputFile: null`, error only in server log). The stop response now carries `exportError`, and `flamegraphPath` is always attempted so every editor has a local viewer ([PROFILE-REQUESTS-STOP]).
5. **Neovim opened `https://www.speedscope.app/#profileURL=file://…`** — an https page can never fetch a `file://` URL, so this *always* failed with "Something went wrong. Check the JS console." Worse, it read `result.speedscopeJson`, a field the LSP never returned, so the path was doubly dead. It now opens the LSP-exported self-contained flamegraph SVG locally and logs the speedscope JSON path for manual import ([PROFILE-VIEWER-DELIVERY]).
6. **The old nvim test enshrined the broken behavior** (`assert opened_url:find("speedscope.app")`). Replaced with tests that assert the local-file contract and explicitly forbid handing speedscope.app local data.

## Test hardening

- `assert_speedscope_loadable` enforces the full importer invariant set on every exported file: non-empty profiles, `activeProfileIndex` in bounds, valid `type`/`unit`, finite `startValue`/`endValue`, samples/weights parity, weight sum == endValue−startValue, every frame index within `shared.frames`. Wired into the good-path tests and the e2e pipeline `verify_exports`.
- Flamegraph SVG tests now require real frame names — a structurally valid but empty SVG no longer passes.
- New artifacts-contract tests: empty session ⇒ no paths + surfaced `exportError`; populated session ⇒ all three artifacts exist and validate; `format: "flamegraph"` ⇒ no double export.

## Spec

`LSP-PROFILING-SPEC.md`: new `[PROFILE-SPEEDSCOPE-VALIDATE]` and `[PROFILE-VIEWER-DELIVERY]` sections; `[PROFILE-REQUESTS-STOP]` response now documents `flamegraphPath` / `exportError`.

## Verification

Bug-fix process followed: 5 new tests written first and confirmed failing for the right reasons, then fixed (tests unchanged). Full `basilisk-lsp` suite green (105+456+68+62+19+…, 0 failures), Neovim suite + coverage (45% ≥ 39%) green, workspace clippy 0 errors, `make lint` (incl. deslop) green, fmt clean.
