### PR TITLE
Kill all 7 surviving mutants: mutation kill rate 93.75% → 100%

### DIFF
--- a/crates/basilisk-checker/tests/mutation_kill_tests.rs
+++ b/crates/basilisk-checker/tests/mutation_kill_tests.rs
@@ -1301,3 +1301,128 @@ def func(int_first: IntFirst, str_first: StrFirst) -> None:
     );
     Ok(())
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// e0002/e0003/e0029 — negative-direction and message-arm mutants
+// (`&&`→`||` in check filters, `is_unresolvable`→true, deleted match arms,
+//  wrong-function `find` in E0029). Smoke tests only assert the positive
+//  direction, so these mutants survived them.
+// ═══════════════════════════════════════════════════════════════════════
+
+#[mutation_safe(rule = "e0002")]
+#[test]
+fn mutant_e0002_annotated_function_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r"
+def fully_annotated(x: int) -> int:
+    return x
+
+def returns_nothing() -> None:
+    pass
+";
+    let diagnostics = run(source)?;
+    assert_eq!(
+        count_code(&diagnostics, "BSK-E0002"),
+        0,
+        "annotated functions must not be flagged: {diagnostics:?}"
+    );
+    Ok(())
+}
+
+#[mutation_safe(rule = "e0003")]
+#[test]
+fn mutant_e0003_resolvable_or_annotated_vars_not_flagged() -> Result<(), Box<dyn std::error::Error>>
+{
+    let source = r"
+annotated_empty: list[int] = []
+annotated_none: int | None = None
+resolvable_int = 5
+resolvable_str = 'text'
+";
+    let diagnostics = run(source)?;
+    assert_eq!(
+        count_code(&diagnostics, "BSK-E0003"),
+        0,
+        "annotated or inferable variables must not be flagged: {diagnostics:?}"
+    );
+    Ok(())
+}
+
+#[mutation_safe(rule = "e0003")]
+#[test]
+fn mutant_e0003_messages_name_the_rhs_kind() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r"
+empty_list = []
+empty_dict = {}
+nothing = None
+";
+    let diagnostics = run(source)?;
+    let messages: Vec<&str> = diagnostics
+        .iter()
+        .filter(|d| d.code.code == "BSK-E0003")
+        .map(|d| d.message.as_str())
+        .collect();
+    assert_eq!(
+        messages.len(),
+        3,
+        "all three vars must be flagged: {messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("empty list `[]`")),
+        "empty-list diagnostic must explain the empty list: {messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("empty dict `{}`")),
+        "empty-dict diagnostic must explain the empty dict: {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("infer type from `None`")),
+        "None diagnostic must explain the None value: {messages:?}"
+    );
+    Ok(())
+}
+
+#[mutation_safe(rule = "e0029")]
+#[test]
+fn mutant_e0029_diagnostic_targets_the_typeddict_method() -> Result<(), Box<dyn std::error::Error>>
+{
+    // `Plain.title` comes first so a loosened function lookup (`&&`→`||`)
+    // resolves the wrong function and points the span at the wrong class.
+    let source = r"
+from typing import TypedDict
+
+class Plain:
+    def title(self) -> str:
+        return 'plain'
+
+class Movie(TypedDict):
+    name: str
+
+    def title(self) -> str:
+        return self['name']
+";
+    let diagnostics = run(source)?;
+    let e0029: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code.code == "BSK-E0029")
+        .collect();
+    assert_eq!(
+        e0029.len(),
+        1,
+        "exactly the TypedDict method is flagged: {e0029:?}"
+    );
+    let only = e0029.first().ok_or("expected one E0029 diagnostic")?;
+    let movie_class_offset = u32::try_from(
+        source
+            .find("class Movie")
+            .ok_or("fixture must contain Movie")?,
+    )?;
+    assert!(
+        only.span.start > movie_class_offset,
+        "diagnostic must point inside `Movie`, not `Plain` (span {} <= class offset {})",
+        only.span.start,
+        movie_class_offset
+    );
+    Ok(())
+}

--- a/mutation_testing/mutants_report.html
+++ b/mutation_testing/mutants_report.html
@@ -62,12 +62,12 @@
 <body>
 <header>
   <h1>Basilisk Mutation Report <span>cargo-mutants v26.0.0</span></h1>
-  <div class="meta">2026-06-11T20:23:17.815117Z → 2026-06-11T20:33:27.083232Z</div>
+  <div class="meta">2026-06-11T21:14:30.924511Z → 2026-06-11T21:30:16.814013Z</div>
 </header>
 
 <div class="stats">
   <div class="stat score good">
-    <div class="val">93.8%</div>
+    <div class="val">100.0%</div>
     <div class="lbl">Mutation Score</div>
   </div>
   <div class="stat">
@@ -75,11 +75,11 @@
     <div class="lbl">Total Mutants</div>
   </div>
   <div class="stat">
-    <div class="val missed">7</div>
+    <div class="val missed">0</div>
     <div class="lbl">Missed</div>
   </div>
   <div class="stat">
-    <div class="val caught">105</div>
+    <div class="val caught">112</div>
     <div class="lbl">Caught</div>
   </div>
   <div class="stat">
@@ -93,259 +93,14 @@
 </div>
 
 <div class="tabs">
-  <div class="tab active" onclick="switchTab('missed')">Missed (7)</div>
-  <div class="tab" onclick="switchTab('caught')">Caught (105)</div>
+  <div class="tab active" onclick="switchTab('missed')">Missed (0)</div>
+  <div class="tab" onclick="switchTab('caught')">Caught (112)</div>
   <div class="tab" onclick="switchTab('other')">Other (5)</div>
 </div>
 
 <div id="tab-missed" class="tab-content active">
   <div class="filter"><input type="text" placeholder="Filter by file, function, replacement…" oninput="filterTable('tab-missed-table', this.value)"></div>
-  
-        <table id='tab-missed-table'>
-          <thead><tr>
-            <th>Status</th><th>Location</th><th>Function</th>
-            <th>Replacement</th><th>Time</th>
-          </tr></thead>
-          <tbody>
-    <tr class='row-missed' onclick="this.classList.toggle('expanded')">
-      <td><span class='status missed'>MISSED</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0002.rs:26:54</td>
-      <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>14.3s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-12')">▶ show diff</div>
-        <pre id='diff-12' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0002.rs
-+++ replace &amp;&amp; with || in &lt;impl Rule for MissingReturnAnnotation&gt;::check
-@@ -18,17 +18,17 @@
- pub(crate) struct MissingReturnAnnotation;
- 
- impl Rule for MissingReturnAnnotation {
-     fn check(&amp;self, module: &amp;ResolvedModule, diagnostics: &amp;mut Vec&lt;Diagnostic&gt;) {
-         module
-             .functions
-             .iter()
-             .filter(|func| {
--                !func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
-+                !func.return_annotation.is_present() || /* ~ changed by cargo-mutants ~ */ !is_stub_context(func, &amp;module.classes)
-             })
-             .for_each(|func| diagnostics.push(make_diagnostic(func, &amp;module.path)));
-     }
- }
- 
- fn make_diagnostic(func: &amp;FunctionInfo, path: &amp;str) -&gt; Diagnostic {
-     error_diagnostic_owned(
-         CODE.clone(),
-</pre></td></tr>
-    <tr class='row-missed' onclick="this.classList.toggle('expanded')">
-      <td><span class='status missed'>MISSED</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:27:47</td>
-      <td><code><impl Rule for MissingVariableType>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>13.2s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-15')">▶ show diff</div>
-        <pre id='diff-15' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
-+++ replace &amp;&amp; with || in &lt;impl Rule for MissingVariableType&gt;::check
-@@ -19,17 +19,17 @@
- /// Emits BSK-E0003 for every unannotated module-level variable.
- pub(crate) struct MissingVariableType;
- 
- impl Rule for MissingVariableType {
-     fn check(&amp;self, module: &amp;ResolvedModule, diagnostics: &amp;mut Vec&lt;Diagnostic&gt;) {
-         module
-             .module_vars
-             .iter()
--            .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
-+            .filter(|var| !var.has_annotation || /* ~ changed by cargo-mutants ~ */ is_unresolvable(&amp;var.rhs_kind))
-             .for_each(|var| diagnostics.push(make_diagnostic(var, &amp;module.path)));
-     }
- }
- 
- /// Returns `true` for RHS kinds whose element/value type cannot be inferred
- /// from the literal alone.
- fn is_unresolvable(rhs: &amp;RhsKind) -&gt; bool {
-     matches!(
-</pre></td></tr>
-    <tr class='row-missed' onclick="this.classList.toggle('expanded')">
-      <td><span class='status missed'>MISSED</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:35:5</td>
-      <td><code>is_unresolvable</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>true</code></td>
-      <td class='dur'>14.2s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-18')">▶ show diff</div>
-        <pre id='diff-18' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
-+++ replace is_unresolvable -&gt; bool with true
-@@ -27,20 +27,17 @@
-             .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
-             .for_each(|var| diagnostics.push(make_diagnostic(var, &amp;module.path)));
-     }
- }
- 
- /// Returns `true` for RHS kinds whose element/value type cannot be inferred
- /// from the literal alone.
- fn is_unresolvable(rhs: &amp;RhsKind) -&gt; bool {
--    matches!(
--        rhs,
--        RhsKind::EmptyList | RhsKind::EmptyDict | RhsKind::NoneValue
--    )
-+    true /* ~ changed by cargo-mutants ~ */
- }
- 
- fn make_diagnostic(var: &amp;VariableInfo, path: &amp;str) -&gt; Diagnostic {
-     let (message, help) = match &amp;var.rhs_kind {
-         RhsKind::EmptyList =&gt; (
-             format!(
-                 &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
-                 var.name
-</pre></td></tr>
-    <tr class='row-missed' onclick="this.classList.toggle('expanded')">
-      <td><span class='status missed'>MISSED</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:43:9</td>
-      <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>13.2s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-20')">▶ show diff</div>
-        <pre id='diff-20' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
-+++ delete match arm RhsKind::EmptyList in make_diagnostic
-@@ -35,23 +35,17 @@
-     matches!(
-         rhs,
-         RhsKind::EmptyList | RhsKind::EmptyDict | RhsKind::NoneValue
-     )
- }
- 
- fn make_diagnostic(var: &amp;VariableInfo, path: &amp;str) -&gt; Diagnostic {
-     let (message, help) = match &amp;var.rhs_kind {
--        RhsKind::EmptyList =&gt; (
--            format!(
--                &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
--                var.name
--            ),
--            format!(&quot;{}: list[&lt;type&gt;] = []&quot;, var.name),
--        ),
-+         /* ~ changed by cargo-mutants ~ */
-         RhsKind::EmptyDict =&gt; (
-             format!(
-                 &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
-                 var.name
-             ),
-             format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
-         ),
-         RhsKind::NoneValue =&gt; (
-</pre></td></tr>
-    <tr class='row-missed' onclick="this.classList.toggle('expanded')">
-      <td><span class='status missed'>MISSED</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:50:9</td>
-      <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>12.3s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-21')">▶ show diff</div>
-        <pre id='diff-21' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
-+++ delete match arm RhsKind::EmptyDict in make_diagnostic
-@@ -42,23 +42,17 @@
-     let (message, help) = match &amp;var.rhs_kind {
-         RhsKind::EmptyList =&gt; (
-             format!(
-                 &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
-                 var.name
-             ),
-             format!(&quot;{}: list[&lt;type&gt;] = []&quot;, var.name),
-         ),
--        RhsKind::EmptyDict =&gt; (
--            format!(
--                &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
--                var.name
--            ),
--            format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
--        ),
-+         /* ~ changed by cargo-mutants ~ */
-         RhsKind::NoneValue =&gt; (
-             format!(
-                 &quot;Missing type annotation for `{}` — cannot infer type from `None`&quot;,
-                 var.name
-             ),
-             format!(&quot;{}: &lt;type&gt; | None = None&quot;, var.name),
-         ),
-         _ =&gt; (
-</pre></td></tr>
-    <tr class='row-missed' onclick="this.classList.toggle('expanded')">
-      <td><span class='status missed'>MISSED</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:57:9</td>
-      <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>13.6s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-22')">▶ show diff</div>
-        <pre id='diff-22' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
-+++ delete match arm RhsKind::NoneValue in make_diagnostic
-@@ -49,23 +49,17 @@
-         ),
-         RhsKind::EmptyDict =&gt; (
-             format!(
-                 &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
-                 var.name
-             ),
-             format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
-         ),
--        RhsKind::NoneValue =&gt; (
--            format!(
--                &quot;Missing type annotation for `{}` — cannot infer type from `None`&quot;,
--                var.name
--            ),
--            format!(&quot;{}: &lt;type&gt; | None = None&quot;, var.name),
--        ),
-+         /* ~ changed by cargo-mutants ~ */
-         _ =&gt; (
-             format!(
-                 &quot;Missing type annotation for module-level variable `{}`&quot;,
-                 var.name
-             ),
-             format!(&quot;{}: &lt;type&gt; = ...&quot;, var.name),
-         ),
-     };
-</pre></td></tr>
-    <tr class='row-missed' onclick="this.classList.toggle('expanded')">
-      <td><span class='status missed'>MISSED</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0029.rs:33:66</td>
-      <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>17.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-42')">▶ show diff</div>
-        <pre id='diff-42' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0029.rs
-+++ replace &amp;&amp; with || in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
-@@ -25,17 +25,17 @@
-                 // __init_subclass__ and __class_getitem__ are synthesised; skip them.
-                 if matches!(
-                     method_name.as_str(),
-                     &quot;__init_subclass__&quot; | &quot;__class_getitem__&quot;
-                 ) {
-                     continue;
-                 }
-                 let func = module.functions.iter().find(|f| {
--                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
-+                    f.class_name.as_deref() == Some(&amp;class.name) || /* ~ changed by cargo-mutants ~ */ &amp;f.name == method_name
-                 });
-                 if let Some(f) = func {
-                     diagnostics.push(error_diagnostic_owned(
-                         CODE.clone(),
-                         format!(
-                             &quot;Method `{}` is not allowed in TypedDict class `{}`&quot;,
-                             method_name, class.name
-                         ),
-</pre></td></tr></tbody>
-        </table>
+  <p class='empty'>None.</p>
 </div>
 <div id="tab-caught" class="tab-content">
   <div class="filter"><input type="text" placeholder="Filter by file, function, replacement…" oninput="filterTable('tab-caught-table', this.value)"></div>
@@ -361,7 +116,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:23:9</td>
       <td><code><impl Rule for MissingParameterAnnotation>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>35.8s</td>
+      <td class='dur'>43.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-0')">▶ show diff</div>
@@ -396,7 +151,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:26:28</td>
       <td><code><impl Rule for MissingParameterAnnotation>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>43.0s</td>
+      <td class='dur'>46.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-1')">▶ show diff</div>
@@ -427,7 +182,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:34:59</td>
       <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>46.2s</td>
+      <td class='dur'>47.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-2')">▶ show diff</div>
@@ -455,76 +210,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:34:39</td>
-      <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>12.2s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:32:5</td>
+      <td><code>check_function</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>48.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-3')">▶ show diff</div>
         <pre id='diff-3' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0001.rs
-+++ replace &amp;&amp; with || in check_function
-@@ -26,17 +26,17 @@
-             .filter(|func| !is_stub_context(func, &amp;module.classes))
-             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-     }
- }
- 
- fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
-     func.parameters
-         .iter()
--        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-+        .filter(|p| !p.has_annotation || /* ~ changed by cargo-mutants ~ */ p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-         .for_each(|p| out.push(make_diagnostic(p, path)));
- }
- 
- fn make_diagnostic(param: &amp;ParameterInfo, path: &amp;str) -&gt; Diagnostic {
-     error_diagnostic_owned(
-         CODE.clone(),
-         format!(&quot;Missing parameter type annotation for `{}`&quot;, param.name),
-         param.name_span,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:34:21</td>
-      <td><code>check_function</code>  <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>9.6s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-4')">▶ show diff</div>
-        <pre id='diff-4' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0001.rs
-+++ delete ! in check_function
-@@ -26,17 +26,17 @@
-             .filter(|func| !is_stub_context(func, &amp;module.classes))
-             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-     }
- }
- 
- fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
-     func.parameters
-         .iter()
--        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-+        .filter(|p|  /* ~ changed by cargo-mutants ~ */p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-         .for_each(|p| out.push(make_diagnostic(p, path)));
- }
- 
- fn make_diagnostic(param: &amp;ParameterInfo, path: &amp;str) -&gt; Diagnostic {
-     error_diagnostic_owned(
-         CODE.clone(),
-         format!(&quot;Missing parameter type annotation for `{}`&quot;, param.name),
-         param.name_span,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:32:5</td>
-      <td><code>check_function</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>53.0s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-5')">▶ show diff</div>
-        <pre id='diff-5' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0001.rs
 +++ replace check_function with ()
 @@ -24,20 +24,17 @@
              .functions
@@ -551,14 +244,76 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:34:49</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:34:39</td>
       <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>8.8s</td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>9.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-4')">▶ show diff</div>
+        <pre id='diff-4' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0001.rs
++++ replace &amp;&amp; with || in check_function
+@@ -26,17 +26,17 @@
+             .filter(|func| !is_stub_context(func, &amp;module.classes))
+             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
+     }
+ }
+ 
+ fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
+     func.parameters
+         .iter()
+-        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
++        .filter(|p| !p.has_annotation || /* ~ changed by cargo-mutants ~ */ p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
+         .for_each(|p| out.push(make_diagnostic(p, path)));
+ }
+ 
+ fn make_diagnostic(param: &amp;ParameterInfo, path: &amp;str) -&gt; Diagnostic {
+     error_diagnostic_owned(
+         CODE.clone(),
+         format!(&quot;Missing parameter type annotation for `{}`&quot;, param.name),
+         param.name_span,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:34:21</td>
+      <td><code>check_function</code>  <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>13.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-6')">▶ show diff</div>
         <pre id='diff-6' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0001.rs
++++ delete ! in check_function
+@@ -26,17 +26,17 @@
+             .filter(|func| !is_stub_context(func, &amp;module.classes))
+             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
+     }
+ }
+ 
+ fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
+     func.parameters
+         .iter()
+-        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
++        .filter(|p|  /* ~ changed by cargo-mutants ~ */p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
+         .for_each(|p| out.push(make_diagnostic(p, path)));
+ }
+ 
+ fn make_diagnostic(param: &amp;ParameterInfo, path: &amp;str) -&gt; Diagnostic {
+     error_diagnostic_owned(
+         CODE.clone(),
+         format!(&quot;Missing parameter type annotation for `{}`&quot;, param.name),
+         param.name_span,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:34:49</td>
+      <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>16.3s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-7')">▶ show diff</div>
+        <pre id='diff-7' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0001.rs
 +++ replace != with == in check_function
 @@ -26,17 +26,17 @@
              .filter(|func| !is_stub_context(func, &amp;module.classes))
@@ -585,7 +340,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:34:69</td>
       <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>9.5s</td>
+      <td class='dur'>16.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-8')">▶ show diff</div>
@@ -613,45 +368,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0002.rs:26:17</td>
-      <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>10.9s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0002.rs:22:9</td>
+      <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>16.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-9')">▶ show diff</div>
         <pre id='diff-9' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0002.rs
-+++ delete ! in &lt;impl Rule for MissingReturnAnnotation&gt;::check
-@@ -18,17 +18,17 @@
- pub(crate) struct MissingReturnAnnotation;
- 
- impl Rule for MissingReturnAnnotation {
-     fn check(&amp;self, module: &amp;ResolvedModule, diagnostics: &amp;mut Vec&lt;Diagnostic&gt;) {
-         module
-             .functions
-             .iter()
-             .filter(|func| {
--                !func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
-+                 /* ~ changed by cargo-mutants ~ */func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
-             })
-             .for_each(|func| diagnostics.push(make_diagnostic(func, &amp;module.path)));
-     }
- }
- 
- fn make_diagnostic(func: &amp;FunctionInfo, path: &amp;str) -&gt; Diagnostic {
-     error_diagnostic_owned(
-         CODE.clone(),
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0002.rs:22:9</td>
-      <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>15.4s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-11')">▶ show diff</div>
-        <pre id='diff-11' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0002.rs
 +++ replace &lt;impl Rule for MissingReturnAnnotation&gt;::check with ()
 @@ -14,23 +14,17 @@
  
@@ -681,10 +405,72 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0002.rs:26:54</td>
+      <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>15.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-10')">▶ show diff</div>
+        <pre id='diff-10' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0002.rs
++++ replace &amp;&amp; with || in &lt;impl Rule for MissingReturnAnnotation&gt;::check
+@@ -18,17 +18,17 @@
+ pub(crate) struct MissingReturnAnnotation;
+ 
+ impl Rule for MissingReturnAnnotation {
+     fn check(&amp;self, module: &amp;ResolvedModule, diagnostics: &amp;mut Vec&lt;Diagnostic&gt;) {
+         module
+             .functions
+             .iter()
+             .filter(|func| {
+-                !func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
++                !func.return_annotation.is_present() || /* ~ changed by cargo-mutants ~ */ !is_stub_context(func, &amp;module.classes)
+             })
+             .for_each(|func| diagnostics.push(make_diagnostic(func, &amp;module.path)));
+     }
+ }
+ 
+ fn make_diagnostic(func: &amp;FunctionInfo, path: &amp;str) -&gt; Diagnostic {
+     error_diagnostic_owned(
+         CODE.clone(),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0002.rs:26:17</td>
+      <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>20.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-12')">▶ show diff</div>
+        <pre id='diff-12' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0002.rs
++++ delete ! in &lt;impl Rule for MissingReturnAnnotation&gt;::check
+@@ -18,17 +18,17 @@
+ pub(crate) struct MissingReturnAnnotation;
+ 
+ impl Rule for MissingReturnAnnotation {
+     fn check(&amp;self, module: &amp;ResolvedModule, diagnostics: &amp;mut Vec&lt;Diagnostic&gt;) {
+         module
+             .functions
+             .iter()
+             .filter(|func| {
+-                !func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
++                 /* ~ changed by cargo-mutants ~ */func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
+             })
+             .for_each(|func| diagnostics.push(make_diagnostic(func, &amp;module.path)));
+     }
+ }
+ 
+ fn make_diagnostic(func: &amp;FunctionInfo, path: &amp;str) -&gt; Diagnostic {
+     error_diagnostic_owned(
+         CODE.clone(),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0002.rs:26:57</td>
       <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>12.6s</td>
+      <td class='dur'>20.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-13')">▶ show diff</div>
@@ -715,7 +501,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:24:9</td>
       <td><code><impl Rule for MissingVariableType>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>8.8s</td>
+      <td class='dur'>18.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-14')">▶ show diff</div>
@@ -747,10 +533,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:27:47</td>
+      <td><code><impl Rule for MissingVariableType>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>20.0s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-15')">▶ show diff</div>
+        <pre id='diff-15' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
++++ replace &amp;&amp; with || in &lt;impl Rule for MissingVariableType&gt;::check
+@@ -19,17 +19,17 @@
+ /// Emits BSK-E0003 for every unannotated module-level variable.
+ pub(crate) struct MissingVariableType;
+ 
+ impl Rule for MissingVariableType {
+     fn check(&amp;self, module: &amp;ResolvedModule, diagnostics: &amp;mut Vec&lt;Diagnostic&gt;) {
+         module
+             .module_vars
+             .iter()
+-            .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
++            .filter(|var| !var.has_annotation || /* ~ changed by cargo-mutants ~ */ is_unresolvable(&amp;var.rhs_kind))
+             .for_each(|var| diagnostics.push(make_diagnostic(var, &amp;module.path)));
+     }
+ }
+ 
+ /// Returns `true` for RHS kinds whose element/value type cannot be inferred
+ /// from the literal alone.
+ fn is_unresolvable(rhs: &amp;RhsKind) -&gt; bool {
+     matches!(
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:27:27</td>
       <td><code><impl Rule for MissingVariableType>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>13.2s</td>
+      <td class='dur'>21.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-16')">▶ show diff</div>
@@ -780,8 +597,42 @@
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:35:5</td>
       <td><code>is_unresolvable</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>true</code></td>
+      <td class='dur'>22.3s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-17')">▶ show diff</div>
+        <pre id='diff-17' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
++++ replace is_unresolvable -&gt; bool with true
+@@ -27,20 +27,17 @@
+             .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
+             .for_each(|var| diagnostics.push(make_diagnostic(var, &amp;module.path)));
+     }
+ }
+ 
+ /// Returns `true` for RHS kinds whose element/value type cannot be inferred
+ /// from the literal alone.
+ fn is_unresolvable(rhs: &amp;RhsKind) -&gt; bool {
+-    matches!(
+-        rhs,
+-        RhsKind::EmptyList | RhsKind::EmptyDict | RhsKind::NoneValue
+-    )
++    true /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ fn make_diagnostic(var: &amp;VariableInfo, path: &amp;str) -&gt; Diagnostic {
+     let (message, help) = match &amp;var.rhs_kind {
+         RhsKind::EmptyList =&gt; (
+             format!(
+                 &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
+                 var.name
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:35:5</td>
+      <td><code>is_unresolvable</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>false</code></td>
-      <td class='dur'>13.1s</td>
+      <td class='dur'>18.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-19')">▶ show diff</div>
@@ -812,10 +663,121 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:57:9</td>
+      <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>13.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-20')">▶ show diff</div>
+        <pre id='diff-20' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
++++ delete match arm RhsKind::NoneValue in make_diagnostic
+@@ -49,23 +49,17 @@
+         ),
+         RhsKind::EmptyDict =&gt; (
+             format!(
+                 &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
+                 var.name
+             ),
+             format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
+         ),
+-        RhsKind::NoneValue =&gt; (
+-            format!(
+-                &quot;Missing type annotation for `{}` — cannot infer type from `None`&quot;,
+-                var.name
+-            ),
+-            format!(&quot;{}: &lt;type&gt; | None = None&quot;, var.name),
+-        ),
++         /* ~ changed by cargo-mutants ~ */
+         _ =&gt; (
+             format!(
+                 &quot;Missing type annotation for module-level variable `{}`&quot;,
+                 var.name
+             ),
+             format!(&quot;{}: &lt;type&gt; = ...&quot;, var.name),
+         ),
+     };
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:43:9</td>
+      <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>22.5s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-21')">▶ show diff</div>
+        <pre id='diff-21' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
++++ delete match arm RhsKind::EmptyList in make_diagnostic
+@@ -35,23 +35,17 @@
+     matches!(
+         rhs,
+         RhsKind::EmptyList | RhsKind::EmptyDict | RhsKind::NoneValue
+     )
+ }
+ 
+ fn make_diagnostic(var: &amp;VariableInfo, path: &amp;str) -&gt; Diagnostic {
+     let (message, help) = match &amp;var.rhs_kind {
+-        RhsKind::EmptyList =&gt; (
+-            format!(
+-                &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
+-                var.name
+-            ),
+-            format!(&quot;{}: list[&lt;type&gt;] = []&quot;, var.name),
+-        ),
++         /* ~ changed by cargo-mutants ~ */
+         RhsKind::EmptyDict =&gt; (
+             format!(
+                 &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
+                 var.name
+             ),
+             format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
+         ),
+         RhsKind::NoneValue =&gt; (
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:50:9</td>
+      <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>27.5s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-22')">▶ show diff</div>
+        <pre id='diff-22' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
++++ delete match arm RhsKind::EmptyDict in make_diagnostic
+@@ -42,23 +42,17 @@
+     let (message, help) = match &amp;var.rhs_kind {
+         RhsKind::EmptyList =&gt; (
+             format!(
+                 &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
+                 var.name
+             ),
+             format!(&quot;{}: list[&lt;type&gt;] = []&quot;, var.name),
+         ),
+-        RhsKind::EmptyDict =&gt; (
+-            format!(
+-                &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
+-                var.name
+-            ),
+-            format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
+-        ),
++         /* ~ changed by cargo-mutants ~ */
+         RhsKind::NoneValue =&gt; (
+             format!(
+                 &quot;Missing type annotation for `{}` — cannot infer type from `None`&quot;,
+                 var.name
+             ),
+             format!(&quot;{}: &lt;type&gt; | None = None&quot;, var.name),
+         ),
+         _ =&gt; (
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:212:5</td>
       <td><code>check_vars</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>13.8s</td>
+      <td class='dur'>24.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-23')">▶ show diff</div>
@@ -975,7 +937,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:219:49</td>
       <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>13.5s</td>
+      <td class='dur'>23.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-24')">▶ show diff</div>
@@ -1006,7 +968,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:246:21</td>
       <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>14.8s</td>
+      <td class='dur'>20.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-25')">▶ show diff</div>
@@ -1037,7 +999,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:245:21</td>
       <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>14.8s</td>
+      <td class='dur'>28.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-26')">▶ show diff</div>
@@ -1068,7 +1030,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:244:30</td>
       <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>18.5s</td>
+      <td class='dur'>28.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-27')">▶ show diff</div>
@@ -1099,7 +1061,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:297:20</td>
       <td><code>check_vars</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>14.3s</td>
+      <td class='dur'>23.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-28')">▶ show diff</div>
@@ -1130,7 +1092,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:481:5</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>None</code></td>
-      <td class='dur'>14.6s</td>
+      <td class='dur'>25.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-29')">▶ show diff</div>
@@ -1181,64 +1143,12 @@
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:481:5</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>Some(&quot;&quot;)</code></td>
-      <td class='dur'>16.0s</td>
+      <td><code class='replacement'>Some(&quot;xyzzy&quot;)</code></td>
+      <td class='dur'>24.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-30')">▶ show diff</div>
         <pre id='diff-30' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0014/mod.rs
-+++ replace extract_annotation -&gt; Option&lt;&amp;str&gt; with Some(&quot;&quot;)
-@@ -473,38 +473,10 @@
- 
- /// Extract the annotation text from the source line containing `name_span`.
- ///
- /// Looks for `: &lt;annotation&gt;` on the same source line as the variable name,
- /// stopping at the `=` sign that introduces the RHS.  Returns `None` if no
- /// such pattern is found.
- pub(super) fn extract_annotation(source: &amp;str, name_span: Span) -&gt; Option&lt;&amp;str&gt; {
-     // Find the byte offset of the start of the line containing the name.
--    let start = usize::try_from(name_span.start).ok()?;
--    let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos + 1);
--    let line_end = source
--        .get(start..)?
--        .find('\n')
--        .map_or(source.len(), |pos| start + pos);
--
--    let line = source.get(line_start..line_end)?;
--
--    // Position of the name within the line.
--    let name_offset = start.checked_sub(line_start)?;
--
--    // Find `: ` after the name position on this line.
--    let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
--    let after_colon = colon_pos + 2; // skip ': '
--
--    // Find `=` that ends the annotation (must be after the colon).
--    let annotation_end = line
--        .get(after_colon..)?
--        .find('=')
--        .map_or(line.len(), |p| after_colon + p);
--
--    let annotation = line.get(after_colon..annotation_end)?.trim();
--
--    if annotation.is_empty() {
--        None
--    } else {
--        Some(annotation)
--    }
-+    Some(&quot;&quot;) /* ~ changed by cargo-mutants ~ */
- }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:481:5</td>
-      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>Some(&quot;xyzzy&quot;)</code></td>
-      <td class='dur'>13.4s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-31')">▶ show diff</div>
-        <pre id='diff-31' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0014/mod.rs
 +++ replace extract_annotation -&gt; Option&lt;&amp;str&gt; with Some(&quot;xyzzy&quot;)
 @@ -473,38 +473,10 @@
  
@@ -1283,10 +1193,62 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:481:5</td>
+      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>Some(&quot;&quot;)</code></td>
+      <td class='dur'>27.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-31')">▶ show diff</div>
+        <pre id='diff-31' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0014/mod.rs
++++ replace extract_annotation -&gt; Option&lt;&amp;str&gt; with Some(&quot;&quot;)
+@@ -473,38 +473,10 @@
+ 
+ /// Extract the annotation text from the source line containing `name_span`.
+ ///
+ /// Looks for `: &lt;annotation&gt;` on the same source line as the variable name,
+ /// stopping at the `=` sign that introduces the RHS.  Returns `None` if no
+ /// such pattern is found.
+ pub(super) fn extract_annotation(source: &amp;str, name_span: Span) -&gt; Option&lt;&amp;str&gt; {
+     // Find the byte offset of the start of the line containing the name.
+-    let start = usize::try_from(name_span.start).ok()?;
+-    let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos + 1);
+-    let line_end = source
+-        .get(start..)?
+-        .find('\n')
+-        .map_or(source.len(), |pos| start + pos);
+-
+-    let line = source.get(line_start..line_end)?;
+-
+-    // Position of the name within the line.
+-    let name_offset = start.checked_sub(line_start)?;
+-
+-    // Find `: ` after the name position on this line.
+-    let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
+-    let after_colon = colon_pos + 2; // skip ': '
+-
+-    // Find `=` that ends the annotation (must be after the colon).
+-    let annotation_end = line
+-        .get(after_colon..)?
+-        .find('=')
+-        .map_or(line.len(), |p| after_colon + p);
+-
+-    let annotation = line.get(after_colon..annotation_end)?.trim();
+-
+-    if annotation.is_empty() {
+-        None
+-    } else {
+-        Some(annotation)
+-    }
++    Some(&quot;&quot;) /* ~ changed by cargo-mutants ~ */
+ }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:482:75</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>15.7s</td>
+      <td class='dur'>26.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-32')">▶ show diff</div>
@@ -1317,7 +1279,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:486:43</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>17.1s</td>
+      <td class='dur'>27.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-33')">▶ show diff</div>
@@ -1348,7 +1310,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:494:58</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>15.1s</td>
+      <td class='dur'>28.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-34')">▶ show diff</div>
@@ -1379,7 +1341,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:495:33</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>15.1s</td>
+      <td class='dur'>28.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-35')">▶ show diff</div>
@@ -1410,7 +1372,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/mod.rs:501:45</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>12.6s</td>
+      <td class='dur'>27.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-36')">▶ show diff</div>
@@ -1441,7 +1403,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0023.rs:25:9</td>
       <td><code><impl Rule for NonExhaustiveMatch>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>16.4s</td>
+      <td class='dur'>26.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-38')">▶ show diff</div>
@@ -1476,7 +1438,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0023.rs:28:28</td>
       <td><code><impl Rule for NonExhaustiveMatch>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>17.7s</td>
+      <td class='dur'>28.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-39')">▶ show diff</div>
@@ -1507,7 +1469,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0027.rs:23:9</td>
       <td><code><impl Rule for DuplicateTypeVarInGeneric>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>14.6s</td>
+      <td class='dur'>28.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-40')">▶ show diff</div>
@@ -1557,7 +1519,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0029.rs:23:9</td>
       <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>14.2s</td>
+      <td class='dur'>30.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-41')">▶ show diff</div>
@@ -1608,15 +1570,15 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0029.rs:33:45</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0029.rs:33:66</td>
       <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>!=</code></td>
-      <td class='dur'>15.6s</td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>30.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-43')">▶ show diff</div>
-        <pre id='diff-43' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0029.rs
-+++ replace == with != in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
+        <div class='diff-toggle' onclick="toggle('diff-42')">▶ show diff</div>
+        <pre id='diff-42' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0029.rs
++++ replace &amp;&amp; with || in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
 @@ -25,17 +25,17 @@
                  // __init_subclass__ and __class_getitem__ are synthesised; skip them.
                  if matches!(
@@ -1627,7 +1589,7 @@
                  }
                  let func = module.functions.iter().find(|f| {
 -                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
-+                    f.class_name.as_deref() != /* ~ changed by cargo-mutants ~ */ Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
++                    f.class_name.as_deref() == Some(&amp;class.name) || /* ~ changed by cargo-mutants ~ */ &amp;f.name == method_name
                  });
                  if let Some(f) = func {
                      diagnostics.push(error_diagnostic_owned(
@@ -1642,11 +1604,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0029.rs:33:77</td>
       <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>15.5s</td>
+      <td class='dur'>25.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-45')">▶ show diff</div>
-        <pre id='diff-45' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0029.rs
+        <div class='diff-toggle' onclick="toggle('diff-43')">▶ show diff</div>
+        <pre id='diff-43' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0029.rs
 +++ replace == with != in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
 @@ -25,17 +25,17 @@
                  // __init_subclass__ and __class_getitem__ are synthesised; skip them.
@@ -1670,10 +1632,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0029.rs:33:45</td>
+      <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>!=</code></td>
+      <td class='dur'>30.5s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-44')">▶ show diff</div>
+        <pre id='diff-44' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0029.rs
++++ replace == with != in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
+@@ -25,17 +25,17 @@
+                 // __init_subclass__ and __class_getitem__ are synthesised; skip them.
+                 if matches!(
+                     method_name.as_str(),
+                     &quot;__init_subclass__&quot; | &quot;__class_getitem__&quot;
+                 ) {
+                     continue;
+                 }
+                 let func = module.functions.iter().find(|f| {
+-                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
++                    f.class_name.as_deref() != /* ~ changed by cargo-mutants ~ */ Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
+                 });
+                 if let Some(f) = func {
+                     diagnostics.push(error_diagnostic_owned(
+                         CODE.clone(),
+                         format!(
+                             &quot;Method `{}` is not allowed in TypedDict class `{}`&quot;,
+                             method_name, class.name
+                         ),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0033.rs:25:9</td>
       <td><code><impl Rule for InvalidRevealTypeCall>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>15.4s</td>
+      <td class='dur'>35.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-46')">▶ show diff</div>
@@ -1713,7 +1706,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0033.rs:25:76</td>
       <td><code><impl Rule for InvalidRevealTypeCall>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>14.5s</td>
+      <td class='dur'>35.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-47')">▶ show diff</div>
@@ -1744,7 +1737,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:90:5</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>None</code></td>
-      <td class='dur'>12.4s</td>
+      <td class='dur'>41.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-48')">▶ show diff</div>
@@ -1786,7 +1779,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:90:5</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Some(&quot;&quot;)</code></td>
-      <td class='dur'>13.6s</td>
+      <td class='dur'>29.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-49')">▶ show diff</div>
@@ -1825,14 +1818,45 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:90:5</td>
-      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>Some(&quot;xyzzy&quot;)</code></td>
-      <td class='dur'>20.3s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:90:23</td>
+      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>37.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-50')">▶ show diff</div>
         <pre id='diff-50' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
++++ replace &amp;&amp; with || in redeclaration_violation
+@@ -82,17 +82,17 @@
+ 
+ /// Returns the reason a child redeclaration of an inherited `base` field is
+ /// illegal under the typing spec / PEP 705, or `None` when it is allowed.
+ fn redeclaration_violation(
+     base: &amp;FieldQualifiers&lt;'_&gt;,
+     child: &amp;FieldQualifiers&lt;'_&gt;,
+ ) -&gt; Option&lt;&amp;'static str&gt; {
+     // A writable item may not be redeclared as ReadOnly.
+-    if !base.readonly &amp;&amp; child.readonly {
++    if !base.readonly || /* ~ changed by cargo-mutants ~ */ child.readonly {
+         return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
+     }
+     // A required item may not be redeclared as not-required.
+     if base.required &amp;&amp; !child.required {
+         return Some(&quot;a required item may not be redeclared as not-required&quot;);
+     }
+     // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
+     if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:90:5</td>
+      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>Some(&quot;xyzzy&quot;)</code></td>
+      <td class='dur'>41.6s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-51')">▶ show diff</div>
+        <pre id='diff-51' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
 +++ replace redeclaration_violation -&gt; Option&lt;&amp;'static str&gt; with Some(&quot;xyzzy&quot;)
 @@ -82,28 +82,17 @@
  
@@ -1867,41 +1891,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:90:23</td>
-      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>19.6s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-51')">▶ show diff</div>
-        <pre id='diff-51' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
-+++ replace &amp;&amp; with || in redeclaration_violation
-@@ -82,17 +82,17 @@
- 
- /// Returns the reason a child redeclaration of an inherited `base` field is
- /// illegal under the typing spec / PEP 705, or `None` when it is allowed.
- fn redeclaration_violation(
-     base: &amp;FieldQualifiers&lt;'_&gt;,
-     child: &amp;FieldQualifiers&lt;'_&gt;,
- ) -&gt; Option&lt;&amp;'static str&gt; {
-     // A writable item may not be redeclared as ReadOnly.
--    if !base.readonly &amp;&amp; child.readonly {
-+    if !base.readonly || /* ~ changed by cargo-mutants ~ */ child.readonly {
-         return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
-     }
-     // A required item may not be redeclared as not-required.
-     if base.required &amp;&amp; !child.required {
-         return Some(&quot;a required item may not be redeclared as not-required&quot;);
-     }
-     // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
-     if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:90:8</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>20.1s</td>
+      <td class='dur'>42.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-52')">▶ show diff</div>
@@ -1932,7 +1925,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:94:22</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>18.1s</td>
+      <td class='dur'>42.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-53')">▶ show diff</div>
@@ -1963,7 +1956,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:94:25</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>14.2s</td>
+      <td class='dur'>32.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-54')">▶ show diff</div>
@@ -1994,7 +1987,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:98:32</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>13.8s</td>
+      <td class='dur'>31.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-55')">▶ show diff</div>
@@ -2025,7 +2018,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:98:18</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>16.5s</td>
+      <td class='dur'>23.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-56')">▶ show diff</div>
@@ -2056,7 +2049,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:110:5</td>
       <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>true</code></td>
-      <td class='dur'>18.3s</td>
+      <td class='dur'>30.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-57')">▶ show diff</div>
@@ -2087,14 +2080,45 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:110:5</td>
-      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>false</code></td>
-      <td class='dur'>15.4s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:110:8</td>
+      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>33.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-58')">▶ show diff</div>
         <pre id='diff-58' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
++++ delete ! in value_type_incompatible
+@@ -102,17 +102,17 @@
+ }
+ 
+ /// Decide whether a changed value type is incompatible given the base's
+ /// read-only-ness. Writable items are invariant (any change is illegal);
+ /// `ReadOnly` items may narrow to a subtype, approximated as: a different
+ /// container head is a legal narrowing, but the same *invariant* container with
+ /// different type arguments is not.
+ fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+-    if !base.readonly {
++    if  /* ~ changed by cargo-mutants ~ */base.readonly {
+         return true;
+     }
+     type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
+ }
+ 
+ /// The container/base name of a type expression: the text before the first `[`.
+ fn type_head(core: &amp;str) -&gt; &amp;str {
+     core.split('[').next().unwrap_or(core).trim()
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:110:5</td>
+      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>false</code></td>
+      <td class='dur'>35.0s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-59')">▶ show diff</div>
+        <pre id='diff-59' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
 +++ replace value_type_incompatible -&gt; bool with false
 @@ -102,20 +102,17 @@
  }
@@ -2121,41 +2145,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:110:8</td>
-      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>19.5s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-59')">▶ show diff</div>
-        <pre id='diff-59' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
-+++ delete ! in value_type_incompatible
-@@ -102,17 +102,17 @@
- }
- 
- /// Decide whether a changed value type is incompatible given the base's
- /// read-only-ness. Writable items are invariant (any change is illegal);
- /// `ReadOnly` items may narrow to a subtype, approximated as: a different
- /// container head is a legal narrowing, but the same *invariant* container with
- /// different type arguments is not.
- fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    if !base.readonly {
-+    if  /* ~ changed by cargo-mutants ~ */base.readonly {
-         return true;
-     }
-     type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
- }
- 
- /// The container/base name of a type expression: the text before the first `[`.
- fn type_head(core: &amp;str) -&gt; &amp;str {
-     core.split('[').next().unwrap_or(core).trim()
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:113:51</td>
       <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>15.9s</td>
+      <td class='dur'>34.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-60')">▶ show diff</div>
@@ -2186,7 +2179,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:113:26</td>
       <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>19.9s</td>
+      <td class='dur'>26.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-61')">▶ show diff</div>
@@ -2216,43 +2209,12 @@
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:118:5</td>
       <td><code>type_head</code> -> &str <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>&quot;&quot;</code></td>
-      <td class='dur'>20.1s</td>
+      <td><code class='replacement'>&quot;xyzzy&quot;</code></td>
+      <td class='dur'>31.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-62')">▶ show diff</div>
         <pre id='diff-62' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
-+++ replace type_head -&gt; &amp;str with &quot;&quot;
-@@ -110,17 +110,17 @@
-     if !base.readonly {
-         return true;
-     }
-     type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
- }
- 
- /// The container/base name of a type expression: the text before the first `[`.
- fn type_head(core: &amp;str) -&gt; &amp;str {
--    core.split('[').next().unwrap_or(core).trim()
-+    &quot;&quot; /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Containers whose element type is invariant, so narrowing their arguments in a
- /// `ReadOnly` redeclaration remains illegal.
- fn is_invariant_container(head: &amp;str) -&gt; bool {
-     matches!(
-         head,
-         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:118:5</td>
-      <td><code>type_head</code> -> &str <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>&quot;xyzzy&quot;</code></td>
-      <td class='dur'>15.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-63')">▶ show diff</div>
-        <pre id='diff-63' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
 +++ replace type_head -&gt; &amp;str with &quot;xyzzy&quot;
 @@ -110,17 +110,17 @@
      if !base.readonly {
@@ -2276,10 +2238,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:118:5</td>
+      <td><code>type_head</code> -> &str <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>&quot;&quot;</code></td>
+      <td class='dur'>33.2s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-63')">▶ show diff</div>
+        <pre id='diff-63' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
++++ replace type_head -&gt; &amp;str with &quot;&quot;
+@@ -110,17 +110,17 @@
+     if !base.readonly {
+         return true;
+     }
+     type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
+ }
+ 
+ /// The container/base name of a type expression: the text before the first `[`.
+ fn type_head(core: &amp;str) -&gt; &amp;str {
+-    core.split('[').next().unwrap_or(core).trim()
++    &quot;&quot; /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Containers whose element type is invariant, so narrowing their arguments in a
+ /// `ReadOnly` redeclaration remains illegal.
+ fn is_invariant_container(head: &amp;str) -&gt; bool {
+     matches!(
+         head,
+         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:124:5</td>
       <td><code>is_invariant_container</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>true</code></td>
-      <td class='dur'>22.2s</td>
+      <td class='dur'>31.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-64')">▶ show diff</div>
@@ -2313,7 +2306,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:124:5</td>
       <td><code>is_invariant_container</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>false</code></td>
-      <td class='dur'>22.3s</td>
+      <td class='dur'>31.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-65')">▶ show diff</div>
@@ -2346,43 +2339,12 @@
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:5</td>
       <td><code>bases_conflict</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>false</code></td>
-      <td class='dur'>17.5s</td>
+      <td><code class='replacement'>true</code></td>
+      <td class='dur'>23.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-66')">▶ show diff</div>
         <pre id='diff-66' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
-+++ replace bases_conflict -&gt; bool with false
-@@ -125,17 +125,17 @@
-         head,
-         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
-     )
- }
- 
- /// Returns `true` when two base declarations of the same field cannot be merged:
- /// different core types, required-ness, or read-only-ness.
- fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    left.core != right.core || left.required != right.required || left.readonly != right.readonly
-+    false /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
- fn check_mixed_bases(
-     cls: &amp;ClassInfo,
-     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:5</td>
-      <td><code>bases_conflict</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>true</code></td>
-      <td class='dur'>22.8s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-67')">▶ show diff</div>
-        <pre id='diff-67' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
 +++ replace bases_conflict -&gt; bool with true
 @@ -125,17 +125,17 @@
          head,
@@ -2406,10 +2368,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:5</td>
+      <td><code>bases_conflict</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>false</code></td>
+      <td class='dur'>26.5s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-67')">▶ show diff</div>
+        <pre id='diff-67' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
++++ replace bases_conflict -&gt; bool with false
+@@ -125,17 +125,17 @@
+         head,
+         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+     )
+ }
+ 
+ /// Returns `true` when two base declarations of the same field cannot be merged:
+ /// different core types, required-ness, or read-only-ness.
+ fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+-    left.core != right.core || left.required != right.required || left.readonly != right.readonly
++    false /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
+ fn check_mixed_bases(
+     cls: &amp;ClassInfo,
+     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:64</td>
       <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>13.4s</td>
+      <td class='dur'>38.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-68')">▶ show diff</div>
@@ -2437,45 +2430,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:29</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:15</td>
       <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>16.1s</td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>36.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-69')">▶ show diff</div>
         <pre id='diff-69' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
-+++ replace || with &amp;&amp; in bases_conflict
-@@ -125,17 +125,17 @@
-         head,
-         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
-     )
- }
- 
- /// Returns `true` when two base declarations of the same field cannot be merged:
- /// different core types, required-ness, or read-only-ness.
- fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    left.core != right.core || left.required != right.required || left.readonly != right.readonly
-+    left.core != right.core &amp;&amp; /* ~ changed by cargo-mutants ~ */ left.required != right.required || left.readonly != right.readonly
- }
- 
- /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
- fn check_mixed_bases(
-     cls: &amp;ClassInfo,
-     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:15</td>
-      <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>25.9s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-70')">▶ show diff</div>
-        <pre id='diff-70' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
 +++ replace != with == in bases_conflict
 @@ -125,17 +125,17 @@
          head,
@@ -2499,10 +2461,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:29</td>
+      <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>&amp;&amp;</code></td>
+      <td class='dur'>38.9s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-70')">▶ show diff</div>
+        <pre id='diff-70' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
++++ replace || with &amp;&amp; in bases_conflict
+@@ -125,17 +125,17 @@
+         head,
+         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+     )
+ }
+ 
+ /// Returns `true` when two base declarations of the same field cannot be merged:
+ /// different core types, required-ness, or read-only-ness.
+ fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+-    left.core != right.core || left.required != right.required || left.readonly != right.readonly
++    left.core != right.core &amp;&amp; /* ~ changed by cargo-mutants ~ */ left.required != right.required || left.readonly != right.readonly
+ }
+ 
+ /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
+ fn check_mixed_bases(
+     cls: &amp;ClassInfo,
+     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:46</td>
       <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>27.0s</td>
+      <td class='dur'>34.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-71')">▶ show diff</div>
@@ -2533,7 +2526,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:133:81</td>
       <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>23.8s</td>
+      <td class='dur'>24.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-72')">▶ show diff</div>
@@ -2561,14 +2554,76 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:179:5</td>
-      <td><code>check_field_override</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>16.1s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:184:16</td>
+      <td><code>check_field_override</code>  <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>27.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-73')">▶ show diff</div>
         <pre id='diff-73' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
++++ delete ! in check_field_override
+@@ -176,17 +176,17 @@
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+ ) {
+     for base_name in typed_dict_bases {
+         let base_total = class_map
+             .get(base_name)
+             .is_none_or(|c| c.is_typeddict_total);
+         for child_attr in &amp;cls.attributes {
+-            if !child_attr.has_annotation {
++            if  /* ~ changed by cargo-mutants ~ */child_attr.has_annotation {
+                 continue;
+             }
+             let Some(base_attr) = attr_map.get(&amp;(base_name, child_attr.name.as_str())) else {
+                 continue;
+             };
+             if !base_attr.has_annotation {
+                 continue;
+             }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:190:16</td>
+      <td><code>check_field_override</code>  <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>28.3s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-74')">▶ show diff</div>
+        <pre id='diff-74' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
++++ delete ! in check_field_override
+@@ -182,17 +182,17 @@
+             .is_none_or(|c| c.is_typeddict_total);
+         for child_attr in &amp;cls.attributes {
+             if !child_attr.has_annotation {
+                 continue;
+             }
+             let Some(base_attr) = attr_map.get(&amp;(base_name, child_attr.name.as_str())) else {
+                 continue;
+             };
+-            if !base_attr.has_annotation {
++            if  /* ~ changed by cargo-mutants ~ */base_attr.has_annotation {
+                 continue;
+             }
+             let Some(child_ann) = annotation_text(source, child_attr.annotation_span) else {
+                 continue;
+             };
+             let Some(base_ann) = annotation_text(source, base_attr.annotation_span) else {
+                 continue;
+             };
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:179:5</td>
+      <td><code>check_field_override</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>32.7s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-75')">▶ show diff</div>
+        <pre id='diff-75' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
 +++ replace check_field_override with ()
 @@ -171,52 +171,17 @@
      cls: &amp;ClassInfo,
@@ -2627,65 +2682,34 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:184:16</td>
-      <td><code>check_field_override</code>  <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>14.3s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:227:31</td>
+      <td><code>check_conflicting_bases</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>23.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-74')">▶ show diff</div>
-        <pre id='diff-74' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
-+++ delete ! in check_field_override
-@@ -176,17 +176,17 @@
+        <div class='diff-toggle' onclick="toggle('diff-76')">▶ show diff</div>
+        <pre id='diff-76' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
++++ replace &lt; with == in check_conflicting_bases
+@@ -219,17 +219,17 @@
+ fn check_conflicting_bases(
+     cls: &amp;ClassInfo,
+     typed_dict_bases: &amp;[&amp;str],
+     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
+     source: &amp;str,
      path: &amp;str,
      diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
  ) {
+-    if typed_dict_bases.len() &lt; 2 {
++    if typed_dict_bases.len() == /* ~ changed by cargo-mutants ~ */ 2 {
+         return;
+     }
+     let mut seen: HashMap&lt;&amp;str, (&amp;str, FieldQualifiers&lt;'_&gt;)&gt; = HashMap::new();
      for base_name in typed_dict_bases {
-         let base_total = class_map
-             .get(base_name)
-             .is_none_or(|c| c.is_typeddict_total);
-         for child_attr in &amp;cls.attributes {
--            if !child_attr.has_annotation {
-+            if  /* ~ changed by cargo-mutants ~ */child_attr.has_annotation {
-                 continue;
-             }
-             let Some(base_attr) = attr_map.get(&amp;(base_name, child_attr.name.as_str())) else {
-                 continue;
-             };
-             if !base_attr.has_annotation {
-                 continue;
-             }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:190:16</td>
-      <td><code>check_field_override</code>  <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>22.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-75')">▶ show diff</div>
-        <pre id='diff-75' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
-+++ delete ! in check_field_override
-@@ -182,17 +182,17 @@
-             .is_none_or(|c| c.is_typeddict_total);
-         for child_attr in &amp;cls.attributes {
-             if !child_attr.has_annotation {
-                 continue;
-             }
-             let Some(base_attr) = attr_map.get(&amp;(base_name, child_attr.name.as_str())) else {
-                 continue;
-             };
--            if !base_attr.has_annotation {
-+            if  /* ~ changed by cargo-mutants ~ */base_attr.has_annotation {
-                 continue;
-             }
-             let Some(child_ann) = annotation_text(source, child_attr.annotation_span) else {
-                 continue;
-             };
-             let Some(base_ann) = annotation_text(source, base_attr.annotation_span) else {
-                 continue;
-             };
+         let Some(base_cls) = class_map.get(base_name) else {
+             continue;
+         };
+         for attr in &amp;base_cls.attributes {
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
@@ -2695,8 +2719,8 @@
       <td class='dur'>29.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-76')">▶ show diff</div>
-        <pre id='diff-76' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
+        <div class='diff-toggle' onclick="toggle('diff-77')">▶ show diff</div>
+        <pre id='diff-77' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
 +++ replace check_conflicting_bases with ()
 @@ -219,49 +219,17 @@
  fn check_conflicting_bases(
@@ -2754,39 +2778,8 @@
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:227:31</td>
       <td><code>check_conflicting_bases</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>29.3s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-77')">▶ show diff</div>
-        <pre id='diff-77' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
-+++ replace &lt; with == in check_conflicting_bases
-@@ -219,17 +219,17 @@
- fn check_conflicting_bases(
-     cls: &amp;ClassInfo,
-     typed_dict_bases: &amp;[&amp;str],
-     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
-     source: &amp;str,
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
- ) {
--    if typed_dict_bases.len() &lt; 2 {
-+    if typed_dict_bases.len() == /* ~ changed by cargo-mutants ~ */ 2 {
-         return;
-     }
-     let mut seen: HashMap&lt;&amp;str, (&amp;str, FieldQualifiers&lt;'_&gt;)&gt; = HashMap::new();
-     for base_name in typed_dict_bases {
-         let Some(base_cls) = class_map.get(base_name) else {
-             continue;
-         };
-         for attr in &amp;base_cls.attributes {
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:227:31</td>
-      <td><code>check_conflicting_bases</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&gt;</code></td>
-      <td class='dur'>22.7s</td>
+      <td class='dur'>25.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-78')">▶ show diff</div>
@@ -2817,7 +2810,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:227:31</td>
       <td><code>check_conflicting_bases</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&lt;=</code></td>
-      <td class='dur'>17.0s</td>
+      <td class='dur'>28.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-79')">▶ show diff</div>
@@ -2848,7 +2841,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:236:16</td>
       <td><code>check_conflicting_bases</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>15.7s</td>
+      <td class='dur'>30.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-80')">▶ show diff</div>
@@ -2876,14 +2869,45 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0039.rs:26:9</td>
-      <td><code><impl Rule for InvalidAssertTypeCall>::check</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>22.2s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0039.rs:26:76</td>
+      <td><code><impl Rule for InvalidAssertTypeCall>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>26.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-81')">▶ show diff</div>
         <pre id='diff-81' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0039.rs
++++ replace != with == in &lt;impl Rule for InvalidAssertTypeCall&gt;::check
+@@ -18,17 +18,17 @@
+     docs_url: &quot;https://www.basilisk-python.dev/errors/BSK-E0039&quot;,
+ };
+ 
+ /// Emits BSK-E0039 for invalid `assert_type()` calls.
+ pub(crate) struct InvalidAssertTypeCall;
+ 
+ impl Rule for InvalidAssertTypeCall {
+     fn check(&amp;self, module: &amp;ResolvedModule, diagnostics: &amp;mut Vec&lt;Diagnostic&gt;) {
+-        for call in module.assert_type_calls.iter().filter(|c| c.arg_count != 2) {
++        for call in module.assert_type_calls.iter().filter(|c| c.arg_count == /* ~ changed by cargo-mutants ~ */ 2) {
+             let arg_count = call.arg_count;
+             diagnostics.push(error_diagnostic_owned(
+                 CODE.clone(),
+                 format!(
+                     &quot;`assert_type()` requires exactly 2 arguments (value, type), got {arg_count}&quot;
+                 ),
+                 call.span,
+                 &amp;module.path,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0039.rs:26:9</td>
+      <td><code><impl Rule for InvalidAssertTypeCall>::check</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>31.5s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-82')">▶ show diff</div>
+        <pre id='diff-82' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0039.rs
 +++ replace &lt;impl Rule for InvalidAssertTypeCall&gt;::check with ()
 @@ -18,27 +18,11 @@
      docs_url: &quot;https://www.basilisk-python.dev/errors/BSK-E0039&quot;,
@@ -2917,41 +2941,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0039.rs:26:76</td>
-      <td><code><impl Rule for InvalidAssertTypeCall>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>21.2s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-82')">▶ show diff</div>
-        <pre id='diff-82' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0039.rs
-+++ replace != with == in &lt;impl Rule for InvalidAssertTypeCall&gt;::check
-@@ -18,17 +18,17 @@
-     docs_url: &quot;https://www.basilisk-python.dev/errors/BSK-E0039&quot;,
- };
- 
- /// Emits BSK-E0039 for invalid `assert_type()` calls.
- pub(crate) struct InvalidAssertTypeCall;
- 
- impl Rule for InvalidAssertTypeCall {
-     fn check(&amp;self, module: &amp;ResolvedModule, diagnostics: &amp;mut Vec&lt;Diagnostic&gt;) {
--        for call in module.assert_type_calls.iter().filter(|c| c.arg_count != 2) {
-+        for call in module.assert_type_calls.iter().filter(|c| c.arg_count == /* ~ changed by cargo-mutants ~ */ 2) {
-             let arg_count = call.arg_count;
-             diagnostics.push(error_diagnostic_owned(
-                 CODE.clone(),
-                 format!(
-                     &quot;`assert_type()` requires exactly 2 arguments (value, type), got {arg_count}&quot;
-                 ),
-                 call.span,
-                 &amp;module.path,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:61:5</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>vec![]</code></td>
-      <td class='dur'>23.3s</td>
+      <td class='dur'>29.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-83')">▶ show diff</div>
@@ -3008,7 +3001,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:61:5</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>vec![String::new()]</code></td>
-      <td class='dur'>24.9s</td>
+      <td class='dur'>26.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-84')">▶ show diff</div>
@@ -3062,45 +3055,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:63:24</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>27.3s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:61:5</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>vec![&quot;xyzzy&quot;.into()]</code></td>
+      <td class='dur'>43.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-85')">▶ show diff</div>
         <pre id='diff-85' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
-+++ replace != with == in collect_type_alias_names
-@@ -55,17 +55,17 @@
- ///
- /// Handles:
- /// - `from typing import TypeAlias`
- /// - `from typing import TypeAlias as TA`
- /// - `import typing` (used as `typing.TypeAlias`)
- fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
-     let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
-     for import in &amp;module.imports {
--        if import.kind != ImportKind::From {
-+        if import.kind == /* ~ changed by cargo-mutants ~ */ ImportKind::From {
-             continue;
-         }
-         if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
-             continue;
-         }
-         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
-         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
-             continue;
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:61:5</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>vec![&quot;xyzzy&quot;.into()]</code></td>
-      <td class='dur'>34.5s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-86')">▶ show diff</div>
-        <pre id='diff-86' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
 +++ replace collect_type_alias_names -&gt; Vec&lt;String&gt; with vec![&quot;xyzzy&quot;.into()]
 @@ -53,43 +53,17 @@
  
@@ -3153,11 +3115,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:66:26</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>35.4s</td>
+      <td class='dur'>43.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-87')">▶ show diff</div>
-        <pre id='diff-87' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
+        <div class='diff-toggle' onclick="toggle('diff-86')">▶ show diff</div>
+        <pre id='diff-86' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
 +++ replace != with == in collect_type_alias_names
 @@ -58,17 +58,17 @@
  /// - `from typing import TypeAlias as TA`
@@ -3181,10 +3143,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:63:24</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>51.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-87')">▶ show diff</div>
+        <pre id='diff-87' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
++++ replace != with == in collect_type_alias_names
+@@ -55,17 +55,17 @@
+ ///
+ /// Handles:
+ /// - `from typing import TypeAlias`
+ /// - `from typing import TypeAlias as TA`
+ /// - `import typing` (used as `typing.TypeAlias`)
+ fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
+     let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
+     for import in &amp;module.imports {
+-        if import.kind != ImportKind::From {
++        if import.kind == /* ~ changed by cargo-mutants ~ */ ImportKind::From {
+             continue;
+         }
+         if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
+             continue;
+         }
+         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
+         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
+             continue;
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:66:55</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>28.5s</td>
+      <td class='dur'>37.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-88')">▶ show diff</div>
@@ -3215,7 +3208,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:77:42</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>21.0s</td>
+      <td class='dur'>34.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-89')">▶ show diff</div>
@@ -3246,7 +3239,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:77:42</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>*</code></td>
-      <td class='dur'>26.9s</td>
+      <td class='dur'>32.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-90')">▶ show diff</div>
@@ -3277,7 +3270,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:80:53</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>19.0s</td>
+      <td class='dur'>34.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-91')">▶ show diff</div>
@@ -3308,7 +3301,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:80:59</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>19.6s</td>
+      <td class='dur'>39.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-92')">▶ show diff</div>
@@ -3339,7 +3332,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:82:16</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>18.3s</td>
+      <td class='dur'>30.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-93')">▶ show diff</div>
@@ -3370,7 +3363,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:82:43</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>16.0s</td>
+      <td class='dur'>38.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-94')">▶ show diff</div>
@@ -3401,7 +3394,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:166:5</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>true</code></td>
-      <td class='dur'>18.0s</td>
+      <td class='dur'>35.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-95')">▶ show diff</div>
@@ -3448,7 +3441,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:166:5</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>false</code></td>
-      <td class='dur'>22.3s</td>
+      <td class='dur'>31.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-96')">▶ show diff</div>
@@ -3495,7 +3488,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:174:13</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArm</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>21.6s</td>
+      <td class='dur'>29.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-97')">▶ show diff</div>
@@ -3523,45 +3516,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:175:13</td>
-      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArm</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>21.1s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:176:18</td>
+      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArmGuard</span></td>
+      <td><code class='replacement'>true</code></td>
+      <td class='dur'>36.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-98')">▶ show diff</div>
         <pre id='diff-98' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
-+++ delete match arm b']' | b')' | b'}' in has_top_level_token
-@@ -167,17 +167,17 @@
-     let bytes = s.as_bytes();
-     let tok = token.as_bytes();
-     let tok_len = tok.len();
-     // `enumerate` yields each index exactly once — forward progress is
-     // structural, so mutating the loop counter is impossible.
-     for (i, &amp;byte) in bytes.iter().enumerate() {
-         match byte {
-             b'[' | b'(' | b'{' =&gt; depth += 1,
--            b']' | b')' | b'}' =&gt; depth -= 1,
-+             /* ~ changed by cargo-mutants ~ */
-             _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
-                 return true;
-             }
-             _ =&gt; {}
-         }
-     }
-     false
- }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:176:18</td>
-      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArmGuard</span></td>
-      <td><code class='replacement'>true</code></td>
-      <td class='dur'>26.0s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-99')">▶ show diff</div>
-        <pre id='diff-99' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
 +++ replace match guard depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) with true in has_top_level_token
 @@ -168,17 +168,17 @@
      let tok = token.as_bytes();
@@ -3588,11 +3550,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:176:18</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArmGuard</span></td>
       <td><code class='replacement'>false</code></td>
-      <td class='dur'>22.8s</td>
+      <td class='dur'>28.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-100')">▶ show diff</div>
-        <pre id='diff-100' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
+        <div class='diff-toggle' onclick="toggle('diff-99')">▶ show diff</div>
+        <pre id='diff-99' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
 +++ replace match guard depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) with false in has_top_level_token
 @@ -168,17 +168,17 @@
      let tok = token.as_bytes();
@@ -3616,10 +3578,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:175:13</td>
+      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArm</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>43.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-100')">▶ show diff</div>
+        <pre id='diff-100' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
++++ delete match arm b']' | b')' | b'}' in has_top_level_token
+@@ -167,17 +167,17 @@
+     let bytes = s.as_bytes();
+     let tok = token.as_bytes();
+     let tok_len = tok.len();
+     // `enumerate` yields each index exactly once — forward progress is
+     // structural, so mutating the loop counter is impossible.
+     for (i, &amp;byte) in bytes.iter().enumerate() {
+         match byte {
+             b'[' | b'(' | b'{' =&gt; depth += 1,
+-            b']' | b')' | b'}' =&gt; depth -= 1,
++             /* ~ changed by cargo-mutants ~ */
+             _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
+                 return true;
+             }
+             _ =&gt; {}
+         }
+     }
+     false
+ }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:174:41</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-=</code></td>
-      <td class='dur'>27.3s</td>
+      <td class='dur'>28.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-101')">▶ show diff</div>
@@ -3650,7 +3643,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:174:41</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>*=</code></td>
-      <td class='dur'>27.3s</td>
+      <td class='dur'>41.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-102')">▶ show diff</div>
@@ -3680,43 +3673,12 @@
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:175:41</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>+=</code></td>
-      <td class='dur'>33.9s</td>
+      <td><code class='replacement'>/=</code></td>
+      <td class='dur'>45.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-103')">▶ show diff</div>
         <pre id='diff-103' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
-+++ replace -= with += in has_top_level_token
-@@ -167,17 +167,17 @@
-     let bytes = s.as_bytes();
-     let tok = token.as_bytes();
-     let tok_len = tok.len();
-     // `enumerate` yields each index exactly once — forward progress is
-     // structural, so mutating the loop counter is impossible.
-     for (i, &amp;byte) in bytes.iter().enumerate() {
-         match byte {
-             b'[' | b'(' | b'{' =&gt; depth += 1,
--            b']' | b')' | b'}' =&gt; depth -= 1,
-+            b']' | b')' | b'}' =&gt; depth += /* ~ changed by cargo-mutants ~ */ 1,
-             _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
-                 return true;
-             }
-             _ =&gt; {}
-         }
-     }
-     false
- }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:175:41</td>
-      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>/=</code></td>
-      <td class='dur'>32.5s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-104')">▶ show diff</div>
-        <pre id='diff-104' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
 +++ replace -= with /= in has_top_level_token
 @@ -167,17 +167,17 @@
      let bytes = s.as_bytes();
@@ -3740,10 +3702,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:175:41</td>
+      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>+=</code></td>
+      <td class='dur'>50.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-104')">▶ show diff</div>
+        <pre id='diff-104' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0048.rs
++++ replace -= with += in has_top_level_token
+@@ -167,17 +167,17 @@
+     let bytes = s.as_bytes();
+     let tok = token.as_bytes();
+     let tok_len = tok.len();
+     // `enumerate` yields each index exactly once — forward progress is
+     // structural, so mutating the loop counter is impossible.
+     for (i, &amp;byte) in bytes.iter().enumerate() {
+         match byte {
+             b'[' | b'(' | b'{' =&gt; depth += 1,
+-            b']' | b')' | b'}' =&gt; depth -= 1,
++            b']' | b')' | b'}' =&gt; depth += /* ~ changed by cargo-mutants ~ */ 1,
+             _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
+                 return true;
+             }
+             _ =&gt; {}
+         }
+     }
+     false
+ }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:176:29</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>25.7s</td>
+      <td class='dur'>47.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-105')">▶ show diff</div>
@@ -3774,7 +3767,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:176:24</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>27.3s</td>
+      <td class='dur'>40.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-106')">▶ show diff</div>
@@ -3805,7 +3798,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:176:58</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>14.1s</td>
+      <td class='dur'>41.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-107')">▶ show diff</div>
@@ -3836,7 +3829,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:176:47</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>27.7s</td>
+      <td class='dur'>43.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-108')">▶ show diff</div>
@@ -3867,7 +3860,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0048.rs:176:47</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>*</code></td>
-      <td class='dur'>27.4s</td>
+      <td class='dur'>42.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-109')">▶ show diff</div>
@@ -3898,7 +3891,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0049.rs:35:9</td>
       <td><code><impl Rule for MultipleUnboundedTupleTypes>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>22.4s</td>
+      <td class='dur'>29.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-110')">▶ show diff</div>
@@ -3935,7 +3928,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0088.rs:37:9</td>
       <td><code><impl Rule for TypedDictRuntimeViolation>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>27.7s</td>
+      <td class='dur'>37.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-111')">▶ show diff</div>
@@ -3975,7 +3968,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0105.rs:30:9</td>
       <td><code><impl Rule for BoundedTypeVarAttrAccess>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>29.6s</td>
+      <td class='dur'>36.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-112')">▶ show diff</div>
@@ -4028,7 +4021,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/callable_check.rs:283:5</td>
       <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>None</code></td>
-      <td class='dur'>31.3s</td>
+      <td class='dur'>37.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-113')">▶ show diff</div>
@@ -4112,7 +4105,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/callable_check.rs:283:5</td>
       <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Some(Default::default())</code></td>
-      <td class='dur'>29.2s</td>
+      <td class='dur'>35.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-114')">▶ show diff</div>
@@ -4196,7 +4189,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/callable_check.rs:307:13</td>
       <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>MatchArm</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>24.3s</td>
+      <td class='dur'>27.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-115')">▶ show diff</div>
@@ -4234,7 +4227,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0014/callable_check.rs:324:17</td>
       <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>StructField</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>14.3s</td>
+      <td class='dur'>28.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-116')">▶ show diff</div>
@@ -4275,11 +4268,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0001.rs:39:5</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>2.6s</td>
+      <td class='dur'>5.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-7')">▶ show diff</div>
-        <pre id='diff-7' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0001.rs
+        <div class='diff-toggle' onclick="toggle('diff-5')">▶ show diff</div>
+        <pre id='diff-5' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0001.rs
 +++ replace make_diagnostic -&gt; Diagnostic with Default::default()
 @@ -31,17 +31,10 @@
  fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
@@ -4306,11 +4299,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0002.rs:33:5</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>1.9s</td>
+      <td class='dur'>8.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-10')">▶ show diff</div>
-        <pre id='diff-10' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0002.rs
+        <div class='diff-toggle' onclick="toggle('diff-11')">▶ show diff</div>
+        <pre id='diff-11' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0002.rs
 +++ replace make_diagnostic -&gt; Diagnostic with Default::default()
 @@ -25,26 +25,10 @@
              .filter(|func| {
@@ -4346,11 +4339,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0003.rs:42:5</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>2.3s</td>
+      <td class='dur'>5.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-17')">▶ show diff</div>
-        <pre id='diff-17' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
+        <div class='diff-toggle' onclick="toggle('diff-18')">▶ show diff</div>
+        <pre id='diff-18' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0003.rs
 +++ replace make_diagnostic -&gt; Diagnostic with Default::default()
 @@ -34,50 +34,10 @@
  fn is_unresolvable(rhs: &amp;RhsKind) -&gt; bool {
@@ -4410,7 +4403,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0023.rs:34:5</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>4.3s</td>
+      <td class='dur'>7.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-37')">▶ show diff</div>
@@ -4445,11 +4438,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/e0038.rs:66:5</td>
       <td><code>parse_field_qualifiers</code> -> FieldQualifiers<'_> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>3.6s</td>
+      <td class='dur'>15.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-44')">▶ show diff</div>
-        <pre id='diff-44' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
+        <div class='diff-toggle' onclick="toggle('diff-45')">▶ show diff</div>
+        <pre id='diff-45' class='diff hidden'>--- crates/basilisk-checker/src/rules/e0038.rs
 +++ replace parse_field_qualifiers -&gt; FieldQualifiers&lt;'_&gt; with Default::default()
 @@ -58,31 +58,17 @@
      required: bool,

--- a/mutation_testing/mutation_scores.json
+++ b/mutation_testing/mutation_scores.json
@@ -1,10 +1,10 @@
 {
   "scores": {
     "working": {
-      "caught": 105,
+      "caught": 112,
       "date": "2026-06-12",
-      "kill_rate": 93.75,
-      "missed": 7,
+      "kill_rate": 100.0,
+      "missed": 0,
       "timeout": 0,
       "total": 117,
       "unviable": 5


### PR DESCRIPTION
## Summary

Kills all 7 mutants that survived the working-scope mutation suite, taking the kill rate from **93.75% to 100%** (117 mutants: 112 caught, 0 missed, 5 unviable). The baseline in `mutation_testing/mutation_scores.json` is ratcheted, so the viable-pool/caught/missed/kill-rate gates now hold the suite at zero missed.

## The 7 mutants and what kills them

| Mutant | Killing assertion |
|---|---|
| `e0002.rs` `&&`→`\|\|` in `check` | Annotated functions produce **zero** E0002 |
| `e0003.rs` `&&`→`\|\|` in `check` | Annotated empty-list/None vars produce **zero** E0003 |
| `e0003.rs` `is_unresolvable`→`true` | Unannotated but inferable vars (`x = 5`) produce **zero** E0003 |
| `e0003.rs` delete `EmptyList` arm | Message must say ``empty list `[]` `` |
| `e0003.rs` delete `EmptyDict` arm | Message must say ``empty dict `{}` `` |
| `e0003.rs` delete `NoneValue` arm | Message must say ``infer type from `None` `` |
| `e0029.rs` `&&`→`\|\|` in function `find` | Diagnostic span must point inside the TypedDict, not at a same-named method on an earlier class |

The pattern behind all seven: the existing smoke tests asserted only the positive direction (≥1 diagnostic fires), so mutants that *added* false diagnostics or degraded messages survived. These tests assert the negative direction and message specificity.

## Verification

Scoped `cargo mutants` over e0002/e0003/e0029: 18/18 viable mutants caught. Full `make mutation-test`: 117 mutants, 0 missed, baseline ratcheted to 100%. Full `mutation_kill_tests` suite green (46 tests), workspace clippy 0 errors, fmt clean.
