### PR TITLE
Fix all 7 critical issues (#110, #93, #94, #81, #79, #113, #58)

### DIFF
--- a/crates/basilisk-checker/src/context.rs
+++ b/crates/basilisk-checker/src/context.rs
@@ -1,0 +1,57 @@
+//! Implements [CHKARCH-VERSION-TARGET]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-VERSION-TARGET
+//!
+//! Per-run context threaded into every rule (issue #93).
+//!
+//! The configured `python_version` / `python_platform` flow from
+//! `BasiliskConfig` (CLI: `pyproject.toml` / `basilisk.json`; LSP: the
+//! `[LSPUV-PYTHON-VERSION-RESOLUTION-ORDER]` cascade) into [`CheckContext`],
+//! so rules evaluate version/platform conditionals against the *configured*
+//! target instead of a hardcoded constant.
+
+/// The single, centralized default target version (canonical Python 3.12).
+pub const DEFAULT_TARGET_VERSION: (u32, u32) = (3, 12);
+
+/// Per-run facts every rule may consult.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckContext {
+    /// Target Python version as `(major, minor)`, e.g. `(3, 9)`.
+    pub target_version: (u32, u32),
+    /// Target platform (`"linux"`, `"darwin"`, `"win32"`), if configured.
+    pub target_platform: Option<String>,
+}
+
+impl Default for CheckContext {
+    fn default() -> Self {
+        Self {
+            target_version: DEFAULT_TARGET_VERSION,
+            target_platform: None,
+        }
+    }
+}
+
+impl CheckContext {
+    /// Build a context from project configuration.
+    ///
+    /// An absent or unparsable `python_version` falls back to
+    /// [`DEFAULT_TARGET_VERSION`] so a malformed config behaves exactly like
+    /// the default rather than panicking or disabling version gating.
+    #[must_use]
+    pub fn from_config(config: &basilisk_config::BasiliskConfig) -> Self {
+        Self {
+            target_version: config
+                .python_version
+                .as_deref()
+                .and_then(parse_target_version)
+                .unwrap_or(DEFAULT_TARGET_VERSION),
+            target_platform: config.python_platform.clone(),
+        }
+    }
+}
+
+/// Parse `"3.9"` / `"3.12.1"` into `(major, minor)`.
+fn parse_target_version(raw: &str) -> Option<(u32, u32)> {
+    let mut parts = raw.trim().split('.');
+    let major = parts.next()?.parse::<u32>().ok()?;
+    let minor = parts.next().map_or(Some(0), |m| m.parse::<u32>().ok())?;
+    Some((major, minor))
+}

--- a/crates/basilisk-checker/src/lib.rs
+++ b/crates/basilisk-checker/src/lib.rs
@@ -28,6 +28,7 @@
 
 pub mod cached;
 pub mod collection_inference;
+pub mod context;
 pub mod diagnostic;
 pub mod inference;
 pub mod rules;
@@ -64,7 +65,9 @@ pub fn check_with_config(
     let inline_overrides = suppression::parse_source_overrides(&module.source);
     let source = &module.source;
     let file_path = std::path::Path::new(&module.path);
-    let raw = rules::run_all(module);
+    // [CHKARCH-VERSION-TARGET] every rule sees the configured target.
+    let ctx = context::CheckContext::from_config(config);
+    let raw = rules::run_all(module, &ctx);
 
     // Build the set of symbol names imported from unresolved modules.
     // Used for cascade suppression: downstream errors referencing these names

--- a/crates/basilisk-checker/src/rules/e0001.rs
+++ b/crates/basilisk-checker/src/rules/e0001.rs
@@ -19,7 +19,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MissingParameterAnnotation;
 
 impl Rule for MissingParameterAnnotation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .functions
             .iter()

--- a/crates/basilisk-checker/src/rules/e0002.rs
+++ b/crates/basilisk-checker/src/rules/e0002.rs
@@ -18,7 +18,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MissingReturnAnnotation;
 
 impl Rule for MissingReturnAnnotation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .functions
             .iter()

--- a/crates/basilisk-checker/src/rules/e0003.rs
+++ b/crates/basilisk-checker/src/rules/e0003.rs
@@ -20,7 +20,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MissingVariableType;
 
 impl Rule for MissingVariableType {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .module_vars
             .iter()

--- a/crates/basilisk-checker/src/rules/e0004.rs
+++ b/crates/basilisk-checker/src/rules/e0004.rs
@@ -21,7 +21,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MissingVarArgAnnotation;
 
 impl Rule for MissingVarArgAnnotation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .functions
             .iter()

--- a/crates/basilisk-checker/src/rules/e0005.rs
+++ b/crates/basilisk-checker/src/rules/e0005.rs
@@ -27,7 +27,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MissingAttributeAnnotation;
 
 impl Rule for MissingAttributeAnnotation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Collect all TypeVar names (module-level and class-body) so we can
         // exempt unannotated TypeVar assignments like `T = TypeVar("T")` from E0005.
         let typevar_names: std::collections::HashSet<&str> = module

--- a/crates/basilisk-checker/src/rules/e0010.rs
+++ b/crates/basilisk-checker/src/rules/e0010.rs
@@ -29,7 +29,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ImportFromUntypedModule;
 
 impl Rule for ImportFromUntypedModule {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .imports
             .iter()
@@ -146,7 +151,11 @@ mod tests {
     fn run_check(import: ImportInfo) -> Vec<crate::Diagnostic> {
         let module = make_module(vec![import]);
         let mut diagnostics = Vec::new();
-        ImportFromUntypedModule.check(&module, &mut diagnostics);
+        ImportFromUntypedModule.check(
+            &module,
+            &crate::context::CheckContext::default(),
+            &mut diagnostics,
+        );
         diagnostics
     }
 

--- a/crates/basilisk-checker/src/rules/e0011.rs
+++ b/crates/basilisk-checker/src/rules/e0011.rs
@@ -47,7 +47,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ReturnTypeMismatch;
 
 impl Rule for ReturnTypeMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for func in &module.functions {
             check_explicit_any(func, &module.path, diagnostics);
 

--- a/crates/basilisk-checker/src/rules/e0012.rs
+++ b/crates/basilisk-checker/src/rules/e0012.rs
@@ -32,7 +32,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ArgumentTypeMismatch;
 
 impl Rule for ArgumentTypeMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Group module-level functions by name → list of overloads/implementations.
         let mut func_groups: HashMap<&str, Vec<&FunctionInfo>> = HashMap::new();
         for func in &module.functions {

--- a/crates/basilisk-checker/src/rules/e0013.rs
+++ b/crates/basilisk-checker/src/rules/e0013.rs
@@ -23,7 +23,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ReturnTypeMismatch;
 
 impl Rule for ReturnTypeMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .functions
             .iter()

--- a/crates/basilisk-checker/src/rules/e0014/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0014/mod.rs
@@ -46,7 +46,12 @@ pub(crate) const CODE: ErrorCode = ErrorCode {
 pub(crate) struct AssignmentTypeMismatch;
 
 impl Rule for AssignmentTypeMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let empty_params = ParamMaps::default();
         let skip = SkipNames {
             typeddict: collect_typeddict_names(module),

--- a/crates/basilisk-checker/src/rules/e0015.rs
+++ b/crates/basilisk-checker/src/rules/e0015.rs
@@ -35,7 +35,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct InvalidTypeArgCount;
 
 impl Rule for InvalidTypeArgCount {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .functions
             .iter()

--- a/crates/basilisk-checker/src/rules/e0016.rs
+++ b/crates/basilisk-checker/src/rules/e0016.rs
@@ -36,7 +36,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct IncompatibleOverride;
 
 impl Rule for IncompatibleOverride {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build map: class_name → method_name → &FunctionInfo
         let method_map: HashMap<(&str, &str), &FunctionInfo> = module
             .functions

--- a/crates/basilisk-checker/src/rules/e0017.rs
+++ b/crates/basilisk-checker/src/rules/e0017.rs
@@ -48,7 +48,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct IncompatibleVariableOverride;
 
 impl Rule for IncompatibleVariableOverride {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build map: class_name → &ClassInfo
         let class_map = super::shared::class_name_map(&module.classes);
 

--- a/crates/basilisk-checker/src/rules/e0018.rs
+++ b/crates/basilisk-checker/src/rules/e0018.rs
@@ -25,7 +25,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct UndefinedVariable;
 
 impl Rule for UndefinedVariable {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Collect all import-bound names (both `import X` and `from X import Y`).
         let import_names: Vec<&str> = module
             .imports

--- a/crates/basilisk-checker/src/rules/e0019.rs
+++ b/crates/basilisk-checker/src/rules/e0019.rs
@@ -28,7 +28,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct UnboundVariable;
 
 impl Rule for UnboundVariable {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module.functions.iter().for_each(|func| {
             check_function(func, &module.path, diagnostics);
         });

--- a/crates/basilisk-checker/src/rules/e0020.rs
+++ b/crates/basilisk-checker/src/rules/e0020.rs
@@ -28,7 +28,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MissingOverloadImpl;
 
 impl Rule for MissingOverloadImpl {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a set of Protocol/ABC class names so we can exempt their methods.
         let exempt_classes: std::collections::HashSet<&str> = module
             .classes

--- a/crates/basilisk-checker/src/rules/e0021.rs
+++ b/crates/basilisk-checker/src/rules/e0021.rs
@@ -27,7 +27,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct OverlappingOverloads;
 
 impl Rule for OverlappingOverloads {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Group overloaded functions by (class_name, function_name) so overloads
         // in different classes with the same method name don't cross-contaminate.
         let mut groups: HashMap<(Option<&str>, &str), Vec<&FunctionInfo>> = HashMap::new();

--- a/crates/basilisk-checker/src/rules/e0022.rs
+++ b/crates/basilisk-checker/src/rules/e0022.rs
@@ -24,7 +24,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct UnhashableDictKey;
 
 impl Rule for UnhashableDictKey {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .functions
             .iter()

--- a/crates/basilisk-checker/src/rules/e0023.rs
+++ b/crates/basilisk-checker/src/rules/e0023.rs
@@ -21,7 +21,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct NonExhaustiveMatch;
 
 impl Rule for NonExhaustiveMatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .match_stmts
             .iter()

--- a/crates/basilisk-checker/src/rules/e0024.rs
+++ b/crates/basilisk-checker/src/rules/e0024.rs
@@ -28,7 +28,12 @@ const HELP: &str = "Use a type name like `int`, `str`, `float` instead of a lite
 pub(crate) struct InvalidTypeForm;
 
 impl Rule for InvalidTypeForm {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .functions
             .iter()

--- a/crates/basilisk-checker/src/rules/e0025.rs
+++ b/crates/basilisk-checker/src/rules/e0025.rs
@@ -30,7 +30,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MissingOverrideDecorator;
 
 impl Rule for MissingOverrideDecorator {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a raw class map first (name → ClassInfo).
         let raw_map = super::shared::class_name_map(&module.classes);
 

--- a/crates/basilisk-checker/src/rules/e0026.rs
+++ b/crates/basilisk-checker/src/rules/e0026.rs
@@ -21,7 +21,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarSingleConstraint;
 
 impl Rule for TypeVarSingleConstraint {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for tv in &module.typevar_calls {
             check_typevar_constraints(tv, module, diagnostics);
         }

--- a/crates/basilisk-checker/src/rules/e0027.rs
+++ b/crates/basilisk-checker/src/rules/e0027.rs
@@ -19,7 +19,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct DuplicateTypeVarInGeneric;
 
 impl Rule for DuplicateTypeVarInGeneric {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for class in &module.classes {
             let params = &class.generic_params;
             let mut seen: Vec<&str> = Vec::new();

--- a/crates/basilisk-checker/src/rules/e0029.rs
+++ b/crates/basilisk-checker/src/rules/e0029.rs
@@ -19,7 +19,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypedDictMethodNotAllowed;
 
 impl Rule for TypedDictMethodNotAllowed {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for class in module.classes.iter().filter(|c| c.is_typed_dict) {
             for method_name in &class.method_names {
                 // __init_subclass__ and __class_getitem__ are synthesised; skip them.

--- a/crates/basilisk-checker/src/rules/e0030.rs
+++ b/crates/basilisk-checker/src/rules/e0030.rs
@@ -35,7 +35,12 @@ struct TvMeta {
 pub(crate) struct NonDefaultAfterDefault;
 
 impl Rule for NonDefaultAfterDefault {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let tv_meta: HashMap<&str, TvMeta> = module
             .typevar_calls
             .iter()

--- a/crates/basilisk-checker/src/rules/e0031.rs
+++ b/crates/basilisk-checker/src/rules/e0031.rs
@@ -23,7 +23,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct InvalidCastCall;
 
 impl Rule for InvalidCastCall {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for call in module.calls.iter().filter(|c| c.callee == "cast") {
             let arg_count = call.args.len();
             if arg_count == 2 {

--- a/crates/basilisk-checker/src/rules/e0032.rs
+++ b/crates/basilisk-checker/src/rules/e0032.rs
@@ -25,7 +25,12 @@ pub(crate) struct InvalidTypedDictBase;
 const KNOWN_TYPED_DICT_KEYWORDS: &[&str] = &["total", "extra_items", "closed"];
 
 impl Rule for InvalidTypedDictBase {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for class in module.classes.iter().filter(|c| c.is_typed_dict) {
             for kw in &class.class_keywords {
                 if !KNOWN_TYPED_DICT_KEYWORDS.contains(&kw.as_str()) {

--- a/crates/basilisk-checker/src/rules/e0033.rs
+++ b/crates/basilisk-checker/src/rules/e0033.rs
@@ -21,7 +21,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct InvalidRevealTypeCall;
 
 impl Rule for InvalidRevealTypeCall {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for call in module.reveal_type_calls.iter().filter(|c| c.arg_count != 1) {
             let arg_count = call.arg_count;
             diagnostics.push(error_diagnostic_owned(

--- a/crates/basilisk-checker/src/rules/e0034.rs
+++ b/crates/basilisk-checker/src/rules/e0034.rs
@@ -34,7 +34,12 @@ fn is_final_decorator(d: &str) -> bool {
 pub(crate) struct FinalViolation;
 
 impl Rule for FinalViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a map of class name → ClassInfo for fast lookup.
         let class_map = super::shared::class_name_map(&module.classes);
 

--- a/crates/basilisk-checker/src/rules/e0035.rs
+++ b/crates/basilisk-checker/src/rules/e0035.rs
@@ -83,7 +83,12 @@ fn is_in_typed_dict_hierarchy(cls: &ClassInfo, class_map: &HashMap<&str, &ClassI
 pub(crate) struct RequiredNotRequiredContext;
 
 impl Rule for RequiredNotRequiredContext {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0036/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0036/mod.rs
@@ -61,7 +61,12 @@ impl Rule for ClassVarInvalidContext {
         clippy::too_many_lines,
         reason = "ClassVar validation covers many distinct contexts"
     )]
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0037.rs
+++ b/crates/basilisk-checker/src/rules/e0037.rs
@@ -39,7 +39,12 @@ pub(crate) struct InvalidTypedDictCall;
 const ALLOWED_KEYWORDS: &[&str] = &["total", "extra_items", "closed"];
 
 impl Rule for InvalidTypedDictCall {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for td in &module.typeddict_calls {
             // Check 1: second arg must be a dict literal.
             if td.second_arg_kind == TypedDictSecondArgKind::NotDictLiteral {

--- a/crates/basilisk-checker/src/rules/e0038.rs
+++ b/crates/basilisk-checker/src/rules/e0038.rs
@@ -263,7 +263,12 @@ fn check_conflicting_bases(
 pub(crate) struct InvalidTypedDictInheritance;
 
 impl Rule for InvalidTypedDictInheritance {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let class_map = super::shared::class_name_map(&module.classes);
 
         let attr_map: HashMap<(&str, &str), &AttributeInfo> = module

--- a/crates/basilisk-checker/src/rules/e0039.rs
+++ b/crates/basilisk-checker/src/rules/e0039.rs
@@ -22,7 +22,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct InvalidAssertTypeCall;
 
 impl Rule for InvalidAssertTypeCall {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for call in module.assert_type_calls.iter().filter(|c| c.arg_count != 2) {
             let arg_count = call.arg_count;
             diagnostics.push(error_diagnostic_owned(

--- a/crates/basilisk-checker/src/rules/e0040.rs
+++ b/crates/basilisk-checker/src/rules/e0040.rs
@@ -53,7 +53,12 @@ fn has_enum_members(cls: &ClassInfo) -> bool {
 pub(crate) struct EnumWithMembersFinal;
 
 impl Rule for EnumWithMembersFinal {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let class_map = super::shared::class_name_map(&module.classes);
 
         for child in &module.classes {

--- a/crates/basilisk-checker/src/rules/e0041.rs
+++ b/crates/basilisk-checker/src/rules/e0041.rs
@@ -38,7 +38,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TooFewArguments;
 
 impl Rule for TooFewArguments {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         check_plain_function_calls(module, diagnostics);
         check_constructor_calls(module, diagnostics);
         check_namedtuple_calls(module, diagnostics);

--- a/crates/basilisk-checker/src/rules/e0042.rs
+++ b/crates/basilisk-checker/src/rules/e0042.rs
@@ -81,7 +81,12 @@ fn is_word_boundary_match(haystack: &str, needle: &str) -> bool {
 pub(crate) struct Pep695TraditionalTypeVarMix;
 
 impl Rule for Pep695TraditionalTypeVarMix {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a set of all module-level traditional TypeVar names.
         let traditional_typevars: HashSet<&str> =
             basilisk_resolver::collect_name_set(&module.typevar_calls);

--- a/crates/basilisk-checker/src/rules/e0043.rs
+++ b/crates/basilisk-checker/src/rules/e0043.rs
@@ -42,7 +42,12 @@ fn make_diagnostic(message: String, span: basilisk_resolver::Span, path: &str) -
 pub(crate) struct NonTypeVarInGeneric;
 
 impl Rule for NonTypeVarInGeneric {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Collect all module-level TypeVar names (traditional TypeVar calls).
         let typevar_names: HashSet<&str> =
             basilisk_resolver::collect_name_set(&module.typevar_calls);

--- a/crates/basilisk-checker/src/rules/e0044.rs
+++ b/crates/basilisk-checker/src/rules/e0044.rs
@@ -119,7 +119,12 @@ fn has_final_multiple_type_args(ann: &str) -> bool {
 pub(crate) struct FinalInvalidPosition;
 
 impl Rule for FinalInvalidPosition {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0045/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0045/mod.rs
@@ -64,7 +64,12 @@ fn make_diagnostic(message: String, span: Span, path: &str) -> Diagnostic {
 pub(crate) struct AnnotatedInvalidFirstArg;
 
 impl Rule for AnnotatedInvalidFirstArg {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0046.rs
+++ b/crates/basilisk-checker/src/rules/e0046.rs
@@ -34,7 +34,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct EnumMemberAnnotated;
 
 impl Rule for EnumMemberAnnotated {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for cls in module.classes.iter().filter(|c| is_enum_class(c)) {
             for attr in cls
                 .attributes

--- a/crates/basilisk-checker/src/rules/e0047/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0047/mod.rs
@@ -78,7 +78,12 @@ fn make_diagnostic(message: String, span: Span, path: &str) -> Diagnostic {
 pub(crate) struct InvalidTypeAnnotation;
 
 impl Rule for InvalidTypeAnnotation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         check_invalid_type_annotations(module, diagnostics);
     }
 }

--- a/crates/basilisk-checker/src/rules/e0048.rs
+++ b/crates/basilisk-checker/src/rules/e0048.rs
@@ -194,7 +194,12 @@ fn paren_has_top_level_comma(s: &str) -> bool {
 pub(crate) struct TypeAliasInvalidRhs;
 
 impl Rule for TypeAliasInvalidRhs {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
         let type_alias_names = collect_type_alias_names(module);

--- a/crates/basilisk-checker/src/rules/e0049.rs
+++ b/crates/basilisk-checker/src/rules/e0049.rs
@@ -31,7 +31,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MultipleUnboundedTupleTypes;
 
 impl Rule for MultipleUnboundedTupleTypes {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for &span in &module.multiple_unbounded_tuple_spans {
             diagnostics.push(error_diagnostic_owned(
                 CODE.clone(),

--- a/crates/basilisk-checker/src/rules/e0050.rs
+++ b/crates/basilisk-checker/src/rules/e0050.rs
@@ -229,7 +229,12 @@ fn check_newtype_call(
 pub(crate) struct InvalidNewType;
 
 impl Rule for InvalidNewType {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0051.rs
+++ b/crates/basilisk-checker/src/rules/e0051.rs
@@ -185,7 +185,12 @@ fn is_complete_string_literal(arg: &str) -> bool {
 pub(crate) struct InvalidLiteralParam;
 
 impl Rule for InvalidLiteralParam {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0052.rs
+++ b/crates/basilisk-checker/src/rules/e0052.rs
@@ -39,7 +39,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct FrozenDataclassAssignment;
 
 impl Rule for FrozenDataclassAssignment {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let transform_classes = super::guards::collect_transform_classes(module);
 
         let class_frozen: HashMap<&str, (bool, bool)> = module

--- a/crates/basilisk-checker/src/rules/e0053.rs
+++ b/crates/basilisk-checker/src/rules/e0053.rs
@@ -30,7 +30,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct AssertTypeMismatch;
 
 impl Rule for AssertTypeMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for call in module
             .assert_type_calls
             .iter()

--- a/crates/basilisk-checker/src/rules/e0054.rs
+++ b/crates/basilisk-checker/src/rules/e0054.rs
@@ -107,7 +107,12 @@ fn collect_class_final_attr_map(module: &ResolvedModule) -> HashMap<String, Hash
 pub(crate) struct FinalAnnotationViolation;
 
 impl Rule for FinalAnnotationViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let path = &module.path;
         let module_final_names = collect_module_final_names(module);
         let class_final_map = collect_class_final_attr_map(module);

--- a/crates/basilisk-checker/src/rules/e0055.rs
+++ b/crates/basilisk-checker/src/rules/e0055.rs
@@ -61,7 +61,12 @@ impl Rule for TypeVarInvalidKwargs {
         clippy::too_many_lines,
         reason = "TypeVar/TypeVarTuple/ParamSpec keyword validation requires extensive branching"
     )]
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let path = &module.path;
         for tv in &module.typevar_calls {
             // TypeVarTuple and ParamSpec do not support variance flags, bound, or constraints.

--- a/crates/basilisk-checker/src/rules/e0056.rs
+++ b/crates/basilisk-checker/src/rules/e0056.rs
@@ -33,7 +33,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ReadOnlyTypedDictMutation;
 
 impl Rule for ReadOnlyTypedDictMutation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for v in &module.readonly_violations {
             let message = match v.kind {
                 ReadOnlyViolationKind::SubscriptAssign => {

--- a/crates/basilisk-checker/src/rules/e0057.rs
+++ b/crates/basilisk-checker/src/rules/e0057.rs
@@ -148,7 +148,12 @@ fn is_non_type_name(rhs: &str, non_type_names: &HashSet<String>) -> bool {
 pub(crate) struct TypeStatementInvalidRhs;
 
 impl Rule for TypeStatementInvalidRhs {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
         let non_type_names = collect_non_type_names(module);

--- a/crates/basilisk-checker/src/rules/e0058.rs
+++ b/crates/basilisk-checker/src/rules/e0058.rs
@@ -92,7 +92,12 @@ fn check_annotation(ann: &str, name_span: Span, path: &str, diagnostics: &mut Ve
 pub(crate) struct AnnotatedTooFewArguments;
 
 impl Rule for AnnotatedTooFewArguments {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0059.rs
+++ b/crates/basilisk-checker/src/rules/e0059.rs
@@ -32,7 +32,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MatchArgsFalseAccess;
 
 impl Rule for MatchArgsFalseAccess {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Collect names of dataclasses that have match_args=False AND do not
         // already define __match_args__ in their body.
         let no_match_args: HashSet<&str> = module

--- a/crates/basilisk-checker/src/rules/e0060.rs
+++ b/crates/basilisk-checker/src/rules/e0060.rs
@@ -56,7 +56,12 @@ struct SourceComparison {
 pub(crate) struct CrossTypeDataclassOrderComparison;
 
 impl Rule for CrossTypeDataclassOrderComparison {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let transform_classes = super::guards::collect_transform_classes(module);
 
         let all_dc_classes = collect_dc_classes(module, &transform_classes);

--- a/crates/basilisk-checker/src/rules/e0061.rs
+++ b/crates/basilisk-checker/src/rules/e0061.rs
@@ -33,7 +33,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct AssertTypeEnumLiteralMismatch;
 
 impl Rule for AssertTypeEnumLiteralMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let path = &module.path;
 
         // Build a map of enum class names → ClassInfo for lookup

--- a/crates/basilisk-checker/src/rules/e0062.rs
+++ b/crates/basilisk-checker/src/rules/e0062.rs
@@ -48,7 +48,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct NoReturnFallThrough;
 
 impl Rule for NoReturnFallThrough {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module.functions.iter().for_each(|func| {
             check_function(func, &module.source, &module.path, diagnostics);
         });

--- a/crates/basilisk-checker/src/rules/e0063.rs
+++ b/crates/basilisk-checker/src/rules/e0063.rs
@@ -49,7 +49,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct NonHashableDataclassAssignment;
 
 impl Rule for NonHashableDataclassAssignment {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a set of class names that are non-hashable dataclasses.
         // A dataclass is non-hashable when:
         //   - it is a dataclass (`is_dataclass`)

--- a/crates/basilisk-checker/src/rules/e0064.rs
+++ b/crates/basilisk-checker/src/rules/e0064.rs
@@ -69,7 +69,12 @@ fn keyword_rhs_mismatch(annotation: &str, rhs: &RhsKind) -> Option<&'static str>
 pub(crate) struct InvalidNamedTupleCall;
 
 impl Rule for InvalidNamedTupleCall {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build map from NamedTuple LHS name → definition.
         let nt_map: HashMap<&str, &NamedTupleDefInfo> = module
             .namedtuple_defs

--- a/crates/basilisk-checker/src/rules/e0065.rs
+++ b/crates/basilisk-checker/src/rules/e0065.rs
@@ -35,7 +35,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct FloatParamIntAttrAccess;
 
 impl Rule for FloatParamIntAttrAccess {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for access in &module.float_param_int_attr_accesses {
             diagnostics.push(error_diagnostic_owned(
                 CODE.clone(),

--- a/crates/basilisk-checker/src/rules/e0066.rs
+++ b/crates/basilisk-checker/src/rules/e0066.rs
@@ -36,7 +36,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct EnumValueTypeMismatch;
 
 impl Rule for EnumValueTypeMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.enum_value_type_violations {
             let (message, help) = match violation.kind {
                 EnumValueTypeViolationKind::MemberValueTypeMismatch => (

--- a/crates/basilisk-checker/src/rules/e0067.rs
+++ b/crates/basilisk-checker/src/rules/e0067.rs
@@ -37,7 +37,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct EnumNonMemberInLiteral;
 
 impl Rule for EnumNonMemberInLiteral {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a map of enum class names → ClassInfo for lookup.
         let enum_classes: HashMap<&str, &ClassInfo> = module
             .classes

--- a/crates/basilisk-checker/src/rules/e0068.rs
+++ b/crates/basilisk-checker/src/rules/e0068.rs
@@ -34,7 +34,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct LiteralStringEnumMismatch;
 
 impl Rule for LiteralStringEnumMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for mismatch in &module.literal_string_enum_mismatches {
             diagnostics.push(error_diagnostic_owned(
                 CODE.clone(),

--- a/crates/basilisk-checker/src/rules/e0069.rs
+++ b/crates/basilisk-checker/src/rules/e0069.rs
@@ -36,7 +36,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct DataclassKwOnlyViolation;
 
 impl Rule for DataclassKwOnlyViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let positional_counts = build_positional_counts(&module.classes);
         let init_false_fields = build_init_false_fields(&module.classes);
 

--- a/crates/basilisk-checker/src/rules/e0070.rs
+++ b/crates/basilisk-checker/src/rules/e0070.rs
@@ -40,7 +40,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct NeverTypeCompatibility;
 
 impl Rule for NeverTypeCompatibility {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0071.rs
+++ b/crates/basilisk-checker/src/rules/e0071.rs
@@ -39,7 +39,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct HistoricalPositionalViolation;
 
 impl Rule for HistoricalPositionalViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let path = &module.path;
         for violation in &module.historical_positional_violations {
             let diagnostic = match violation.kind {

--- a/crates/basilisk-checker/src/rules/e0072.rs
+++ b/crates/basilisk-checker/src/rules/e0072.rs
@@ -38,7 +38,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct NoMatchingOverload;
 
 impl Rule for NoMatchingOverload {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0073.rs
+++ b/crates/basilisk-checker/src/rules/e0073.rs
@@ -41,7 +41,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct NamedTupleTupleCompat;
 
 impl Rule for NamedTupleTupleCompat {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0074.rs
+++ b/crates/basilisk-checker/src/rules/e0074.rs
@@ -46,7 +46,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ConstructorCallNewMismatch;
 
 impl Rule for ConstructorCallNewMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0075.rs
+++ b/crates/basilisk-checker/src/rules/e0075.rs
@@ -48,7 +48,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct SelfTypeAttributeIncompatible;
 
 impl Rule for SelfTypeAttributeIncompatible {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0076.rs
+++ b/crates/basilisk-checker/src/rules/e0076.rs
@@ -36,7 +36,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct OverloadUnionExpansionFailure;
 
 impl Rule for OverloadUnionExpansionFailure {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0077.rs
+++ b/crates/basilisk-checker/src/rules/e0077.rs
@@ -36,7 +36,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ProtocolSelfViolation;
 
 impl Rule for ProtocolSelfViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.protocol_self_violations {
             diagnostics.push(error_diagnostic_owned(
                 CODE.clone(),

--- a/crates/basilisk-checker/src/rules/e0078.rs
+++ b/crates/basilisk-checker/src/rules/e0078.rs
@@ -44,7 +44,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct SelfTypeViolation;
 
 impl Rule for SelfTypeViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0079.rs
+++ b/crates/basilisk-checker/src/rules/e0079.rs
@@ -41,7 +41,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ModuleProtocolIncompatible;
 
 impl Rule for ModuleProtocolIncompatible {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0080.rs
+++ b/crates/basilisk-checker/src/rules/e0080.rs
@@ -37,7 +37,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarBoundViolation;
 
 impl Rule for TypeVarBoundViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
 
         // Step 1: Build a map of TypeVar name -> bound text.

--- a/crates/basilisk-checker/src/rules/e0081.rs
+++ b/crates/basilisk-checker/src/rules/e0081.rs
@@ -37,7 +37,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarTupleUnpackViolation;
 
 impl Rule for TypeVarTupleUnpackViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0082.rs
+++ b/crates/basilisk-checker/src/rules/e0082.rs
@@ -39,7 +39,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarTupleCallableMismatch;
 
 impl Rule for TypeVarTupleCallableMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0083.rs
+++ b/crates/basilisk-checker/src/rules/e0083.rs
@@ -111,7 +111,12 @@ fn find_matching_bracket(content: &str) -> Option<usize> {
 pub(crate) struct TypeVarTupleUnpackRequired;
 
 impl Rule for TypeVarTupleUnpackRequired {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Collect all TypeVarTuple names defined in this module.
         let tvt_names = super::shared::typevar_tuple_names(&module.typevar_calls);
 

--- a/crates/basilisk-checker/src/rules/e0084.rs
+++ b/crates/basilisk-checker/src/rules/e0084.rs
@@ -29,7 +29,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarTupleInvalidParams;
 
 impl Rule for TypeVarTupleInvalidParams {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for call in &module.calls {
             if call.callee != "TypeVarTuple" {
                 continue;

--- a/crates/basilisk-checker/src/rules/e0085/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0085/mod.rs
@@ -35,7 +35,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarTupleArgCountMismatch;
 
 impl Rule for TypeVarTupleArgCountMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0086.rs
+++ b/crates/basilisk-checker/src/rules/e0086.rs
@@ -95,7 +95,12 @@ fn find_matching_bracket(content: &str) -> Option<usize> {
 pub(crate) struct MultipleTypeVarTuplesInGeneric;
 
 impl Rule for MultipleTypeVarTuplesInGeneric {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // 1. Check class generic parameters.
         for cls in &module.classes {
             let tvt_count = cls

--- a/crates/basilisk-checker/src/rules/e0088.rs
+++ b/crates/basilisk-checker/src/rules/e0088.rs
@@ -33,7 +33,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypedDictRuntimeViolation;
 
 impl Rule for TypedDictRuntimeViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for span in &module.isinstance_typeddict_violations {
             diagnostics.push(error_diagnostic_owned(
                 CODE.clone(),

--- a/crates/basilisk-checker/src/rules/e0089.rs
+++ b/crates/basilisk-checker/src/rules/e0089.rs
@@ -39,7 +39,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct Pep695InvalidBound;
 
 impl Rule for Pep695InvalidBound {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.pep695_bound_violations {
             let message = match &violation.kind {
                 Pep695BoundViolationKind::ListLiteralBound => format!(

--- a/crates/basilisk-checker/src/rules/e0090.rs
+++ b/crates/basilisk-checker/src/rules/e0090.rs
@@ -35,7 +35,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct InvalidTupleTypeSyntax;
 
 impl Rule for InvalidTupleTypeSyntax {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
 
         // Check all variable annotations for tuple type syntax violations

--- a/crates/basilisk-checker/src/rules/e0091.rs
+++ b/crates/basilisk-checker/src/rules/e0091.rs
@@ -37,7 +37,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarDefaultIncompatible;
 
 impl Rule for TypeVarDefaultIncompatible {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a set of TypeVar names in scope — when the default is another TypeVar,
         // the check is referential and requires comparing bounds, which is out of scope
         // for this simple check. Skip those to avoid false positives.

--- a/crates/basilisk-checker/src/rules/e0092.rs
+++ b/crates/basilisk-checker/src/rules/e0092.rs
@@ -282,7 +282,12 @@ fn is_parameters_form(arg: &str, paramspec_names: &HashSet<&str>) -> bool {
 }
 
 impl Rule for TooFewTypeArguments {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let arities = compute_arities(module);
         check_paramspec_slot_args(module, diagnostics);
 

--- a/crates/basilisk-checker/src/rules/e0093/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0093/mod.rs
@@ -38,7 +38,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypedDictKeyValidation;
 
 impl Rule for TypedDictKeyValidation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         type_consistency::check_typeddict_assignability(module, diagnostics);
 
         // TypedDicts declared with `extra_items=` accept keys beyond their

--- a/crates/basilisk-checker/src/rules/e0094.rs
+++ b/crates/basilisk-checker/src/rules/e0094.rs
@@ -145,7 +145,12 @@ fn check_func_annotations_for_self(
 pub(crate) struct SelfInvalidLocation;
 
 impl Rule for SelfInvalidLocation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         check_self_invalid_locations(module, diagnostics);
     }
 }

--- a/crates/basilisk-checker/src/rules/e0095.rs
+++ b/crates/basilisk-checker/src/rules/e0095.rs
@@ -73,7 +73,12 @@ fn extract_initvar_inner(ann: &str) -> Option<&str> {
 pub(crate) struct InitVarViolation;
 
 impl Rule for InitVarViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         check_post_init_signatures(module, diagnostics);
         check_initvar_attribute_access(module, diagnostics);
     }

--- a/crates/basilisk-checker/src/rules/e0096.rs
+++ b/crates/basilisk-checker/src/rules/e0096.rs
@@ -32,7 +32,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct DataclassFieldDefaultFactoryMismatch;
 
 impl Rule for DataclassFieldDefaultFactoryMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0097.rs
+++ b/crates/basilisk-checker/src/rules/e0097.rs
@@ -32,7 +32,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ProtocolNewSelfAttrViolation;
 
 impl Rule for ProtocolNewSelfAttrViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Find protocol classes.
         let protocol_classes: Vec<_> = module
             .classes

--- a/crates/basilisk-checker/src/rules/e0098.rs
+++ b/crates/basilisk-checker/src/rules/e0098.rs
@@ -75,7 +75,12 @@ fn is_protocol_class(name: &str, module: &ResolvedModule) -> bool {
 }
 
 impl Rule for NonProtocolBaseInProtocol {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for class in &module.classes {
             // Only check classes that have Protocol as a base.
             let has_protocol = class.bases.iter().any(|b| b == "Protocol");

--- a/crates/basilisk-checker/src/rules/e0099.rs
+++ b/crates/basilisk-checker/src/rules/e0099.rs
@@ -28,7 +28,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ProtocolInstantiation;
 
 impl Rule for ProtocolInstantiation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.protocol_instantiation_violations {
             let message = if violation.is_abstract {
                 format!(

--- a/crates/basilisk-checker/src/rules/e0100.rs
+++ b/crates/basilisk-checker/src/rules/e0100.rs
@@ -29,7 +29,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct LiteralAugmentedAssign;
 
 impl Rule for LiteralAugmentedAssign {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // First, emit any violations collected by the resolver.
         for violation in &module.literal_augmented_assign_violations {
             diagnostics.push(make_diagnostic(

--- a/crates/basilisk-checker/src/rules/e0101.rs
+++ b/crates/basilisk-checker/src/rules/e0101.rs
@@ -35,7 +35,12 @@ fn has_only_self_or_cls(func: &basilisk_resolver::FunctionInfo) -> bool {
 }
 
 impl Rule for TypeGuardNoNarrowingParam {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
 
         for func in &module.functions {

--- a/crates/basilisk-checker/src/rules/e0102.rs
+++ b/crates/basilisk-checker/src/rules/e0102.rs
@@ -272,7 +272,12 @@ fn check_default_constraints_vs_bound(
 }
 
 impl Rule for TypeVarDefaultReferential {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let typevar_by_name: HashMap<&str, &basilisk_resolver::TypeVarCallInfo> = module
             .typevar_calls
             .iter()

--- a/crates/basilisk-checker/src/rules/e0103.rs
+++ b/crates/basilisk-checker/src/rules/e0103.rs
@@ -25,7 +25,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TupleIndexOutOfBounds;
 
 impl Rule for TupleIndexOutOfBounds {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.tuple_index_violations {
             let len = i64::try_from(violation.tuple_length).unwrap_or(i64::MAX);
             let detail = if violation.index_value >= 0 {

--- a/crates/basilisk-checker/src/rules/e0104.rs
+++ b/crates/basilisk-checker/src/rules/e0104.rs
@@ -115,7 +115,12 @@ fn has_container_wrapper(alias: &basilisk_resolver::TypeAliasDefInfo) -> bool {
 }
 
 impl Rule for CyclicalTypeAliasReference {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a set of all TypeAlias names for quick membership tests.
         let alias_names: HashSet<&str> =
             basilisk_resolver::collect_name_set(&module.type_alias_defs);

--- a/crates/basilisk-checker/src/rules/e0105.rs
+++ b/crates/basilisk-checker/src/rules/e0105.rs
@@ -26,7 +26,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct BoundedTypeVarAttrAccess;
 
 impl Rule for BoundedTypeVarAttrAccess {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.bounded_typevar_attr_violations {
             diagnostics.push(error_diagnostic_owned(
                 CODE.clone(),

--- a/crates/basilisk-checker/src/rules/e0106.rs
+++ b/crates/basilisk-checker/src/rules/e0106.rs
@@ -39,7 +39,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ProtocolClassObject;
 
 impl Rule for ProtocolClassObject {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.protocol_class_object_violations {
             diagnostics.push(error_diagnostic_owned(
                 CODE.clone(),

--- a/crates/basilisk-checker/src/rules/e0107.rs
+++ b/crates/basilisk-checker/src/rules/e0107.rs
@@ -69,7 +69,12 @@ struct VarianceViolation {
 pub(crate) struct VarianceIncompatibleBase;
 
 impl Rule for VarianceIncompatibleBase {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a map of TypeVar name -> variance.
         let tv_variance: HashMap<&str, Variance> = module
             .typevar_calls

--- a/crates/basilisk-checker/src/rules/e0108.rs
+++ b/crates/basilisk-checker/src/rules/e0108.rs
@@ -39,7 +39,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct DataclassSlotsViolation;
 
 impl Rule for DataclassSlotsViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         check_self_attr_assignments(module, diagnostics);
         check_slots_access_on_non_slots_class(module, diagnostics);
     }

--- a/crates/basilisk-checker/src/rules/e0109.rs
+++ b/crates/basilisk-checker/src/rules/e0109.rs
@@ -42,7 +42,12 @@ fn bound_incompatible(bound: &str, arg_type: &str) -> bool {
 }
 
 impl Rule for TypeVarBoundCallViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
 
         // Build map: TypeVar name → bound type name

--- a/crates/basilisk-checker/src/rules/e0110.rs
+++ b/crates/basilisk-checker/src/rules/e0110.rs
@@ -332,7 +332,12 @@ impl VarianceContext<'_> {
 }
 
 impl Rule for ProtocolVarianceViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
 
         // Build TypeVar name -> variance map (skip ParamSpec and TypeVarTuple).

--- a/crates/basilisk-checker/src/rules/e0111/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0111/mod.rs
@@ -39,7 +39,12 @@ use helpers::{
 pub(crate) struct ConstructorCallError;
 
 impl Rule for ConstructorCallError {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0112.rs
+++ b/crates/basilisk-checker/src/rules/e0112.rs
@@ -233,7 +233,12 @@ fn build_mismatch_messages(
 }
 
 impl Rule for TypeGuardCallableReturnMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
 
         let mut func_map: HashMap<&str, &basilisk_resolver::FunctionInfo> = HashMap::new();

--- a/crates/basilisk-checker/src/rules/e0113.rs
+++ b/crates/basilisk-checker/src/rules/e0113.rs
@@ -166,7 +166,12 @@ fn split_generic(type_text: &str) -> Option<(&str, &str)> {
 }
 
 impl Rule for TypeIsInconsistentNarrowing {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
 
         for func in &module.functions {

--- a/crates/basilisk-checker/src/rules/e0114.rs
+++ b/crates/basilisk-checker/src/rules/e0114.rs
@@ -39,7 +39,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ProtocolRuntimeCheckableViolation;
 
 impl Rule for ProtocolRuntimeCheckableViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.protocol_runtime_checkable_violations {
             let (message, help, note) = match &violation.kind {
                 ProtocolRtcViolationKind::NotRuntimeCheckable {

--- a/crates/basilisk-checker/src/rules/e0115/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0115/mod.rs
@@ -43,7 +43,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct DeprecatedUsage;
 
 impl Rule for DeprecatedUsage {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0116.rs
+++ b/crates/basilisk-checker/src/rules/e0116.rs
@@ -33,7 +33,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct NamedTupleDefError;
 
 impl Rule for NamedTupleDefError {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let class_map = super::shared::class_name_map(&module.classes);
 
         for class in &module.classes {

--- a/crates/basilisk-checker/src/rules/e0117.rs
+++ b/crates/basilisk-checker/src/rules/e0117.rs
@@ -41,7 +41,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct UnboundTypeVarScope;
 
 impl Rule for UnboundTypeVarScope {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Collect all known TypeVar names from module-level TypeVar() calls.
         let typevar_names: HashSet<&str> =
             basilisk_resolver::collect_name_set(&module.typevar_calls);

--- a/crates/basilisk-checker/src/rules/e0118.rs
+++ b/crates/basilisk-checker/src/rules/e0118.rs
@@ -41,7 +41,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct SuperAbstractCall;
 
 impl Rule for SuperAbstractCall {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0119.rs
+++ b/crates/basilisk-checker/src/rules/e0119.rs
@@ -410,7 +410,12 @@ fn check_expr_for_violations(
 }
 
 impl Rule for ProtocolUnsafeOverlap {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0120.rs
+++ b/crates/basilisk-checker/src/rules/e0120.rs
@@ -40,7 +40,12 @@ use crate::types::InferredType;
 pub(crate) struct GeneratorReturnTypeViolation;
 
 impl Rule for GeneratorReturnTypeViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Emit violations collected by the resolver (invalid return types).
         for violation in &module.generator_violations {
             let (message, help, note) = match &violation.kind {

--- a/crates/basilisk-checker/src/rules/e0121.rs
+++ b/crates/basilisk-checker/src/rules/e0121.rs
@@ -67,7 +67,12 @@ fn known_protocol_methods(name: &str) -> Option<&'static [&'static str]> {
 pub(crate) struct ProtocolAssignmentConformance;
 
 impl Rule for ProtocolAssignmentConformance {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0122/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0122/mod.rs
@@ -28,7 +28,12 @@ mod paramspec_components;
 pub(crate) struct CallableCallSiteViolation;
 
 impl Rule for CallableCallSiteViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0123.rs
+++ b/crates/basilisk-checker/src/rules/e0123.rs
@@ -40,7 +40,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct SuperCallOnAbstractProtocolMethod;
 
 impl Rule for SuperCallOnAbstractProtocolMethod {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let class_map = super::shared::class_name_map(&module.classes);
 
         let method_map: HashMap<(&str, &str), &FunctionInfo> = module

--- a/crates/basilisk-checker/src/rules/e0124.rs
+++ b/crates/basilisk-checker/src/rules/e0124.rs
@@ -40,7 +40,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ProtocolTupleElementMismatch;
 
 impl Rule for ProtocolTupleElementMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let class_map = super::shared::class_name_map(&module.classes);
 
         let method_map: HashMap<(&str, &str), &FunctionInfo> = module

--- a/crates/basilisk-checker/src/rules/e0125.rs
+++ b/crates/basilisk-checker/src/rules/e0125.rs
@@ -46,7 +46,12 @@ struct ScanContext<'a> {
 }
 
 impl Rule for InstanceAttrOnClass {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0126.rs
+++ b/crates/basilisk-checker/src/rules/e0126.rs
@@ -43,7 +43,12 @@ use super::Rule;
 pub(crate) struct LiteralStringAssignment;
 
 impl Rule for LiteralStringAssignment {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0127.rs
+++ b/crates/basilisk-checker/src/rules/e0127.rs
@@ -30,7 +30,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TupleIndexOutOfRange;
 
 impl Rule for TupleIndexOutOfRange {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
 
         for func in &module.functions {

--- a/crates/basilisk-checker/src/rules/e0128.rs
+++ b/crates/basilisk-checker/src/rules/e0128.rs
@@ -53,7 +53,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarDefaultReferential;
 
 impl Rule for TypeVarDefaultReferential {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let typevar_names: HashSet<&str> =
             basilisk_resolver::collect_name_set(&module.typevar_calls);
 

--- a/crates/basilisk-checker/src/rules/e0129.rs
+++ b/crates/basilisk-checker/src/rules/e0129.rs
@@ -38,7 +38,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct LiteralValueIncompatible;
 
 impl Rule for LiteralValueIncompatible {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0130/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0130/mod.rs
@@ -54,7 +54,12 @@ impl Rule for TypeVarScopeViolation {
         clippy::cognitive_complexity,
         reason = "TypeVar scoping requires many interleaved checks"
     )]
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let all_typevars: HashSet<String> = module
             .typevar_calls
             .iter()

--- a/crates/basilisk-checker/src/rules/e0131/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0131/mod.rs
@@ -44,7 +44,12 @@ pub(crate) const CODE: ErrorCode = ErrorCode {
 pub(crate) struct GeneratorTypeMismatch;
 
 impl Rule for GeneratorTypeMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a map of function name -> return annotation text for cross-referencing
         // yield-from targets.
         let func_return_annotations: HashMap<&str, &str> = module

--- a/crates/basilisk-checker/src/rules/e0132.rs
+++ b/crates/basilisk-checker/src/rules/e0132.rs
@@ -32,7 +32,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct InconsistentTypeVarOrder;
 
 impl Rule for InconsistentTypeVarOrder {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a map of class_name -> ClassInfo for classes in this module.
         let class_map: HashMap<&str, &basilisk_resolver::ClassInfo> =
             basilisk_resolver::name_lookup(&module.classes);

--- a/crates/basilisk-checker/src/rules/e0133.rs
+++ b/crates/basilisk-checker/src/rules/e0133.rs
@@ -136,7 +136,12 @@ enum InferredVariance {
 pub(crate) struct ProtocolVarianceMismatch;
 
 impl Rule for ProtocolVarianceMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Build a map of TypeVar name -> (is_covariant, is_contravariant).
         // Skip ParamSpec and TypeVarTuple — they don't have traditional variance.
         let typevar_variance: HashMap<&str, (bool, bool)> = module

--- a/crates/basilisk-checker/src/rules/e0134.rs
+++ b/crates/basilisk-checker/src/rules/e0134.rs
@@ -34,7 +34,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct InvariantGenericArgMismatch;
 
 impl Rule for InvariantGenericArgMismatch {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0136.rs
+++ b/crates/basilisk-checker/src/rules/e0136.rs
@@ -41,7 +41,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct CallableSubtypingViolation;
 
 impl Rule for CallableSubtypingViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0137/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0137/mod.rs
@@ -52,7 +52,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct GenericProtocolViolation;
 
 impl Rule for GenericProtocolViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0138/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0138/mod.rs
@@ -48,7 +48,12 @@ use helpers::{
 pub(crate) struct DataclassTransformMetaViolation;
 
 impl Rule for DataclassTransformMetaViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0139.rs
+++ b/crates/basilisk-checker/src/rules/e0139.rs
@@ -49,7 +49,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeVarTupleSpecializationViolation;
 
 impl Rule for TypeVarTupleSpecializationViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0140/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0140/mod.rs
@@ -25,7 +25,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct CallableAssignmentViolation;
 
 impl Rule for CallableAssignmentViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0141.rs
+++ b/crates/basilisk-checker/src/rules/e0141.rs
@@ -26,7 +26,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct UnpackKwargsViolation;
 
 impl Rule for UnpackKwargsViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0142/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0142/mod.rs
@@ -45,7 +45,12 @@ use helpers::{
 pub(crate) struct DataclassTransformClassViolation;
 
 impl Rule for DataclassTransformClassViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let transform_bases = collect_transform_base_classes(module);
         if transform_bases.is_empty() {
             return;

--- a/crates/basilisk-checker/src/rules/e0143.rs
+++ b/crates/basilisk-checker/src/rules/e0143.rs
@@ -46,7 +46,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct NamedTupleUsageViolation;
 
 impl Rule for NamedTupleUsageViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0144/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0144/mod.rs
@@ -39,7 +39,12 @@ use helpers::{
 pub(crate) struct TypeCallConstructorViolation;
 
 impl Rule for TypeCallConstructorViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0145/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0145/mod.rs
@@ -45,7 +45,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeBracketViolation;
 
 impl Rule for TypeBracketViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0146.rs
+++ b/crates/basilisk-checker/src/rules/e0146.rs
@@ -51,7 +51,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct ProtocolClassObjectViolation;
 
 impl Rule for ProtocolClassObjectViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0147/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0147/mod.rs
@@ -57,7 +57,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TupleStarredUnpackCompatibility;
 
 impl Rule for TupleStarredUnpackCompatibility {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0148/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0148/mod.rs
@@ -33,7 +33,12 @@ use helpers::{
 pub(crate) struct GenericTypeArgViolation;
 
 impl Rule for GenericTypeArgViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };

--- a/crates/basilisk-checker/src/rules/e0149/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0149/mod.rs
@@ -47,7 +47,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct Pep695TypeParamScopingViolation;
 
 impl Rule for Pep695TypeParamScopingViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let scoping = &module.pep695_scoping;
         let path = &module.path;
 

--- a/crates/basilisk-checker/src/rules/e0150.rs
+++ b/crates/basilisk-checker/src/rules/e0150.rs
@@ -2,8 +2,9 @@
 //! BSK-E0150: Variable defined only in dead version/platform branch.
 //!
 //! When `sys.version_info`, `sys.platform`, or `os.name` is compared against
-//! a constant, one branch may be statically known to be dead for the target
-//! Python version (3.12) and platform.  Variables defined exclusively in a
+//! a constant, one branch may be statically known to be dead for the
+//! *configured* target Python version ([CHKARCH-VERSION-TARGET], issue #93)
+//! and platform.  Variables defined exclusively in a
 //! dead branch are undefined outside that branch.
 //!
 //! ```python
@@ -33,31 +34,43 @@ const CODE: ErrorCode = ErrorCode {
     docs_url: "https://www.basilisk-python.dev/errors/BSK-E0150",
 };
 
-/// Target Python version for dead-branch analysis.
-const TARGET_VERSION: (u32, u32) = (3, 12);
-
 /// Emits BSK-E0150 for variables defined only in dead version/platform branches.
 pub(crate) struct DeadBranchVariable;
 
 impl Rule for DeadBranchVariable {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let Some(parsed) = super::shared::parse_module(module) else {
             return;
         };
 
-        check_stmts_for_dead_branches(&parsed.ast.body, &module.path, diagnostics);
+        check_stmts_for_dead_branches(
+            &parsed.ast.body,
+            ctx.target_version,
+            &module.path,
+            diagnostics,
+        );
     }
 }
 
 /// Recursively walk statements looking for version/platform guard if-statements.
-fn check_stmts_for_dead_branches(stmts: &[Stmt], path: &str, diagnostics: &mut Vec<Diagnostic>) {
+fn check_stmts_for_dead_branches(
+    stmts: &[Stmt],
+    target: (u32, u32),
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     for stmt in stmts {
         match stmt {
             Stmt::FunctionDef(func) => {
-                check_function_body(&func.body, path, diagnostics);
+                check_function_body(&func.body, target, path, diagnostics);
             }
             Stmt::ClassDef(cls) => {
-                check_stmts_for_dead_branches(&cls.body, path, diagnostics);
+                check_stmts_for_dead_branches(&cls.body, target, path, diagnostics);
             }
             _ => {}
         }
@@ -65,7 +78,12 @@ fn check_stmts_for_dead_branches(stmts: &[Stmt], path: &str, diagnostics: &mut V
 }
 
 /// Check a function body for version/platform guards and dead-branch variables.
-fn check_function_body(stmts: &[Stmt], path: &str, diagnostics: &mut Vec<Diagnostic>) {
+fn check_function_body(
+    stmts: &[Stmt],
+    target: (u32, u32),
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     // Collect all assignments from dead branches at this level.
     let mut dead_vars: HashSet<String> = HashSet::new();
     // Collect all assignments from live branches to exclude from dead_vars.
@@ -74,7 +92,7 @@ fn check_function_body(stmts: &[Stmt], path: &str, diagnostics: &mut Vec<Diagnos
     for stmt in stmts {
         match stmt {
             Stmt::If(if_stmt) => {
-                if let Some(dead_branch) = identify_dead_branch(&if_stmt.test) {
+                if let Some(dead_branch) = identify_dead_branch(&if_stmt.test, target) {
                     match dead_branch {
                         DeadBranch::IfBody => {
                             // The if-body is dead; else-body is live.
@@ -99,20 +117,22 @@ fn check_function_body(stmts: &[Stmt], path: &str, diagnostics: &mut Vec<Diagnos
                     &assign.value,
                     &dead_vars,
                     &live_vars,
+                    target,
                     path,
                     diagnostics,
                 );
                 // Also check targets (for augmented assignment patterns).
-                for target in &assign.targets {
+                for assign_target in &assign.targets {
                     check_expr_for_dead_var_usage(
-                        target,
+                        assign_target,
                         &dead_vars,
                         &live_vars,
+                        target,
                         path,
                         diagnostics,
                     );
                     // This assignment makes the variable live now.
-                    if let Expr::Name(name) = target {
+                    if let Expr::Name(name) = assign_target {
                         let _ = live_vars.insert(name.id.to_string());
                     }
                 }
@@ -122,17 +142,25 @@ fn check_function_body(stmts: &[Stmt], path: &str, diagnostics: &mut Vec<Diagnos
                     &expr_stmt.value,
                     &dead_vars,
                     &live_vars,
+                    target,
                     path,
                     diagnostics,
                 );
             }
             Stmt::AnnAssign(ann_assign) => {
                 if let Some(value) = &ann_assign.value {
-                    check_expr_for_dead_var_usage(value, &dead_vars, &live_vars, path, diagnostics);
+                    check_expr_for_dead_var_usage(
+                        value,
+                        &dead_vars,
+                        &live_vars,
+                        target,
+                        path,
+                        diagnostics,
+                    );
                 }
             }
             Stmt::FunctionDef(func) => {
-                check_function_body(&func.body, path, diagnostics);
+                check_function_body(&func.body, target, path, diagnostics);
             }
             _ => {}
         }
@@ -149,7 +177,7 @@ enum DeadBranch {
 
 /// Determine if a test expression is a version/platform guard and which branch
 /// is dead.
-fn identify_dead_branch(test: &Expr) -> Option<DeadBranch> {
+fn identify_dead_branch(test: &Expr, target: (u32, u32)) -> Option<DeadBranch> {
     let Expr::Compare(cmp) = test else {
         return None;
     };
@@ -166,10 +194,10 @@ fn identify_dead_branch(test: &Expr) -> Option<DeadBranch> {
 
     // Check for `sys.version_info <op> (major, minor[, micro])`.
     if is_version_info_attr(left) {
-        return check_version_guard(*op, right);
+        return check_version_guard(*op, right, target);
     }
     if is_version_info_attr(right) {
-        return check_version_guard(flip_op(*op), left);
+        return check_version_guard(flip_op(*op), left, target);
     }
 
     // Check for `sys.platform <op> "string"`.
@@ -220,11 +248,10 @@ fn flip_op(op: CmpOp) -> CmpOp {
 
 /// Parse a version tuple `(major, minor)` or `(major, minor, micro)` from an
 /// expression and determine dead branch.
-fn check_version_guard(op: CmpOp, version_expr: &Expr) -> Option<DeadBranch> {
+fn check_version_guard(op: CmpOp, version_expr: &Expr, target: (u32, u32)) -> Option<DeadBranch> {
     let version = parse_version_tuple(version_expr)?;
 
-    // Compare target version against the guard version.
-    let target = (TARGET_VERSION.0, TARGET_VERSION.1);
+    // Compare the configured target version against the guard version.
     let guard = (version.0, version.1);
 
     let condition_true = match op {
@@ -300,8 +327,8 @@ fn collect_assignments(stmts: &[Stmt], out: &mut HashSet<String>) {
     for stmt in stmts {
         match stmt {
             Stmt::Assign(assign) => {
-                for target in &assign.targets {
-                    if let Expr::Name(name) = target {
+                for assign_target in &assign.targets {
+                    if let Expr::Name(name) = assign_target {
                         let _ = out.insert(name.id.to_string());
                     }
                 }
@@ -321,6 +348,7 @@ fn check_expr_for_dead_var_usage(
     expr: &Expr,
     dead_vars: &HashSet<String>,
     live_vars: &HashSet<String>,
+    target: (u32, u32),
     path: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -342,7 +370,7 @@ fn check_expr_for_dead_var_usage(
                     Some(format!(
                         "`{var_name}` is assigned in a branch that is unreachable \
                          for the target Python version ({}.{})",
-                        TARGET_VERSION.0, TARGET_VERSION.1
+                        target.0, target.1
                     )),
                     Some(
                         "PEP 484: type checkers should evaluate version/platform guards \
@@ -353,13 +381,27 @@ fn check_expr_for_dead_var_usage(
             }
         }
         Expr::Call(call) => {
-            check_expr_for_dead_var_usage(&call.func, dead_vars, live_vars, path, diagnostics);
+            check_expr_for_dead_var_usage(
+                &call.func,
+                dead_vars,
+                live_vars,
+                target,
+                path,
+                diagnostics,
+            );
             for arg in &call.arguments.args {
-                check_expr_for_dead_var_usage(arg, dead_vars, live_vars, path, diagnostics);
+                check_expr_for_dead_var_usage(arg, dead_vars, live_vars, target, path, diagnostics);
             }
         }
         Expr::Attribute(attr) => {
-            check_expr_for_dead_var_usage(&attr.value, dead_vars, live_vars, path, diagnostics);
+            check_expr_for_dead_var_usage(
+                &attr.value,
+                dead_vars,
+                live_vars,
+                target,
+                path,
+                diagnostics,
+            );
         }
         _ => {}
     }

--- a/crates/basilisk-checker/src/rules/e0151.rs
+++ b/crates/basilisk-checker/src/rules/e0151.rs
@@ -42,7 +42,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct TypeAliasTypeViolation;
 
 impl Rule for TypeAliasTypeViolation {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         for violation in &module.type_alias_type_violations {
             let (message, help) = match &violation.kind {
                 TypeAliasTypeViolationKind::InvalidTypeExpression => (

--- a/crates/basilisk-checker/src/rules/e0152/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0152/mod.rs
@@ -36,7 +36,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct MissingTypeStubs;
 
 impl Rule for MissingTypeStubs {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .imports
             .iter()

--- a/crates/basilisk-checker/src/rules/e0152/tests.rs
+++ b/crates/basilisk-checker/src/rules/e0152/tests.rs
@@ -37,7 +37,11 @@ fn make_import(
 fn run_check(import: ImportInfo) -> Vec<crate::Diagnostic> {
     let module = make_module(vec![import]);
     let mut diagnostics = Vec::new();
-    MissingTypeStubs.check(&module, &mut diagnostics);
+    MissingTypeStubs.check(
+        &module,
+        &crate::context::CheckContext::default(),
+        &mut diagnostics,
+    );
     diagnostics
 }
 
@@ -219,7 +223,11 @@ fn skips_site_packages_package_with_py_typed_marker() -> Result<(), Box<dyn std:
     let module = make_module(vec![import]);
     let mut diagnostics = Vec::new();
 
-    MissingTypeStubs.check(&module, &mut diagnostics);
+    MissingTypeStubs.check(
+        &module,
+        &crate::context::CheckContext::default(),
+        &mut diagnostics,
+    );
 
     assert!(
         diagnostics.is_empty(),
@@ -266,7 +274,11 @@ fn skips_nested_submodule_when_root_package_has_py_typed() -> Result<(), Box<dyn
     let module = make_module(vec![import]);
     let mut diagnostics = Vec::new();
 
-    MissingTypeStubs.check(&module, &mut diagnostics);
+    MissingTypeStubs.check(
+        &module,
+        &crate::context::CheckContext::default(),
+        &mut diagnostics,
+    );
 
     assert!(
         diagnostics.is_empty(),
@@ -315,7 +327,11 @@ fn skips_flat_file_submodule_when_root_package_has_py_typed(
     let module = make_module(vec![import]);
     let mut diagnostics = Vec::new();
 
-    MissingTypeStubs.check(&module, &mut diagnostics);
+    MissingTypeStubs.check(
+        &module,
+        &crate::context::CheckContext::default(),
+        &mut diagnostics,
+    );
 
     assert!(
         diagnostics.is_empty(),
@@ -361,7 +377,11 @@ fn skips_deeper_nested_submodule_when_root_package_has_py_typed(
     let module = make_module(vec![import]);
     let mut diagnostics = Vec::new();
 
-    MissingTypeStubs.check(&module, &mut diagnostics);
+    MissingTypeStubs.check(
+        &module,
+        &crate::context::CheckContext::default(),
+        &mut diagnostics,
+    );
 
     assert!(
         diagnostics.is_empty(),
@@ -406,7 +426,11 @@ fn skips_httpx_underscore_flat_submodule_when_root_has_py_typed(
     let module = make_module(vec![import]);
     let mut diagnostics = Vec::new();
 
-    MissingTypeStubs.check(&module, &mut diagnostics);
+    MissingTypeStubs.check(
+        &module,
+        &crate::context::CheckContext::default(),
+        &mut diagnostics,
+    );
 
     assert!(
         diagnostics.is_empty(),

--- a/crates/basilisk-checker/src/rules/e0153.rs
+++ b/crates/basilisk-checker/src/rules/e0153.rs
@@ -47,7 +47,12 @@ type MethodMap<'a> = HashMap<(&'a str, &'a str), Vec<&'a FunctionInfo>>;
 pub(crate) struct ConstructorCallableMisuse;
 
 impl Rule for ConstructorCallableMisuse {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         let source = &module.source;
         let Ok(parsed) = basilisk_parser::parse_source(source.clone(), module.path.clone()) else {
             return;

--- a/crates/basilisk-checker/src/rules/e0154/mod.rs
+++ b/crates/basilisk-checker/src/rules/e0154/mod.rs
@@ -65,7 +65,12 @@ const MODULE_DUNDERS: &[&str] = &[
 pub(crate) struct ModuleAttributeUndefined;
 
 impl Rule for ModuleAttributeUndefined {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Only projects with user/local stubs populate `imported_modules`, so
         // this short-circuits (and parses nothing) everywhere else.
         if module.imported_modules.is_empty() {

--- a/crates/basilisk-checker/src/rules/e0154/tests.rs
+++ b/crates/basilisk-checker/src/rules/e0154/tests.rs
@@ -35,7 +35,11 @@ fn run(source: &str, imported_modules: HashMap<String, ImportedModuleApi>) -> Ve
         ..ResolvedModule::default()
     };
     let mut diagnostics = Vec::new();
-    ModuleAttributeUndefined.check(&module, &mut diagnostics);
+    ModuleAttributeUndefined.check(
+        &module,
+        &crate::context::CheckContext::default(),
+        &mut diagnostics,
+    );
     diagnostics
 }
 

--- a/crates/basilisk-checker/src/rules/e0155.rs
+++ b/crates/basilisk-checker/src/rules/e0155.rs
@@ -1,0 +1,97 @@
+//! Implements [BSK-E0155] from [CHKARCH-VERSION-TARGET]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-VERSION-TARGET
+//! BSK-E0155: PEP 695 syntax used below the configured target version.
+//!
+//! `type X = ...` aliases and `class Foo[T]` / `def f[T]()` type-parameter
+//! lists are Python 3.12+ syntax (PEP 695). When the configured
+//! `python_version` targets anything older, the file cannot even be parsed by
+//! the target interpreter, so this fires as an error (issue #93).
+//!
+//! ```python
+//! # python_version = "3.11"
+//! type Alias = int          # E0155 — `type` statement requires 3.12+
+//! class Box[T]: ...         # E0155 — PEP 695 type params require 3.12+
+//! def first[T](x: T) -> T:  # E0155 — PEP 695 type params require 3.12+
+//! ```
+
+use basilisk_resolver::{GenericDefKind, ResolvedModule};
+
+use crate::diagnostic::{error_diagnostic_owned, Diagnostic, ErrorCode};
+
+use super::{CheckContext, Rule};
+
+const CODE: ErrorCode = ErrorCode {
+    code: "BSK-E0155",
+    docs_url: "https://www.basilisk-python.dev/errors/BSK-E0155",
+};
+
+/// The first Python version with native PEP 695 syntax.
+const PEP695_MIN_VERSION: (u32, u32) = (3, 12);
+
+/// Emits BSK-E0155 for PEP 695 syntax on sub-3.12 targets.
+pub(crate) struct Pep695BelowTargetViolation;
+
+impl Rule for Pep695BelowTargetViolation {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        ctx: &CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        if ctx.target_version >= PEP695_MIN_VERSION {
+            return;
+        }
+
+        let target = ctx.target_version;
+        for alias in &module.pep695_scoping.aliases {
+            diagnostics.push(make_diagnostic(
+                &format!(
+                    "PEP 695 `type {}` alias statement requires Python 3.12+",
+                    alias.name
+                ),
+                alias.name_span,
+                target,
+                &module.path,
+            ));
+        }
+        for def in &module.pep695_scoping.defs {
+            let kind = match def.kind {
+                GenericDefKind::Class => "class",
+                GenericDefKind::Function => "def",
+            };
+            diagnostics.push(make_diagnostic(
+                &format!(
+                    "PEP 695 type parameter list on `{kind} {}` requires Python 3.12+",
+                    def.name
+                ),
+                def.name_span,
+                target,
+                &module.path,
+            ));
+        }
+    }
+}
+
+/// Build the E0155 diagnostic with target-version remediation.
+fn make_diagnostic(
+    message: &str,
+    span: basilisk_resolver::Span,
+    target: (u32, u32),
+    path: &str,
+) -> Diagnostic {
+    error_diagnostic_owned(
+        CODE.clone(),
+        message.to_owned(),
+        span,
+        path,
+        Some(format!(
+            "the configured target is Python {}.{} — use `TypeVar`/`TypeAlias` from \
+             `typing` (or `typing_extensions`), or raise `python_version` to 3.12+",
+            target.0, target.1
+        )),
+        Some(
+            "PEP 695 syntax is a parse error on interpreters older than 3.12, so code \
+             using it cannot run on the configured target"
+                .to_owned(),
+        ),
+    )
+}

--- a/crates/basilisk-checker/src/rules/mod.rs
+++ b/crates/basilisk-checker/src/rules/mod.rs
@@ -160,6 +160,7 @@ pub(crate) mod e0151;
 pub(crate) mod e0152;
 pub(crate) mod e0153;
 pub(crate) mod e0154;
+pub(crate) mod e0155;
 pub(crate) mod guards;
 pub(crate) mod shared;
 pub(crate) mod w0011;
@@ -172,10 +173,15 @@ use basilisk_resolver::ResolvedModule;
 
 use crate::diagnostic::Diagnostic;
 
+pub use crate::context::CheckContext;
+
 /// A single type checking rule.
 pub(crate) trait Rule {
     /// Run the rule against a resolved module and push any diagnostics.
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>);
+    ///
+    /// `ctx` carries the configured target version/platform
+    /// ([CHKARCH-VERSION-TARGET]) so rules never hardcode a Python version.
+    fn check(&self, module: &ResolvedModule, ctx: &CheckContext, diagnostics: &mut Vec<Diagnostic>);
 }
 
 /// All registered Phase 1 rules.
@@ -332,6 +338,7 @@ fn all_rules() -> &'static [&'static dyn Rule] {
         &e0152::MissingTypeStubs,
         &e0153::ConstructorCallableMisuse,
         &e0154::ModuleAttributeUndefined,
+        &e0155::Pep695BelowTargetViolation,
         &w0011::UndeclaredDependencyImport,
         &w0012::UnusedDependency,
         &w0013::StaleLockFile,
@@ -342,9 +349,9 @@ fn all_rules() -> &'static [&'static dyn Rule] {
 
 /// Run all registered Phase 1 rules against a resolved module.
 #[must_use]
-pub fn run_all(module: &ResolvedModule) -> Vec<Diagnostic> {
+pub fn run_all(module: &ResolvedModule, ctx: &CheckContext) -> Vec<Diagnostic> {
     all_rules().iter().fold(Vec::new(), |mut acc, rule| {
-        rule.check(module, &mut acc);
+        rule.check(module, ctx, &mut acc);
         acc
     })
 }

--- a/crates/basilisk-checker/src/rules/w0011.rs
+++ b/crates/basilisk-checker/src/rules/w0011.rs
@@ -28,7 +28,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct UndeclaredDependencyImport;
 
 impl Rule for UndeclaredDependencyImport {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         module
             .imports
             .iter()
@@ -99,7 +104,11 @@ mod tests {
     fn run_check(import: ImportInfo) -> Vec<crate::Diagnostic> {
         let module = make_module(vec![import]);
         let mut diagnostics = Vec::new();
-        UndeclaredDependencyImport.check(&module, &mut diagnostics);
+        UndeclaredDependencyImport.check(
+            &module,
+            &crate::context::CheckContext::default(),
+            &mut diagnostics,
+        );
         diagnostics
     }
 

--- a/crates/basilisk-checker/src/rules/w0012.rs
+++ b/crates/basilisk-checker/src/rules/w0012.rs
@@ -61,7 +61,12 @@ impl UnusedDependency {
 }
 
 impl Rule for UnusedDependency {
-    fn check(&self, _module: &ResolvedModule, _diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        _module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        _diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Skeleton: this rule requires workspace-level data to determine which
         // declared dependencies are never imported across all files. It will be
         // activated when the workspace layer provides aggregate import sets.
@@ -90,7 +95,11 @@ mod tests {
     fn does_not_fire_without_workspace_data() {
         let module = make_module();
         let mut diagnostics = Vec::new();
-        UnusedDependency.check(&module, &mut diagnostics);
+        UnusedDependency.check(
+            &module,
+            &crate::context::CheckContext::default(),
+            &mut diagnostics,
+        );
         assert!(diagnostics.is_empty());
     }
 

--- a/crates/basilisk-checker/src/rules/w0013.rs
+++ b/crates/basilisk-checker/src/rules/w0013.rs
@@ -56,7 +56,12 @@ impl StaleLockFile {
 }
 
 impl Rule for StaleLockFile {
-    fn check(&self, _module: &ResolvedModule, _diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        _module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        _diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Skeleton: once the workspace layer provides lock-file staleness
         // information (e.g. via a field on ResolvedModule or a shared context),
         // this rule will compare mtimes and emit a diagnostic when uv.lock is
@@ -81,7 +86,11 @@ mod tests {
     fn does_not_fire_without_staleness_data() {
         let module = make_module();
         let mut diagnostics = Vec::new();
-        StaleLockFile.check(&module, &mut diagnostics);
+        StaleLockFile.check(
+            &module,
+            &crate::context::CheckContext::default(),
+            &mut diagnostics,
+        );
         assert!(diagnostics.is_empty());
     }
 

--- a/crates/basilisk-checker/src/rules/w0040.rs
+++ b/crates/basilisk-checker/src/rules/w0040.rs
@@ -28,7 +28,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct LambdaMissingAnnotations;
 
 impl Rule for LambdaMissingAnnotations {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Module-level: `f = lambda x: x + 1` without annotation
         for var in &module.module_vars {
             if var.rhs_kind == RhsKind::Lambda && !var.has_annotation {

--- a/crates/basilisk-checker/src/rules/w0050.rs
+++ b/crates/basilisk-checker/src/rules/w0050.rs
@@ -28,7 +28,12 @@ const CODE: ErrorCode = ErrorCode {
 pub(crate) struct RedundantAnnotationWarning;
 
 impl Rule for RedundantAnnotationWarning {
-    fn check(&self, module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
         // Check module-level variables
         module
             .module_vars
@@ -74,7 +79,8 @@ impl Rule for RedundantAnnotationWarning {
                     base.contains("TypedDict")
                         || base.contains("Protocol")
                         || base.contains("NamedTuple")
-                }) && !is_namedtuple_subclass(class, &module.classes)
+                }) && !transitively_inherits(class, &module.classes, &is_namedtuple_base)
+                    && !annotation_defines_field(class, &module.classes)
             })
             .flat_map(|class| &class.attributes)
             .filter(|attr| attr.has_annotation && attr.has_value)
@@ -250,24 +256,62 @@ fn make_diagnostic_for_var(
     )
 }
 
-/// Check if a class transitively inherits from a `NamedTuple` class.
+/// Whether annotated assignments in this class declare *fields* rather than
+/// plain attributes (issue #110).
 ///
-/// This catches subclasses like `class PointWithName(Point)` where `Point` itself
-/// inherits from `NamedTuple`.
-fn is_namedtuple_subclass(
+/// For `pydantic.BaseModel` subclasses, `@dataclass` classes (including
+/// `dataclass_transform` factories), and attrs-style classes, the annotation is
+/// what makes the assignment a field — removing it silently deletes the field
+/// from validation/serialization or the generated `__init__`. W0050 must never
+/// call such an annotation redundant.
+fn annotation_defines_field(
     class: &basilisk_resolver::ClassInfo,
     all_classes: &[basilisk_resolver::ClassInfo],
 ) -> bool {
+    class.is_dataclass
+        || has_attrs_class_decorator(class)
+        || transitively_inherits(class, all_classes, &is_pydantic_model_base)
+}
+
+/// attrs-style class decorators (`@define`, `@frozen`, `@mutable`, `@attr.s`,
+/// `@attr.attrs`, …). The resolver records only the final name segment, so
+/// `@attr.s` arrives as `"s"` and `@attrs.define` as `"define"`. A stray match
+/// merely suppresses a warning — safe — whereas a miss corrupts a model.
+fn has_attrs_class_decorator(class: &basilisk_resolver::ClassInfo) -> bool {
+    class.decorator_spans.iter().any(|(name, _)| {
+        matches!(
+            name.as_str(),
+            "define" | "frozen" | "mutable" | "attrs" | "s"
+        )
+    })
+}
+
+fn is_namedtuple_base(base: &str) -> bool {
+    base == "NamedTuple"
+}
+
+fn is_pydantic_model_base(base: &str) -> bool {
+    base == "BaseModel" || base.ends_with(".BaseModel")
+}
+
+/// Check if a class transitively inherits from a base matching `is_marker_base`,
+/// directly or via locally-defined intermediate classes.
+///
+/// This catches subclasses like `class PointWithName(Point)` where `Point` itself
+/// inherits from the marker base.
+fn transitively_inherits(
+    class: &basilisk_resolver::ClassInfo,
+    all_classes: &[basilisk_resolver::ClassInfo],
+    is_marker_base: &dyn Fn(&str) -> bool,
+) -> bool {
     for base in &class.bases {
         let stripped = base.split('[').next().unwrap_or(base.as_str());
+        if is_marker_base(stripped) {
+            return true;
+        }
         for other in all_classes {
-            if other.name == stripped {
-                if other.bases.iter().any(|b| b == "NamedTuple") {
-                    return true;
-                }
-                if is_namedtuple_subclass(other, all_classes) {
-                    return true;
-                }
+            if other.name == stripped && transitively_inherits(other, all_classes, is_marker_base) {
+                return true;
             }
         }
     }

--- a/crates/basilisk-checker/tests/categorical_tests.rs
+++ b/crates/basilisk-checker/tests/categorical_tests.rs
@@ -22,3 +22,5 @@ mod redundant_annotation;
 mod rules_coverage;
 #[path = "checker/suppression_tests.rs"]
 mod suppression;
+#[path = "checker/version_target_tests.rs"]
+mod version_target;

--- a/crates/basilisk-checker/tests/checker/version_target_tests.rs
+++ b/crates/basilisk-checker/tests/checker/version_target_tests.rs
@@ -1,0 +1,131 @@
+//! Tests for [CHKARCH-VERSION-TARGET] / [CHKARCH-VERSION-NARROWING].
+//! See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-VERSION-TARGET
+//!
+//! Issue #93: the configured `python_version` must reach every rule. BSK-E0150
+//! dead-branch analysis and the BSK-E0155 PEP 695 syntax gate must follow the
+//! *configured* target, not a hardcoded 3.12.
+
+use super::common::*;
+
+/// A guard whose dead branch flips with the target version: on 3.12 the
+/// if-body is dead (`val`), on 3.9 the else-body is dead (`other`).
+const VERSION_GUARD_SOURCE: &str = concat!(
+    "import sys\n",
+    "\n",
+    "def f():\n",
+    "    if sys.version_info < (3, 10):\n",
+    "        val = \"\"\n",
+    "    else:\n",
+    "        other = \"\"\n",
+    "    print(val)\n",
+    "    print(other)\n",
+);
+
+fn run_with_python_version(source: &str, version: &str) -> Vec<Diagnostic> {
+    let parsed = parse_source(source.to_owned(), "test.py".to_owned()).unwrap();
+    let resolved = resolve(&parsed).unwrap();
+    let config = basilisk_config::BasiliskConfig {
+        python_version: Some(version.to_owned()),
+        ..Default::default()
+    };
+    basilisk_checker::check_with_config(&resolved, &config)
+}
+
+#[test]
+fn test_e0150_default_target_flags_sub_3_10_branch() {
+    let diags = run(VERSION_GUARD_SOURCE).unwrap();
+    let messages = messages_for(&diags, "BSK-E0150");
+    assert!(
+        messages.iter().any(|m| m.contains("`val`")),
+        "on the default 3.12 target the `< (3, 10)` body is dead: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("`other`")),
+        "the else body is live on 3.12: {messages:?}"
+    );
+}
+
+#[test]
+fn test_e0150_follows_configured_3_9_target() {
+    let diags = run_with_python_version(VERSION_GUARD_SOURCE, "3.9");
+    let messages = messages_for(&diags, "BSK-E0150");
+    assert!(
+        messages.iter().any(|m| m.contains("`other`")),
+        "on a 3.9 target the else body is dead: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("`val`")),
+        "the `< (3, 10)` body is live on 3.9 — flagging it is a false positive: {messages:?}"
+    );
+}
+
+#[test]
+fn test_e0155_pep695_type_alias_below_3_12() {
+    let diags = run_with_python_version("type Alias = int\n", "3.11");
+    assert!(
+        has_code(&diags, "BSK-E0155"),
+        "PEP 695 `type` statement requires Python 3.12+, target is 3.11"
+    );
+}
+
+#[test]
+fn test_e0155_pep695_generic_class_below_3_12() {
+    let diags = run_with_python_version("class Box[T]:\n    pass\n", "3.10");
+    assert!(
+        has_code(&diags, "BSK-E0155"),
+        "PEP 695 `class Box[T]` requires Python 3.12+, target is 3.10"
+    );
+}
+
+#[test]
+fn test_e0155_pep695_generic_function_below_3_12() {
+    let diags = run_with_python_version(
+        "def first[T](items: list[T]) -> T:\n    return items[0]\n",
+        "3.11",
+    );
+    assert!(
+        has_code(&diags, "BSK-E0155"),
+        "PEP 695 `def first[T]` requires Python 3.12+, target is 3.11"
+    );
+}
+
+#[test]
+fn test_e0155_silent_on_3_12_target() {
+    let diags = run_with_python_version(
+        "type Alias = int\nclass Box[T]:\n    pass\ndef first[T](items: list[T]) -> T:\n    return items[0]\n",
+        "3.12",
+    );
+    assert!(
+        !has_code(&diags, "BSK-E0155"),
+        "PEP 695 syntax is native on 3.12 — no diagnostic"
+    );
+}
+
+#[test]
+fn test_e0155_silent_without_configured_version() {
+    // The centralized default target is 3.12 — PEP 695 is allowed.
+    let diags = run("type Alias = int\n").unwrap();
+    assert!(!has_code(&diags, "BSK-E0155"));
+}
+
+#[test]
+fn test_python_version_parsed_from_pyproject() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("pyproject.toml");
+    std::fs::write(
+        &path,
+        "[tool.basilisk]\npython-version = \"3.9\"\npython-platform = \"linux\"\n",
+    )
+    .unwrap();
+    let config = basilisk_config::load_basilisk_config(dir.path());
+    assert_eq!(config.python_version.as_deref(), Some("3.9"));
+    assert_eq!(config.python_platform.as_deref(), Some("linux"));
+}
+
+#[test]
+fn test_malformed_python_version_falls_back_to_default() {
+    // An unparsable version must behave exactly like the 3.12 default,
+    // not panic and not produce spurious version gating.
+    let diags = run_with_python_version("type Alias = int\n", "not-a-version");
+    assert!(!has_code(&diags, "BSK-E0155"));
+}

--- a/crates/basilisk-checker/tests/checker/w0050_tests.rs
+++ b/crates/basilisk-checker/tests/checker/w0050_tests.rs
@@ -109,3 +109,94 @@ fn test_w0050_tuple_literal_no_warning() {
     // Collection types rarely match exactly due to inference differences
     assert!(!diags.iter().any(|d| d.code.code == "BSK-W0050"));
 }
+
+// Issue #110: the annotation on a Pydantic/dataclass/attrs field is load-bearing —
+// removing it deletes the field. W0050 must never fire there.
+
+#[test]
+fn test_w0050_pydantic_basemodel_field_not_flagged() {
+    let diags = run(concat!(
+        "from pydantic import BaseModel\n",
+        "class ToolResultIn(BaseModel):\n",
+        "    ok: bool = True\n",
+    ))
+    .unwrap();
+    assert!(
+        !diags.iter().any(|d| d.code.code == "BSK-W0050"),
+        "W0050 on a BaseModel field deletes the field when autofixed"
+    );
+}
+
+#[test]
+fn test_w0050_pydantic_basemodel_transitive_subclass_field_not_flagged() {
+    let diags = run(concat!(
+        "from pydantic import BaseModel\n",
+        "class Base(BaseModel):\n",
+        "    name: str = \"x\"\n",
+        "class Child(Base):\n",
+        "    count: int = 0\n",
+    ))
+    .unwrap();
+    assert!(
+        !diags.iter().any(|d| d.code.code == "BSK-W0050"),
+        "W0050 on a transitive BaseModel subclass field deletes the field when autofixed"
+    );
+}
+
+#[test]
+fn test_w0050_dataclass_field_not_flagged() {
+    let diags = run(concat!(
+        "from dataclasses import dataclass\n",
+        "@dataclass(frozen=True, kw_only=True)\n",
+        "class GitOutcome:\n",
+        "    committed: bool = False\n",
+    ))
+    .unwrap();
+    assert!(
+        !diags.iter().any(|d| d.code.code == "BSK-W0050"),
+        "W0050 on a dataclass field turns an init param into an inert class attribute"
+    );
+}
+
+#[test]
+fn test_w0050_dataclasses_dotted_decorator_field_not_flagged() {
+    let diags = run(concat!(
+        "import dataclasses\n",
+        "@dataclasses.dataclass\n",
+        "class Manifest:\n",
+        "    method: str = \"POST\"\n",
+    ))
+    .unwrap();
+    assert!(!diags.iter().any(|d| d.code.code == "BSK-W0050"));
+}
+
+#[test]
+fn test_w0050_attrs_define_field_not_flagged() {
+    let diags = run(concat!(
+        "from attrs import define\n",
+        "@define\n",
+        "class AuthContext:\n",
+        "    is_platform_admin: bool = False\n",
+    ))
+    .unwrap();
+    assert!(!diags.iter().any(|d| d.code.code == "BSK-W0050"));
+}
+
+#[test]
+fn test_w0050_attr_s_decorator_field_not_flagged() {
+    let diags = run(concat!(
+        "import attr\n",
+        "@attr.s(auto_attribs=True)\n",
+        "class AgentConfig:\n",
+        "    retries: int = 3\n",
+    ))
+    .unwrap();
+    assert!(!diags.iter().any(|d| d.code.code == "BSK-W0050"));
+}
+
+#[test]
+fn test_w0050_plain_class_attribute_still_flagged() {
+    // Regression guard: the exemption must not swallow plain classes.
+    let diags = run("class Plain:\n    x: int = 42\n").unwrap();
+    assert!(diags.iter().any(|d| d.code.code == "BSK-W0050"));
+}

--- a/crates/basilisk-cli/src/main.rs
+++ b/crates/basilisk-cli/src/main.rs
@@ -486,7 +486,13 @@ fn collect_and_check(
             }
         })
         .unwrap_or_else(|| std::path::PathBuf::from("."));
-    let config = basilisk_config::load_basilisk_config(&config_root);
+    let mut config = basilisk_config::load_basilisk_config(&config_root);
+    // [CHKARCH-VERSION-TARGET] Detect the target version from project files
+    // when the config does not pin one, matching the LSP (issue #93).
+    if config.python_version.is_none() {
+        config.python_version =
+            basilisk_uv::python_version::resolve_target_python_version(&config_root);
+    }
 
     let excluded: HashSet<&str> = config.exclude.iter().map(String::as_str).collect();
     info!(

--- a/crates/basilisk-config/src/parse.rs
+++ b/crates/basilisk-config/src/parse.rs
@@ -66,6 +66,19 @@ pub struct BasiliskConfig {
     /// Generated `.pyi` files are placed here and automatically included
     /// in the stub search path. Defaults to `".basilisk/stubs"`.
     pub auto_stub_path: PathBuf,
+
+    /// Target Python version for version-aware rules, e.g. `"3.9"`.
+    ///
+    /// `None` means "use the checker's centralized default" (3.12, see
+    /// `basilisk_checker::context::DEFAULT_TARGET_VERSION`). The LSP fills
+    /// this from its `[LSPUV-PYTHON-VERSION-RESOLUTION-ORDER]` cascade.
+    /// Implements [CHKARCH-VERSION-TARGET].
+    pub python_version: Option<String>,
+
+    /// Target platform for platform-aware rules: `"linux"`, `"darwin"`,
+    /// or `"win32"`. `None` means platform-neutral analysis.
+    /// Implements [CHKARCH-VERSION-TARGET].
+    pub python_platform: Option<String>,
 }
 
 impl Default for BasiliskConfig {
@@ -83,6 +96,8 @@ impl Default for BasiliskConfig {
             uv_dependency_diagnostics: false,
             auto_stub_mode: "hybrid".to_owned(),
             auto_stub_path: PathBuf::from(".basilisk/stubs"),
+            python_version: None,
+            python_platform: None,
         }
     }
 }
@@ -206,6 +221,24 @@ pub fn load_from_json(path: &Path) -> Option<BasiliskConfig> {
         cfg.auto_stub_path = PathBuf::from(val);
     }
 
+    // pythonVersion / python-version [CHKARCH-VERSION-TARGET]
+    if let Some(val) = obj
+        .get("pythonVersion")
+        .or_else(|| obj.get("python-version"))
+        .and_then(|v| v.as_str())
+    {
+        cfg.python_version = Some(val.to_owned());
+    }
+
+    // pythonPlatform / python-platform [CHKARCH-VERSION-TARGET]
+    if let Some(val) = obj
+        .get("pythonPlatform")
+        .or_else(|| obj.get("python-platform"))
+        .and_then(|v| v.as_str())
+    {
+        cfg.python_platform = Some(val.to_owned());
+    }
+
     Some(cfg)
 }
 
@@ -299,6 +332,16 @@ pub fn load_from_pyproject(path: &Path) -> Option<BasiliskConfig> {
     // auto-stub-path
     if let Some(val) = basilisk.get("auto-stub-path").and_then(|v| v.as_str()) {
         cfg.auto_stub_path = PathBuf::from(val);
+    }
+
+    // python-version [CHKARCH-VERSION-TARGET]
+    if let Some(val) = basilisk.get("python-version").and_then(|v| v.as_str()) {
+        cfg.python_version = Some(val.to_owned());
+    }
+
+    // python-platform [CHKARCH-VERSION-TARGET]
+    if let Some(val) = basilisk.get("python-platform").and_then(|v| v.as_str()) {
+        cfg.python_platform = Some(val.to_owned());
     }
 
     Some(cfg)

--- a/crates/basilisk-lsp/src/lib.rs
+++ b/crates/basilisk-lsp/src/lib.rs
@@ -59,6 +59,7 @@ pub mod type_definition;
 pub mod type_hierarchy;
 pub mod util;
 pub mod uv_commands;
+pub mod uv_failure;
 pub mod websocket;
 pub mod workspace;
 pub mod workspace_analysis;

--- a/crates/basilisk-lsp/src/profiler/helper_client/mod.rs
+++ b/crates/basilisk-lsp/src/profiler/helper_client/mod.rs
@@ -245,15 +245,23 @@ async fn handshake(
     let python_version =
         match timeout(HANDSHAKE_TIMEOUT, read_message::<_, Message>(&mut reader)).await {
             Ok(Ok(Some(Message::Attached { python, .. }))) => python,
+            Ok(Ok(Some(Message::AttachFailed { reason, .. }))) => {
+                // The helper reported the real cause (issue #81) — classify it
+                // into an actionable message instead of a bare EOF.
+                return Err(SamplerError::AttachFailed(classify_attach_failure(
+                    pid, &reason,
+                )));
+            }
             Ok(Ok(Some(Message::Samples { .. } | Message::Stopped))) => {
                 return Err(SamplerError::AttachFailed(
                     "helper sent an unexpected message before confirming attach".to_owned(),
                 ))
             }
             Ok(Ok(None)) => {
-                return Err(SamplerError::AttachFailed(
-                    "helper closed the connection before confirming attach".to_owned(),
-                ))
+                // Clean EOF without an AttachFailed report (old helper binary
+                // or a crash): harvest the helper's exit status so the cause
+                // is at least partially diagnosable (issue #81).
+                return Err(SamplerError::AttachFailed(describe_helper_eof(child).await));
             }
             Ok(Err(err)) => {
                 return Err(SamplerError::AttachFailed(format!(
@@ -274,6 +282,58 @@ async fn handshake(
         writer,
         python_version,
     })
+}
+
+/// Map the helper's raw attach-failure reason to an actionable message.
+///
+/// Distinguishes the three failure modes from issue #81: target gone,
+/// permission denied (needs elevation), and any other py-spy attach error.
+fn classify_attach_failure(pid: u32, reason: &str) -> String {
+    let lowered = reason.to_lowercase();
+    if lowered.contains("no such process")
+        || lowered.contains("no process found")
+        || lowered.contains("process exited")
+        || lowered.contains("esrch")
+    {
+        return format!(
+            "target process (PID {pid}) is no longer running — it may have exited \
+             before the profiler could attach. Underlying error: {reason}"
+        );
+    }
+    if lowered.contains("permission denied")
+        || lowered.contains("operation not permitted")
+        || lowered.contains("task_for_pid")
+        || lowered.contains("access is denied")
+    {
+        return format!(
+            "permission denied attaching to PID {pid} — profiling another \
+             process requires elevated privileges on this platform. \
+             Underlying error: {reason}"
+        );
+    }
+    format!("helper could not attach to PID {pid}: {reason}")
+}
+
+/// Describe a helper that hit EOF before confirming attach, harvesting its
+/// exit status when it terminates promptly.
+async fn describe_helper_eof(mut child: tokio::process::Child) -> String {
+    let exit = timeout(Duration::from_secs(2), child.wait()).await;
+    match exit {
+        Ok(Ok(status)) => format!(
+            "helper closed the connection before confirming attach \
+             (helper exit status: {status}); check the helper's stderr in the log"
+        ),
+        Ok(Err(err)) => format!(
+            "helper closed the connection before confirming attach \
+             (could not read helper exit status: {err})"
+        ),
+        Err(_elapsed) => {
+            let _ = child.start_kill();
+            "helper closed the connection before confirming attach \
+             (helper still running; killed)"
+                .to_owned()
+        }
+    }
 }
 
 /// Spawn the helper process per the requested mode (detached — never awaited).
@@ -414,6 +474,10 @@ async fn read_until_stopped(
             }
             Ok(Some(Message::Stopped) | None) => break,
             Ok(Some(Message::Attached { .. })) => {}
+            Ok(Some(Message::AttachFailed { reason, .. })) => {
+                warn!(pid, %reason, "helper reported attach failure mid-stream");
+                break;
+            }
             Err(err) => {
                 warn!(%err, "error reading from profiler helper");
                 break;

--- a/crates/basilisk-lsp/src/server/uv_handlers.rs
+++ b/crates/basilisk-lsp/src/server/uv_handlers.rs
@@ -144,56 +144,87 @@ fn spawn_error(label: &str, err: &std::io::Error) -> tower_lsp::jsonrpc::Error {
 ///
 /// After any successful uv command, the lock file may have changed,
 /// so we rebuild the package registry and re-resolve all imports.
+///
+/// Failures are classified per [LSPUV-COMMAND-FAILURE-UX] (issue #94): the
+/// toast carries a plain-language headline + remediation, while the full uv
+/// stderr stays in the Output channel via `log_message`.
 async fn run_uv_and_refresh<F, Fut>(
     server: &LspServer,
     label: &str,
+    package: Option<&str>,
     command: F,
 ) -> LspResult<Option<serde_json::Value>>
 where
     F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = std::io::Result<crate::uv_commands::UvCommandResult>>,
 {
+    let started = std::time::Instant::now();
     match command().await {
         Ok(result) => {
-            let msg = if result.success {
-                format!("{label} completed successfully")
-            } else {
-                // Strip ANSI escapes — uv emits coloured errors and the
-                // VS Code output channel renders the raw codes (issue #23).
-                let stderr_clean = strip_ansi(result.stderr.trim());
-                if stderr_clean.is_empty() {
-                    format!("{label} failed")
-                } else {
-                    format!("{label} failed: {stderr_clean}")
-                }
-            };
-            let msg_type = if result.success {
-                MessageType::INFO
-            } else {
-                MessageType::ERROR
-            };
-            server
-                .client
-                .log_message(msg_type, format!("Basilisk: {msg}"))
-                .await;
-
-            // Show error to user in the UI (not just the output panel).
-            if !result.success {
+            let duration_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+            if result.success {
+                info!(
+                    command = label,
+                    package = package.unwrap_or(""),
+                    duration_ms,
+                    "uv command succeeded"
+                );
                 server
                     .client
-                    .show_message(MessageType::ERROR, format!("Basilisk: {msg}"))
+                    .log_message(
+                        MessageType::INFO,
+                        format!("Basilisk: {label} completed successfully"),
+                    )
                     .await;
+                // Rebuild registry and re-resolve imports on success.
+                super::init::rebuild_registry_and_resolve(server).await;
+                return Ok(Some(uv_result_to_json(&result)));
             }
 
-            // Rebuild registry and re-resolve imports on success.
-            if result.success {
-                super::init::rebuild_registry_and_resolve(server).await;
-            }
+            // Strip ANSI escapes — uv emits coloured errors and the
+            // VS Code output channel renders the raw codes (issue #23).
+            let stderr_clean = strip_ansi(result.stderr.trim());
+            let failure = crate::uv_failure::classify_uv_failure(label, package, &stderr_clean);
+            warn!(
+                command = label,
+                package = package.unwrap_or(""),
+                exit_code = result.exit_code.unwrap_or(-1),
+                failure_category = failure.category.as_str(),
+                duration_ms,
+                "uv command failed"
+            );
+
+            // Output channel keeps the FULL uv stderr — power users lose nothing.
+            server
+                .client
+                .log_message(
+                    MessageType::ERROR,
+                    format!("Basilisk: {label} failed:\n{stderr_clean}"),
+                )
+                .await;
+
+            // The toast is the classified headline + remediation, never the
+            // raw resolver dump.
+            server
+                .client
+                .show_message(MessageType::ERROR, format!("Basilisk: {}", failure.message))
+                .await;
 
             Ok(Some(uv_result_to_json(&result)))
         }
         Err(err) => {
-            error!(%err, "{label} failed to spawn");
+            let failure = crate::uv_failure::classify_uv_spawn_failure(&err);
+            error!(
+                command = label,
+                package = package.unwrap_or(""),
+                failure_category = failure.category.as_str(),
+                %err,
+                "uv command failed to spawn"
+            );
+            server
+                .client
+                .show_message(MessageType::ERROR, format!("Basilisk: {}", failure.message))
+                .await;
             Err(spawn_error(label, &err))
         }
     }
@@ -231,7 +262,10 @@ pub(super) async fn execute_uv_sync(
         return no_uv_project_response(server, "uv sync").await;
     };
     info!("uv sync requested");
-    run_uv_and_refresh(server, "uv sync", || crate::uv_commands::uv_sync(&root)).await
+    run_uv_and_refresh(server, "uv sync", None, || {
+        crate::uv_commands::uv_sync(&root)
+    })
+    .await
 }
 
 /// Handle `basilisk.uv.add`.
@@ -247,7 +281,7 @@ pub(super) async fn execute_uv_add(
         return Ok(None);
     };
     info!(package = %package, "uv add requested");
-    run_uv_and_refresh(server, &format!("uv add {package}"), || {
+    run_uv_and_refresh(server, &format!("uv add {package}"), Some(&package), || {
         crate::uv_commands::uv_add(&root, &package)
     })
     .await
@@ -266,9 +300,12 @@ pub(super) async fn execute_uv_add_dev(
         return Ok(None);
     };
     info!(package = %package, "uv add --dev requested");
-    run_uv_and_refresh(server, &format!("uv add --dev {package}"), || {
-        crate::uv_commands::uv_add_dev(&root, &package)
-    })
+    run_uv_and_refresh(
+        server,
+        &format!("uv add --dev {package}"),
+        Some(&package),
+        || crate::uv_commands::uv_add_dev(&root, &package),
+    )
     .await
 }
 
@@ -285,9 +322,12 @@ pub(super) async fn execute_uv_remove(
         return Ok(None);
     };
     info!(package = %package, "uv remove requested");
-    run_uv_and_refresh(server, &format!("uv remove {package}"), || {
-        crate::uv_commands::uv_remove(&root, &package)
-    })
+    run_uv_and_refresh(
+        server,
+        &format!("uv remove {package}"),
+        Some(&package),
+        || crate::uv_commands::uv_remove(&root, &package),
+    )
     .await
 }
 
@@ -300,7 +340,10 @@ pub(super) async fn execute_uv_lock(
         return no_uv_project_response(server, "uv lock").await;
     };
     info!("uv lock requested");
-    run_uv_and_refresh(server, "uv lock", || crate::uv_commands::uv_lock(&root)).await
+    run_uv_and_refresh(server, "uv lock", None, || {
+        crate::uv_commands::uv_lock(&root)
+    })
+    .await
 }
 
 /// Handle `basilisk.uv.createEnv`.
@@ -330,7 +373,7 @@ pub(super) async fn execute_uv_create_env(
     });
     let pv = python_version.map(String::from);
     info!(python_version = ?pv, "uv venv requested");
-    run_uv_and_refresh(server, "uv venv", || {
+    run_uv_and_refresh(server, "uv venv", None, || {
         crate::uv_commands::uv_create_env(&root, pv.as_deref())
     })
     .await
@@ -374,6 +417,7 @@ mod tests {
             success: true,
             stdout: "ok".to_owned(),
             stderr: String::new(),
+            exit_code: Some(0),
         };
         let json = uv_result_to_json(&result);
         assert_eq!(json["success"], true);

--- a/crates/basilisk-lsp/src/uv_commands.rs
+++ b/crates/basilisk-lsp/src/uv_commands.rs
@@ -20,6 +20,9 @@ pub struct UvCommandResult {
     pub stdout: String,
     /// Combined stderr output.
     pub stderr: String,
+    /// Process exit code, if the process exited normally.
+    /// Logged as a structured field on failure ([LSPUV-COMMAND-FAILURE-UX]).
+    pub exit_code: Option<i32>,
 }
 
 /// Check if `uv` is available on `PATH`.
@@ -146,6 +149,7 @@ async fn run_uv(project_root: &Path, args: &[&str]) -> Result<UvCommandResult, s
         success,
         stdout,
         stderr,
+        exit_code: output.status.code(),
     })
 }
 
@@ -165,6 +169,7 @@ mod tests {
             success: true,
             stdout: "ok".to_owned(),
             stderr: String::new(),
+            exit_code: Some(0),
         };
         let debug_output = format!("{result:?}");
         assert!(debug_output.contains("success: true"));

--- a/crates/basilisk-lsp/src/uv_failure.rs
+++ b/crates/basilisk-lsp/src/uv_failure.rs
@@ -1,0 +1,126 @@
+//! Implements [LSPUV-COMMAND-FAILURE-UX]. See docs/specs/LSP-UV-INTEGRATION-SPEC.md#LSPUV-COMMAND-FAILURE-UX
+//! uv failure classification — plain-language headlines instead of resolver dumps.
+//!
+//! When a uv subprocess fails, the raw resolver stderr is unactionable for a
+//! typical Python developer (issue #94). This module maps common uv outcomes
+//! to a short headline plus a remediation hint. The full stderr always stays
+//! available in the Basilisk Output channel — only the toast is classified.
+
+/// Broad category of a uv command failure, used for structured logging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UvFailureCategory {
+    /// The requested package does not exist (or has no compatible version).
+    PackageNotFound,
+    /// The resolver found the package but it conflicts with existing pins.
+    ResolutionConflict,
+    /// The package index could not be reached.
+    NetworkError,
+    /// The `uv` binary itself is missing from `PATH`.
+    UvNotFound,
+    /// Anything else — point the user at the Output channel.
+    Generic,
+}
+
+impl UvFailureCategory {
+    /// Stable lowercase name for structured log fields.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::PackageNotFound => "package_not_found",
+            Self::ResolutionConflict => "resolution_conflict",
+            Self::NetworkError => "network_error",
+            Self::UvNotFound => "uv_not_found",
+            Self::Generic => "generic",
+        }
+    }
+}
+
+/// A classified uv failure: what to show the user and how to log it.
+#[derive(Debug, Clone)]
+pub struct UvFailure {
+    /// Failure category (also a structured log field).
+    pub category: UvFailureCategory,
+    /// One-sentence plain-language headline plus remediation for the toast.
+    pub message: String,
+}
+
+/// Classify a failed uv command from its (ANSI-stripped) stderr.
+///
+/// `label` is the human-readable command (e.g. `"uv add six"`); `package` is
+/// the package argument when the command has one.
+#[must_use]
+pub fn classify_uv_failure(label: &str, package: Option<&str>, stderr: &str) -> UvFailure {
+    // uv hard-wraps its resolver prose, so a phrase like "was not found in the
+    // package registry" can straddle a line break — collapse all whitespace
+    // runs before matching.
+    let stderr = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
+    let no_solution = stderr.contains("No solution found");
+    let not_found = stderr.contains("was not found in the package registry")
+        || stderr.contains("there are no versions of")
+        || stderr.contains("not found in the provided package locations");
+
+    if no_solution && not_found {
+        let name = package.unwrap_or("the package");
+        return UvFailure {
+            category: UvFailureCategory::PackageNotFound,
+            message: format!(
+                "Package `{name}` couldn't be found or has no compatible version. \
+                 Check the package name for a typo, or confirm it exists on the \
+                 configured index. Full uv output is in the Basilisk Output channel."
+            ),
+        };
+    }
+
+    if no_solution {
+        let name = package.unwrap_or("the package");
+        return UvFailure {
+            category: UvFailureCategory::ResolutionConflict,
+            message: format!(
+                "`{name}` conflicts with your existing dependencies. Relax a version \
+                 pin, or retry with `--frozen` to skip locking. Full uv output is in \
+                 the Basilisk Output channel."
+            ),
+        };
+    }
+
+    let lowered = stderr.to_lowercase();
+    if lowered.contains("connection refused")
+        || lowered.contains("error sending request")
+        || lowered.contains("network")
+        || lowered.contains("could not connect")
+        || lowered.contains("dns error")
+        || lowered.contains("operation timed out")
+    {
+        return UvFailure {
+            category: UvFailureCategory::NetworkError,
+            message: "Couldn't reach the package index. Check your network or index \
+                      URL, then retry. Full uv output is in the Basilisk Output channel."
+                .to_owned(),
+        };
+    }
+
+    UvFailure {
+        category: UvFailureCategory::Generic,
+        message: format!("{label} failed. See the Basilisk Output channel for the full uv output."),
+    }
+}
+
+/// Classification for a uv process that could not even be spawned.
+#[must_use]
+pub fn classify_uv_spawn_failure(err: &std::io::Error) -> UvFailure {
+    if err.kind() == std::io::ErrorKind::NotFound {
+        UvFailure {
+            category: UvFailureCategory::UvNotFound,
+            message: "`uv` isn't installed or isn't on PATH. Install it from \
+                      https://docs.astral.sh/uv/getting-started/installation/ and retry."
+                .to_owned(),
+        }
+    } else {
+        UvFailure {
+            category: UvFailureCategory::Generic,
+            message: format!(
+                "uv could not be started ({err}). See the Basilisk Output channel for details."
+            ),
+        }
+    }
+}

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -105,11 +105,19 @@ impl WorkspaceIndex {
             .map(|root| {
                 let has_config =
                     root.join("pyproject.toml").is_file() || root.join("basilisk.json").is_file();
-                let cfg = if has_config {
+                let mut cfg = if has_config {
                     basilisk_config::load_basilisk_config(root)
                 } else {
                     checker_config.clone()
                 };
+                // [CHKARCH-VERSION-TARGET] An explicit `python-version` in the
+                // checker config wins; otherwise detect the project's target
+                // from `.python-version` / `requires-python` / `uv.lock` so
+                // version-aware rules follow the real target (issue #93).
+                if cfg.python_version.is_none() {
+                    cfg.python_version =
+                        basilisk_uv::python_version::resolve_target_python_version(root);
+                }
                 (root.clone(), cfg)
             })
             .collect();

--- a/crates/basilisk-lsp/tests/lsp/ws_test_execute_uv.rs
+++ b/crates/basilisk-lsp/tests/lsp/ws_test_execute_uv.rs
@@ -648,3 +648,162 @@ async fn test_e0010_code_action_to_execute_command_full_flow() -> TestResult<()>
     let _ = std::fs::remove_dir_all(&dir);
     Ok(())
 }
+
+// ── uv failure classification [LSPUV-COMMAND-FAILURE-UX] (issue #94) ─────
+
+/// Send a request and collect EVERY message (response + notifications) until
+/// the response id arrives, plus a short post-response drain. The standard
+/// `fixture.request()` helper discards interleaved notifications, which is
+/// exactly where the failure toast lives.
+async fn request_collecting_all(
+    fixture: &mut WsTestFixture,
+    id: u64,
+    method: &str,
+    params: serde_json::Value,
+) -> TestResult<(Option<String>, Vec<String>)> {
+    fixture
+        .send_json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        }))
+        .await?;
+
+    let id_str = format!("\"id\":{id}");
+    let mut messages = Vec::new();
+    let mut response = None;
+    for _ in 0..40 {
+        let Some(msg) = fixture.recv().await else {
+            break;
+        };
+        let is_response = msg.contains(&id_str);
+        messages.push(msg.clone());
+        if is_response {
+            response = Some(msg);
+            break;
+        }
+    }
+    messages.extend(drain_messages(fixture, Duration::from_millis(800)).await);
+    Ok((response, messages))
+}
+
+/// Find the first `window/showMessage` error toast among drained messages.
+fn find_error_toast(messages: &[String]) -> Option<serde_json::Value> {
+    messages
+        .iter()
+        .filter_map(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+        .find(|v| {
+            v["method"].as_str() == Some("window/showMessage")
+                && v["params"]["type"].as_u64() == Some(1)
+        })
+}
+
+#[tokio::test]
+async fn test_uv_add_nonexistent_package_toast_is_actionable_not_resolver_dump() -> TestResult<()> {
+    if !uv_available() {
+        return Ok(());
+    }
+
+    let dir = create_uv_project("bsk_uv_add_notfound");
+    let root_uri = format!("file://{}", dir.display());
+
+    let mut fixture = WsTestFixture::new().await?;
+    let _ = initialize_with_root(&mut fixture, &root_uri, "wholeModule").await?;
+    let _ = drain_messages(&mut fixture, Duration::from_millis(500)).await;
+
+    // A package that does not exist on PyPI — uv's resolver fails.
+    let package = "bsk-no-such-package-issue94";
+    let (resp, messages) = request_collecting_all(
+        &mut fixture,
+        700,
+        "workspace/executeCommand",
+        serde_json::json!({
+            "command": "basilisk.uv.add",
+            "arguments": [package]
+        }),
+    )
+    .await?;
+    let resp = resp.ok_or("no response to workspace/executeCommand")?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&resp)?;
+    assert_eq!(
+        parsed["result"]["success"], false,
+        "adding a nonexistent package must fail: {resp}"
+    );
+
+    let toast = find_error_toast(&messages)
+        .ok_or("expected a window/showMessage error toast for the failed uv add")?;
+    let text = toast["params"]["message"].as_str().unwrap_or_default();
+
+    // Plain-language headline: names the package and says it can't be found.
+    assert!(
+        text.contains(package),
+        "toast must name the failing package: {text}"
+    );
+    assert!(
+        text.to_lowercase().contains("found"),
+        "toast must say the package couldn't be found: {text}"
+    );
+    assert!(
+        text.to_lowercase().contains("check"),
+        "toast must tell the user what to do next (check the name): {text}"
+    );
+
+    // The raw resolver tree must NOT be the toast.
+    assert!(
+        !text.contains("No solution found")
+            && !text.contains("we can conclude")
+            && !text.contains("requirements are unsatisfiable"),
+        "toast must not dump uv's raw resolver output: {text}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_uv_generic_failure_toast_points_to_output_channel() -> TestResult<()> {
+    if !uv_available() {
+        return Ok(());
+    }
+
+    let dir = create_uv_project("bsk_uv_add_generic");
+    let root_uri = format!("file://{}", dir.display());
+
+    let mut fixture = WsTestFixture::new().await?;
+    let _ = initialize_with_root(&mut fixture, &root_uri, "wholeModule").await?;
+    let _ = drain_messages(&mut fixture, Duration::from_millis(500)).await;
+
+    // An invalid requirement string — uv fails before resolution, which must
+    // classify as a generic failure with an Output-channel pointer.
+    let (resp, messages) = request_collecting_all(
+        &mut fixture,
+        701,
+        "workspace/executeCommand",
+        serde_json::json!({
+            "command": "basilisk.uv.add",
+            "arguments": ["not a valid requirement!!"]
+        }),
+    )
+    .await?;
+    let resp = resp.ok_or("no response to workspace/executeCommand")?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&resp)?;
+    assert_eq!(
+        parsed["result"]["success"], false,
+        "adding an invalid requirement must fail: {resp}"
+    );
+
+    let toast = find_error_toast(&messages)
+        .ok_or("expected a window/showMessage error toast for the failed uv add")?;
+    let text = toast["params"]["message"].as_str().unwrap_or_default();
+
+    assert!(
+        text.contains("Output"),
+        "generic failure toast must point at the Basilisk Output channel: {text}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}

--- a/crates/basilisk-lsp/tests/profiler_helper_socket.rs
+++ b/crates/basilisk-lsp/tests/profiler_helper_socket.rs
@@ -277,6 +277,9 @@ async fn collect_sample_batches(
                 }
             }
             Ok(Ok(Some(Message::Attached { .. }))) => {}
+            Ok(Ok(Some(Message::AttachFailed { reason, .. }))) => {
+                panic!("helper reported attach failure mid-stream: {reason}")
+            }
             Ok(Ok(Some(Message::Stopped) | None)) => break,
             Ok(Err(err)) => panic!("sample read failed: {err}"),
             Err(_elapsed) => break,

--- a/crates/basilisk-lsp/tests/profiler_helper_socket.rs
+++ b/crates/basilisk-lsp/tests/profiler_helper_socket.rs
@@ -229,13 +229,20 @@ async fn helper_listener_is_bound_before_helper_connects() {
 
     let err = result.expect_err("attaching to a non-Python process must fail");
     let msg = err.to_string();
+    // The helper CONNECTED (listener bound — the #61 fix) and reported its
+    // attach failure over the socket (the #81 fix): the error must carry the
+    // helper's real py-spy cause, not a connection error or a bare EOF.
     assert!(
-        msg.contains("closed the connection before confirming attach"),
-        "the helper must CONNECT (listener bound) then fail to attach; got: {msg}"
+        msg.contains("could not attach") || msg.contains("py-spy"),
+        "the helper must CONNECT (listener bound) then report the attach failure; got: {msg}"
     );
     assert!(
         !msg.contains("timed out waiting for the profiler helper to connect"),
         "a connection timeout means no listener was bound — the #61 bug: {msg}"
+    );
+    assert!(
+        !msg.contains("closed the connection before confirming attach"),
+        "a bare EOF is the undiagnosable #81 failure mode: {msg}"
     );
 }
 
@@ -536,5 +543,50 @@ fn elevation_command_guards_against_inaccessible_cwd() {
     assert!(
         cd < helper,
         "cd / must precede the helper invocation: {script}"
+    );
+}
+
+/// Issue #81: when the helper cannot attach (here: the target PID is already
+/// dead), the LSP must surface the helper's REAL cause — not the undiagnosable
+/// "helper closed the connection before confirming attach" bare-EOF message.
+#[tokio::test]
+async fn attach_to_exited_pid_reports_real_cause_not_bare_eof() {
+    use basilisk_lsp::profiler::helper_client::{start_helper_sampler, HelperSpawn};
+    use basilisk_lsp::profiler::sampler::SamplerConfig;
+
+    let helper = helper_binary_path();
+
+    // Spawn a process that exits immediately, and reap it so the PID is dead
+    // by the time the helper tries to attach.
+    let mut child = Command::new("true").spawn().expect("spawn `true`");
+    let pid = child.id();
+    let _ = child.wait();
+
+    let config = SamplerConfig {
+        pid,
+        sample_rate: 100,
+        include_native: false,
+        include_idle: false,
+        duration: None,
+    };
+    let err = timeout(
+        Duration::from_secs(30),
+        start_helper_sampler(&config, HelperSpawn::Direct(helper)),
+    )
+    .await
+    .expect("must not hang")
+    .expect_err("attaching to a dead PID must fail");
+
+    let msg = err.to_string();
+    assert!(
+        !msg.contains("closed the connection before confirming attach"),
+        "a bare EOF is not a diagnosis — the helper's failure cause must be surfaced: {msg}"
+    );
+    // The py-spy attach error (process gone / not a Python process) must reach
+    // the caller so the failure is actionable.
+    let lowered = msg.to_lowercase();
+    assert!(
+        lowered.contains("py-spy") || lowered.contains("process"),
+        "expected the helper's real attach-failure cause in the error, got: {msg}"
     );
 }

--- a/crates/basilisk-profiler-helper/src/main.rs
+++ b/crates/basilisk-profiler-helper/src/main.rs
@@ -154,7 +154,23 @@ async fn run_protocol(
     let (pid, sample_rate, include_native) = read_attach_command(&mut reader).await?;
     info!(pid, sample_rate, include_native, "attaching to process");
 
-    let (spy, python_version) = attach_pyspy(pid, sample_rate, include_native)?;
+    // Report attach failures over the socket BEFORE exiting (issue #81):
+    // exiting silently leaves the LSP with an undiagnosable EOF.
+    let (spy, python_version) = match attach_pyspy(pid, sample_rate, include_native) {
+        Ok(attached) => attached,
+        Err(reason) => {
+            error!(pid, %reason, "attach failed");
+            let _ = send_message(
+                &mut writer,
+                &Message::AttachFailed {
+                    pid,
+                    reason: reason.clone(),
+                },
+            )
+            .await;
+            return Err(reason);
+        }
+    };
 
     send_message(
         &mut writer,

--- a/crates/basilisk-profiler-protocol/src/lib.rs
+++ b/crates/basilisk-profiler-protocol/src/lib.rs
@@ -57,6 +57,15 @@ pub enum Message {
         /// Detected Python version (e.g. `"3.12.0"`).
         python: String,
     },
+    /// The attach failed; carries the real cause so the LSP can diagnose it
+    /// (issue #81 — previously the helper exited without reporting and the
+    /// LSP saw only an undiagnosable EOF).
+    AttachFailed {
+        /// Target PID.
+        pid: u32,
+        /// Human-readable failure cause (e.g. the py-spy attach error).
+        reason: String,
+    },
     /// A batch of stack-trace samples from a single sampling tick.
     Samples {
         /// The sampled traces.

--- a/crates/basilisk-uv/src/python_version.rs
+++ b/crates/basilisk-uv/src/python_version.rs
@@ -22,6 +22,56 @@ pub fn read_python_version(root: &Path) -> Option<String> {
         .map(String::from)
 }
 
+/// Resolve the project's target Python version from project files, per
+/// [LSPUV-PYTHON-VERSION-RESOLUTION-ORDER]:
+///
+/// 1. `.python-version` file (uv standard)
+/// 2. `[project].requires-python` lower bound in `pyproject.toml`
+/// 3. `uv.lock` top-level `requires-python` lower bound
+///
+/// Returns `None` when nothing pins a version — callers fall back to the
+/// checker's centralized default ([CHKARCH-VERSION-TARGET], issue #93).
+#[must_use]
+pub fn resolve_target_python_version(root: &Path) -> Option<String> {
+    read_python_version(root)
+        .or_else(|| pyproject_requires_python(root))
+        .or_else(|| lockfile_requires_python(root))
+}
+
+/// Lower bound of `[project].requires-python` in `pyproject.toml`, if any.
+fn pyproject_requires_python(root: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(root.join("pyproject.toml")).ok()?;
+    let table: toml::Table = content.parse().ok()?;
+    let requires = table
+        .get("project")?
+        .as_table()?
+        .get("requires-python")?
+        .as_str()?;
+    constraint_lower_bound(requires)
+}
+
+/// Lower bound of `requires-python` in `uv.lock`, if any.
+fn lockfile_requires_python(root: &Path) -> Option<String> {
+    let lock = crate::lockfile::parse_lock_file(&root.join("uv.lock")).ok()?;
+    constraint_lower_bound(lock.requires_python.as_deref()?)
+}
+
+/// Extract a version from the `>=`/`==`/`~=` clause of a PEP 440 constraint,
+/// e.g. `">=3.10,<4"` → `"3.10"`. `<`-only constraints carry no usable target.
+fn constraint_lower_bound(constraint: &str) -> Option<String> {
+    constraint.split(',').map(str::trim).find_map(|clause| {
+        let version = clause
+            .strip_prefix(">=")
+            .or_else(|| clause.strip_prefix("=="))
+            .or_else(|| clause.strip_prefix("~="))?;
+        let version = version.trim().trim_end_matches(".*");
+        version
+            .split('.')
+            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+            .then(|| version.to_owned())
+    })
+}
+
 #[cfg(test)]
 #[expect(clippy::unwrap_used, reason = "test-only")]
 mod tests {

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -355,6 +355,39 @@ Full support for:
 - `assert_never()` for exhaustiveness checking
 - Platform-aware reachability (default: assume code may run on any platform)
 
+### Target Version and Platform {#CHKARCH-VERSION-TARGET}
+
+Every rule runs against the **configured** target Python version — never a
+hardcoded constant (issue #93).
+
+- `BasiliskConfig.python_version` / `python_platform` (from `basilisk.json`
+  `pythonVersion`/`pythonPlatform` or `pyproject.toml` `[tool.basilisk]`
+  `python-version`/`python-platform`) parse into a typed
+  `CheckContext { target_version: (major, minor), target_platform }`
+  (`crates/basilisk-checker/src/context.rs`).
+- The centralized default is `DEFAULT_TARGET_VERSION = (3, 12)` — the **only**
+  place the default version constant lives. A malformed version string falls
+  back to the default rather than panicking or disabling gating.
+- When the checker config does not pin a version, the CLI and LSP detect it
+  from project files per
+  [`[LSPUV-PYTHON-VERSION-RESOLUTION-ORDER]`](LSP-UV-INTEGRATION-SPEC.md):
+  `.python-version` → `[project].requires-python` lower bound → `uv.lock`
+  `requires-python` lower bound (`basilisk_uv::python_version::resolve_target_python_version`).
+- `rules::run_all(module, ctx)` threads the context into every
+  `Rule::check(module, ctx, diagnostics)` — no rule may reference a literal
+  target version.
+
+#### Version/Platform Narrowing {#CHKARCH-VERSION-NARROWING}
+
+- `BSK-E0150` evaluates `sys.version_info` / `sys.platform` guards against
+  `ctx.target_version`, so dead-branch analysis follows the project's real
+  target.
+- `BSK-E0155` rejects PEP 695 syntax (`type X = …`, `class C[T]`, `def f[T]`)
+  when `ctx.target_version < (3, 12)` — the target interpreter cannot even
+  parse it.
+
+Tests: `crates/basilisk-checker/tests/checker/version_target_tests.rs`.
+
 ---
 
 ## Mojo-Inspired Safety Analysis {#CHKARCH-MOJO-SAFETY}
@@ -694,6 +727,7 @@ list — keep it in sync after adding or renaming a rule.
 | `BSK-E0152` | Missing type stubs for installed package |
 | `BSK-E0153` | Invalid call to a constructor-derived callable ([CHKARCH-DIAG-CTOR-CALLABLE](#CHKARCH-DIAG-CTOR-CALLABLE)) |
 | `BSK-E0154` | Access to a module attribute a local stub does not declare ([CHKARCH-DIAG-STUB-MEMBER](#CHKARCH-DIAG-STUB-MEMBER)) |
+| `BSK-E0155` | PEP 695 syntax used below the configured target version ([CHKARCH-VERSION-TARGET](#CHKARCH-VERSION-TARGET)) |
 | `BSK-W0011` | Undeclared dependency import |
 | `BSK-W0012` | Unused dependency |
 | `BSK-W0013` | Stale uv lock file |

--- a/docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md
+++ b/docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md
@@ -272,6 +272,24 @@ myapp/
 - **On file create/delete/rename**: full re-fetch
 - **Manual**: refresh button
 
+All automatic refreshes flow through the centralized `analysisRevision`
+signal — see [#EXTACT-REACTIVE-STATE].
+
+### Centralized Reactive State (MANDATORY) {#EXTACT-REACTIVE-STATE}
+
+All panel state is centralized in the store (`vscode-extension/src/store.ts`)
+and reactive via Preact signals (issue #58). Panels MUST NOT hand-roll
+`setInterval` polls or register their own LSP notification listeners.
+
+- The store owns a monotonic **`analysisRevision`** signal that bumps when:
+  1. the server reaches `Running` (initial analysis),
+  2. `basilisk/moduleChanged` fires (re-analysis complete),
+  3. diagnostics change (debounced 300 ms).
+- Panels subscribe with a signals `effect(...)` (see
+  `module-explorer.ts::wireReactiveRefresh`) so a state change fires a refresh
+  automatically — the user never has to click Refresh to see the first result.
+- Tests: `vscode-extension/src/test/suite/store-reactivity.test.ts`.
+
 ---
 
 ## Type Health {#EXTACT-HEALTH}

--- a/docs/specs/LSP-ARCHITECTURE-SPEC.md
+++ b/docs/specs/LSP-ARCHITECTURE-SPEC.md
@@ -148,6 +148,17 @@ https://code.visualstudio.com/api/references/vscode-api#commands
 
 This rule applies equally to VS Code, Neovim, and Zed extensions.
 
+### Modules Toolbar Contract (VS Code) {#VSIX-MODULE-EXPLORER-TOOLBAR}
+
+The `basilisk.moduleExplorer` (MODULES) view title-bar follows a fixed contract (issue #113):
+
+1. **Deterministic order.** Every `view/title` entry carries an explicit `@N` index — bare `"group": "navigation"` is forbidden.
+2. **Read-only inline, mutating in overflow.** The inline icon row is exactly the read-only view-state actions, in this order: refresh (`navigation@1`), collapse (`@2`), tree/flat toggle (`@3`), filter (`@4`), sort (`@5`). Mutating actions (`organizeImports`, `fixWorkspace` → group `1_modify`) and server control (`restartServer` → group `9_server`) live in the `…` overflow menu, in distinct groups so VS Code renders a divider between them.
+3. **No colliding glyphs.** No two inline buttons may use the same codicon. Relocating `restartServer` (`$(debug-restart)`) to the overflow keeps it from rendering as a near-duplicate of `$(refresh)`.
+4. **Fix All is feature-flagged.** `basilisk.fixWorkspace` is additionally gated on `config.basilisk.experimental.fixAll` (boolean setting, default `false`). It must not surface to users who have not opted in, and stays gated on `basilisk.serverState == 'running'`.
+
+Enforced by the toolbar contract tests in `vscode-extension/src/test/suite/activity-panel.test.ts`.
+
 ---
 
 ## Custom LSP Commands (`workspace/executeCommand`) {#LSPARCH-CMDS}

--- a/docs/specs/LSP-PROFILING-SPEC.md
+++ b/docs/specs/LSP-PROFILING-SPEC.md
@@ -662,6 +662,14 @@ LSP    -> {"cmd":"stop"}
 helper -> {"type":"stopped"}
 ```
 
+On an attach failure the helper MUST report the cause over the socket before exiting (issue #81 — exiting silently leaves the LSP with an undiagnosable EOF):
+
+```text
+helper -> {"type":"attachfailed","pid":12345,"reason":"py-spy attach failed: ..."}
+```
+
+The LSP classifies the reason into an actionable error — target process exited, permission denied (elevation required), or the verbatim py-spy error — and, when an old helper still EOFs without reporting, harvests the helper's exit status into the error message (`helper_client::describe_helper_eof`).
+
 `traces` carry the minimal per-thread / per-frame fields py-spy produces; the LSP converts them back into py-spy shapes and feeds the same aggregator the in-process sampler uses.
 
 ### Helper Socket Sampling {#PROFILE-HELPER-SOCKET}

--- a/docs/specs/LSP-UV-INTEGRATION-SPEC.md
+++ b/docs/specs/LSP-UV-INTEGRATION-SPEC.md
@@ -154,11 +154,22 @@ Extended version of current Python version detection:
 
 ### 4.2 Impact on Type Checking {#LSPUV-PYTHON-VERSION-IMPACT}
 
-The detected Python version controls:
+The detected version flows into the checker as
+`CheckContext.target_version` — see
+[`[CHKARCH-VERSION-TARGET]`](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-VERSION-TARGET)
+for the typed context, the centralized 3.12 default, and the wiring
+(`basilisk_uv::python_version::resolve_target_python_version` →
+`WorkspaceIndex::new` / CLI `main.rs`).
+
+Implemented impact today:
+
+- `sys.version_info` branch narrowing (`BSK-E0150` dead-branch analysis)
+- PEP 695 syntax gating below 3.12 (`BSK-E0155`)
+
+Planned (not yet version-gated):
 
 - stdlib module availability (e.g., `tomllib` only in 3.11+)
-- Syntax feature support (e.g., `match` in 3.10+, `type` statement in 3.12+)
-- `sys.version_info` branch narrowing
+- further syntax feature support (e.g., `match` in 3.10+)
 - `typing_extensions` vs `typing` import suggestions
 
 ---
@@ -368,7 +379,32 @@ All commands:
 - Execute in the workspace root directory
 - Stream stdout/stderr to the client via `window/logMessage`
 - Trigger `uv.lock` re-parse on successful completion
-- Report failure via `window/showMessage` (error level)
+- Report failure via `window/showMessage` (error level), classified per
+  [9.1](#LSPUV-COMMAND-FAILURE-UX)
+
+### 9.1 Failure Classification & User-Facing Messaging {#LSPUV-COMMAND-FAILURE-UX}
+
+A failed uv command MUST NOT surface raw resolver stderr as the toast (issue
+#94). `crates/basilisk-lsp/src/uv_failure.rs` classifies the (ANSI-stripped,
+whitespace-normalized) stderr and the toast carries a **plain-language headline
+plus a remediation hint**:
+
+| Category | Detected from | Toast headline + action |
+|---|---|---|
+| `package_not_found` | `No solution found` + `was not found in the package registry` / `there are no versions of` | "Package `<pkg>` couldn't be found or has no compatible version. Check the package name for a typo, or confirm it exists on the configured index." |
+| `resolution_conflict` | `No solution found` (without not-found markers) | "`<pkg>` conflicts with your existing dependencies. Relax a version pin, or retry with `--frozen` to skip locking." |
+| `network_error` | connection refused / DNS / request-send errors | "Couldn't reach the package index. Check your network or index URL, then retry." |
+| `uv_not_found` | spawn `ErrorKind::NotFound` | "`uv` isn't installed or isn't on PATH." + install link |
+| `generic` | anything else | "`<label>` failed. See the Basilisk Output channel for the full uv output." |
+
+Requirements:
+- The **full** uv stderr always remains in the Output channel via
+  `window/logMessage` — only the toast is classified.
+- Structured logging on failure includes `command`, `package`, `exit_code`,
+  `failure_category`, and `duration_ms`. Never log index credentials.
+- Covered by the e2e tests in
+  `crates/basilisk-lsp/tests/lsp/ws_test_execute_uv.rs` (package-not-found and
+  generic cases).
 
 ---
 

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -76,7 +76,9 @@ if [[ -f "$REF_STAMP_FILE" ]]; then
     CURRENT_REF=$(cat "$REF_STAMP_FILE")
 fi
 
-if [[ "${1:-}" == "--fetch" ]] || [[ "${1:-}" == "--fetch-only" ]] || \
+# --fetch forces a re-download; --fetch-only only ensures the pinned ref is
+# present (fetch if missing/stale, then exit) so `make test` works offline.
+if [[ "${1:-}" == "--fetch" ]] || \
    [[ ! -d "$CONFORMANCE_DIR" ]] || \
    [[ -z "$(ls -A "$CONFORMANCE_DIR" 2>/dev/null)" ]] || \
    [[ "$CURRENT_REF" != "$TYPING_REF" ]]; then

--- a/vscode-extension/.vscode-test.mjs
+++ b/vscode-extension/.vscode-test.mjs
@@ -1,8 +1,22 @@
 import { defineConfig } from '@vscode/test-cli';
+import crypto from 'crypto';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// VS Code listens on a Unix socket inside the user-data dir; macOS caps
+// AF_UNIX socket paths at 104 bytes ("IPC handle longer than 103 chars").
+// Deep checkouts overflow that and the electron main process dies with
+// `listen EINVAL`, so fall back to a short per-checkout dir under tmp.
+const defaultUserDataDir = path.join(__dirname, '.vscode-test', 'user-data');
+const userDataDir = defaultUserDataDir.length > 80
+    ? path.join(
+        os.tmpdir(),
+        `bsk-vsct-${crypto.createHash('sha256').update(__dirname).digest('hex').slice(0, 8)}`,
+    )
+    : defaultUserDataDir;
 
 export default defineConfig({
     tests: [{
@@ -11,7 +25,7 @@ export default defineConfig({
         // This enables whole-module analysis tests that write Python files to the
         // workspace root without opening them in the editor.
         workspaceFolder: path.join(__dirname, 'test-fixtures', 'workspace'),
-        launchArgs: ['--disable-extensions', '--user-data-dir', path.join(__dirname, '.vscode-test', 'user-data')],
+        launchArgs: ['--disable-extensions', '--user-data-dir', userDataDir],
         // Coverage: tell c8 where compiled sources live. Without this,
         // @vscode/test-cli defaults to 'src' (TypeScript sources), so
         // include patterns like 'out/**/*.js' resolve against src/ and

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -431,42 +431,42 @@
         {
           "command": "basilisk.refreshModuleExplorer",
           "when": "view == basilisk.moduleExplorer",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "basilisk.collapseModuleExplorer",
           "when": "view == basilisk.moduleExplorer",
-          "group": "navigation"
+          "group": "navigation@2"
         },
         {
           "command": "basilisk.toggleModuleExplorerView",
           "when": "view == basilisk.moduleExplorer",
-          "group": "navigation"
+          "group": "navigation@3"
         },
         {
           "command": "basilisk.filterModuleExplorer",
           "when": "view == basilisk.moduleExplorer",
-          "group": "navigation"
+          "group": "navigation@4"
         },
         {
           "command": "basilisk.sortModuleExplorer",
           "when": "view == basilisk.moduleExplorer",
-          "group": "navigation"
-        },
-        {
-          "command": "basilisk.fixWorkspace",
-          "when": "view == basilisk.moduleExplorer && basilisk.serverState == 'running'",
-          "group": "navigation"
+          "group": "navigation@5"
         },
         {
           "command": "basilisk.organizeImports",
           "when": "view == basilisk.moduleExplorer && basilisk.serverState == 'running'",
-          "group": "navigation"
+          "group": "1_modify@1"
+        },
+        {
+          "command": "basilisk.fixWorkspace",
+          "when": "view == basilisk.moduleExplorer && basilisk.serverState == 'running' && config.basilisk.experimental.fixAll",
+          "group": "1_modify@2"
         },
         {
           "command": "basilisk.restartServer",
           "when": "view == basilisk.moduleExplorer && basilisk.serverState == 'running'",
-          "group": "navigation"
+          "group": "9_server@1"
         },
         {
           "command": "basilisk.profileCurrentFile",
@@ -898,6 +898,11 @@
           ],
           "default": "wholeModule",
           "description": "Controls which files Basilisk analyses. 'wholeModule' (default) analyses all workspace files; 'openFilesOnly' analyses only open editors; 'crossModule' is reserved for future cross-file import graph analysis."
+        },
+        "basilisk.experimental.fixAll": {
+          "type": "boolean",
+          "default": false,
+          "description": "Experimental: show the 'Fix All in Workspace' action in the Modules toolbar. Off by default until the mass-autofix flow is hardened."
         }
       }
     },

--- a/vscode-extension/src/module-explorer.ts
+++ b/vscode-extension/src/module-explorer.ts
@@ -8,6 +8,7 @@
  * notifications.
  */
 
+import { effect } from "@preact/signals-core";
 import * as vscode from "vscode";
 import { type Store } from "./store";
 import { Logger } from "./logger";
@@ -367,9 +368,6 @@ export class ModuleExplorerProvider implements vscode.TreeDataProvider<TreeItem>
 
 // ── Registration ─────────────────────────────────────────────────────────
 
-/** Interval (ms) for polling client readiness to wire notification listeners. */
-const CLIENT_POLL_INTERVAL_MS = 1000;
-
 /**
  * Register clipboard and action commands for the module explorer.
  *
@@ -451,30 +449,27 @@ export function registerModuleExplorer(
 
   provider.restoreViewMode(context);
   const commandDisposables = registerExplorerCommands(context, provider);
-  wireModuleChangedListener(store, provider);
+  wireReactiveRefresh(store, provider);
 
   return { provider, disposables: commandDisposables };
 }
 
 /**
- * Watch the store's client signal and register a notification listener for
- * `basilisk/moduleChanged` whenever a new client connects.
+ * Subscribe the panel to the store's centralized `analysisRevision` signal
+ * ([EXTACT-REACTIVE-STATE], issue #58): server-Running, re-analysis
+ * completion, and diagnostics changes all bump the revision in the store, so
+ * the panel refreshes automatically — no per-panel polling or notification
+ * plumbing.
  */
-function wireModuleChangedListener(store: Store, provider: ModuleExplorerProvider): void {
-  let registered = false;
-
-  // Poll for client availability (same pattern as test-explorer).
-  const interval = setInterval(() => {
-    const client = store.client.value;
-    if (!client?.isRunning() || registered) {
-      if (client === undefined) { registered = false; }
-      return;
-    }
-    registered = true;
-    client.onNotification("basilisk/moduleChanged", () => {
+export function wireReactiveRefresh(store: Store, provider: ModuleExplorerProvider): void {
+  let lastRevision = store.analysisRevision.value;
+  const dispose = effect(() => {
+    const revision = store.analysisRevision.value;
+    // The effect runs once on subscription — only refresh on real bumps.
+    if (revision !== lastRevision) {
+      lastRevision = revision;
       provider.refresh();
-    });
-  }, CLIENT_POLL_INTERVAL_MS);
-
-  provider.disposables.push({ dispose: () => { clearInterval(interval); } });
+    }
+  });
+  provider.disposables.push({ dispose });
 }

--- a/vscode-extension/src/process-explorer.ts
+++ b/vscode-extension/src/process-explorer.ts
@@ -312,26 +312,51 @@ export class PythonProcessesProvider implements vscode.TreeDataProvider<TreeItem
 
 // ── Launch actions ───────────────────────────────────────────────────────
 
-/** Guard: narrow to a real selection, warning when an action has no row. */
-function ensureSelection(item: ProcessTreeItem | undefined): item is ProcessTreeItem {
-  if (item === undefined) {
+/**
+ * Resolve the process row an inline action targets (issue #79).
+ *
+ * VS Code normally passes the tree element as the command argument for
+ * inline `view/item/context` buttons, but at runtime the argument has been
+ * observed to arrive `undefined`. The action and its target are the same UI
+ * element, so before warning we fall back to the tree view's current
+ * selection — warning "Select a Python process" while clicking a button ON a
+ * process row is nonsensical.
+ */
+function resolveProcessTarget(
+  item: ProcessTreeItem | undefined,
+  treeView: vscode.TreeView<vscode.TreeItem> | undefined,
+): ProcessTreeItem | undefined {
+  if (item instanceof ProcessTreeItem) { return item; }
+  const selected = treeView?.selection.find(
+    (row): row is ProcessTreeItem => row instanceof ProcessTreeItem,
+  );
+  if (selected === undefined) {
     vscode.window.showWarningMessage("Basilisk: Select a Python process to profile.");
-    return false;
   }
-  return true;
+  return selected;
 }
 
 /** Start CPU profiling the given process row — no input box (the #62 fix). */
-async function profileProcess(store: Store, item: ProcessTreeItem | undefined): Promise<void> {
-  if (!ensureSelection(item)) { return; }
+export async function profileProcess(
+  store: Store,
+  item: ProcessTreeItem | undefined,
+  treeView: vscode.TreeView<vscode.TreeItem> | undefined,
+): Promise<void> {
+  const target = resolveProcessTarget(item, treeView);
+  if (target === undefined) { return; }
   const preset = vscode.workspace.getConfiguration("basilisk").get<string>("profiler.preset", "default");
-  await startProfilingForPid(store, item.process.pid, preset);
+  await startProfilingForPid(store, target.process.pid, preset);
 }
 
 /** Start memory-oriented profiling for the given process row. */
-async function memoryTrackProcess(store: Store, item: ProcessTreeItem | undefined): Promise<void> {
-  if (!ensureSelection(item)) { return; }
-  await startProfilingForPid(store, item.process.pid, "memory");
+export async function memoryTrackProcess(
+  store: Store,
+  item: ProcessTreeItem | undefined,
+  treeView: vscode.TreeView<vscode.TreeItem> | undefined,
+): Promise<void> {
+  const target = resolveProcessTarget(item, treeView);
+  if (target === undefined) { return; }
+  await startProfilingForPid(store, target.process.pid, "memory");
 }
 
 /** Run the active `.py` file under a debug session with profiling on launch. */
@@ -389,10 +414,10 @@ export function registerPythonProcesses(
       provider.setFilter(input ?? "");
     }),
     vscode.commands.registerCommand("basilisk.profileProcess", async (item?: ProcessTreeItem) =>
-      profileProcess(store, item),
+      profileProcess(store, item, treeView),
     ),
     vscode.commands.registerCommand("basilisk.memoryTrackProcess", async (item?: ProcessTreeItem) =>
-      memoryTrackProcess(store, item),
+      memoryTrackProcess(store, item, treeView),
     ),
     vscode.commands.registerCommand("basilisk.profileCurrentFile", async () => profileCurrentFile()),
     vscode.commands.registerCommand("basilisk.copyProcessPid", (item?: ProcessTreeItem) => {

--- a/vscode-extension/src/store.ts
+++ b/vscode-extension/src/store.ts
@@ -50,6 +50,14 @@ export interface Store {
   readonly logSink: ReadonlySignal<LogSink | undefined>;
   readonly lspState: ReadonlySignal<LspState>;
   readonly isServerReady: ReadonlySignal<boolean>;
+  /**
+   * Monotonic counter that bumps whenever fresh analysis may be available:
+   * the server reaches Running, `basilisk/moduleChanged` fires, or
+   * diagnostics change (debounced). Panels subscribe via a signals `effect`
+   * so they refresh automatically — never via per-panel polling
+   * ([EXTACT-REACTIVE-STATE], issue #58).
+   */
+  readonly analysisRevision: ReadonlySignal<number>;
   readonly runtimeResolution: ReadonlySignal<RuntimeResolution | undefined>;
   /** Map of VS Code debug session id → debuggee OS process id (from the DAP `process` event). */
   readonly sessionIdToPid: ReadonlySignal<ReadonlyMap<string, number>>;
@@ -69,6 +77,8 @@ export interface Store {
   getDebuggeeProcessId(sessionId: string): number | undefined;
   /** Forget a debug session's PID mapping (called when the session terminates). */
   clearDebuggeeProcessId(sessionId: string): void;
+  /** Signal that fresh analysis may be available ([EXTACT-REACTIVE-STATE]). */
+  bumpAnalysisRevision(): void;
   isClientCommandRegistered(id: string): boolean;
   isServerCommandAdvertised(id: string): boolean;
   ensureLspReadyPromise(timeoutMs?: number): Promise<Result<LanguageClient>>;
@@ -87,6 +97,11 @@ interface StoreSignals {
   runtimeResolution: Signal<RuntimeResolution | undefined>;
   sessionIdToPid: Signal<Map<string, number>>;
   readyHandle: Signal<ReadyHandle | undefined>;
+  analysisRevision: Signal<number>;
+  /** Trailing-debounce timer for diagnostics-driven analysisRevision bumps. */
+  diagnosticsDebounce: ReturnType<typeof setTimeout> | undefined;
+  /** Whether the global diagnostics listener has been registered. */
+  diagnosticsListenerBound: boolean;
   /** Disposables for client-registered commands — disposed on LSP stop/restart. */
   commandDisposables: vscode.Disposable[];
   /** Disposables for server-advertised command registrations — disposed on LSP stop/restart. */
@@ -217,6 +232,35 @@ function registerClientCommands(signals: StoreSignals, context: vscode.Extension
   });
 }
 
+/** Bump the analysis revision ([EXTACT-REACTIVE-STATE], issue #58). */
+function bumpAnalysisRevision(signals: StoreSignals): void {
+  signals.analysisRevision.value += 1;
+}
+
+/** Debounce window for diagnostics-driven refreshes (diagnostics fire per file). */
+const DIAGNOSTICS_BUMP_DEBOUNCE_MS = 300;
+
+/**
+ * Register the global diagnostics listener exactly once per store: any
+ * diagnostics change bumps the analysis revision (debounced) so panels that
+ * render health rollups stay live ([EXTACT-HEALTH-REFRESH]).
+ */
+function bindDiagnosticsListener(signals: StoreSignals, context: vscode.ExtensionContext): void {
+  if (signals.diagnosticsListenerBound) { return; }
+  signals.diagnosticsListenerBound = true;
+  context.subscriptions.push(
+    vscode.languages.onDidChangeDiagnostics(() => {
+      if (signals.diagnosticsDebounce !== undefined) {
+        clearTimeout(signals.diagnosticsDebounce);
+      }
+      signals.diagnosticsDebounce = setTimeout(() => {
+        signals.diagnosticsDebounce = undefined;
+        bumpAnalysisRevision(signals);
+      }, DIAGNOSTICS_BUMP_DEBOUNCE_MS);
+    }),
+  );
+}
+
 /**
  * Wire up the onDidChangeState listener on the given client.
  * This is the ONLY place commands get registered or populated.
@@ -234,7 +278,16 @@ function bindClientStateListener(
       disposeAllCommands(signals);
       syncServerCommands(signals);
       registerClientCommands(signals, context);
+      // Re-analysis completion: registered after disposeAllCommands each
+      // Running cycle so restarts re-bind it ([EXTACT-REACTIVE-STATE]).
+      signals.commandDisposables.push(
+        lspClient.onNotification("basilisk/moduleChanged", () => {
+          bumpAnalysisRevision(signals);
+        }),
+      );
       resolveLspReady(signals);
+      // Initial analysis becomes available once the server runs.
+      bumpAnalysisRevision(signals);
       return;
     }
 
@@ -359,6 +412,9 @@ function createStoreSignals(): StoreSignals {
     runtimeResolution: signal<RuntimeResolution | undefined>(undefined),
     sessionIdToPid: signal<Map<string, number>>(new Map()),
     readyHandle: signal<ReadyHandle | undefined>(undefined),
+    analysisRevision: signal<number>(0),
+    diagnosticsDebounce: undefined,
+    diagnosticsListenerBound: false,
     commandDisposables: [],
     serverCommandDisposables: [],
   };
@@ -382,10 +438,15 @@ export function createStore(onReset?: () => void): Store {
     sessionIdToPid: signals.sessionIdToPid,
     lspReadyPromise,
     isServerReady,
+    analysisRevision: signals.analysisRevision,
 
     setClient(context: vscode.ExtensionContext, c: LanguageClient): void {
       signals.client.value = c;
       bindClientStateListener(signals, context, c);
+      bindDiagnosticsListener(signals, context);
+    },
+    bumpAnalysisRevision(): void {
+      bumpAnalysisRevision(signals);
     },
     setStatusBarItem(item: vscode.StatusBarItem): void {
       signals.statusBarItem.value = item;

--- a/vscode-extension/src/test/suite/activity-panel.test.ts
+++ b/vscode-extension/src/test/suite/activity-panel.test.ts
@@ -49,6 +49,16 @@ interface WelcomeContribution {
   readonly contents: string;
 }
 
+interface CommandContribution {
+  readonly command: string;
+  readonly title: string;
+  readonly icon?: string;
+}
+
+interface ConfigurationContribution {
+  readonly properties?: Record<string, { type?: string; default?: unknown }>;
+}
+
 interface PackageJSON {
   contributes?: {
     views?: Record<string, ViewContribution[]>;
@@ -57,6 +67,8 @@ interface PackageJSON {
       "view/item/context"?: MenuContribution[];
     };
     viewsWelcome?: WelcomeContribution[];
+    commands?: CommandContribution[];
+    configuration?: ConfigurationContribution | ConfigurationContribution[];
   };
 }
 
@@ -320,6 +332,102 @@ suite("Basilisk Activity Panel E2E Tests", function () {
     for (const cmd of PROMOTED_TOOLBAR_COMMANDS) {
       assertCommandRegistered(cmd, "Promoted toolbar action");
     }
+  });
+
+  // Issue #113 [VSIX-MODULE-EXPLORER-TOOLBAR]: the Modules toolbar contract.
+  // Read-only view-state actions render as deterministically ordered inline
+  // icons; mutating actions and server control live in separate ordered
+  // overflow groups (divider between them); inline glyphs never collide; and
+  // the unrefined Fix All is feature-flagged off by default.
+  test("Modules toolbar: deterministic order, read-only inline, no duplicate glyphs", function () {
+    const contributes = loadContributes();
+    const titleMenus = (contributes?.menus?.["view/title"] ?? []).filter(
+      (entry) => entry.when.includes("view == basilisk.moduleExplorer"),
+    );
+    assert.ok(titleMenus.length > 0, "Modules view must contribute toolbar entries");
+
+    for (const entry of titleMenus) {
+      assert.match(
+        entry.group ?? "",
+        /@\d+$/,
+        `"${entry.command}" must carry an explicit @N order, got: ${entry.group}`,
+      );
+    }
+
+    const inline = titleMenus.filter((entry) => entry.group?.startsWith("navigation") === true);
+    const inlineOrdered = [...inline].sort(
+      (a, b) =>
+        Number(a.group?.split("@")[1] ?? 0) - Number(b.group?.split("@")[1] ?? 0),
+    );
+    assert.deepStrictEqual(
+      inlineOrdered.map((entry) => entry.command),
+      [
+        "basilisk.refreshModuleExplorer",
+        "basilisk.collapseModuleExplorer",
+        "basilisk.toggleModuleExplorerView",
+        "basilisk.filterModuleExplorer",
+        "basilisk.sortModuleExplorer",
+      ],
+      "inline toolbar must be exactly the read-only view-state actions, in order",
+    );
+
+    // Mutating + server-control actions live in the overflow menu, in
+    // distinct groups so VS Code renders a divider between them.
+    const overflow = new Map(
+      titleMenus
+        .filter((entry) => entry.group?.startsWith("navigation") !== true)
+        .map((entry) => [entry.command, entry.group ?? ""]),
+    );
+    const fixAllGroup = overflow.get("basilisk.fixWorkspace");
+    const organizeGroup = overflow.get("basilisk.organizeImports");
+    const restartGroup = overflow.get("basilisk.restartServer");
+    assert.ok(fixAllGroup, "fixWorkspace must be an overflow action, not an inline icon");
+    assert.ok(organizeGroup, "organizeImports must be an overflow action, not an inline icon");
+    assert.ok(restartGroup, "restartServer must be an overflow action, not an inline icon");
+    assert.notStrictEqual(
+      restartGroup.split("@")[0],
+      fixAllGroup.split("@")[0],
+      "server control must be divided from mutating actions",
+    );
+
+    // No two inline buttons may render the same (or near-identical) glyph.
+    const commandIcons = new Map(
+      (contributes?.commands ?? []).map((cmd) => [cmd.command, cmd.icon]),
+    );
+    const inlineIcons = inline.map((entry) => commandIcons.get(entry.command));
+    assert.strictEqual(
+      new Set(inlineIcons).size,
+      inlineIcons.length,
+      `inline toolbar icons must be unique, got: ${inlineIcons.join(", ")}`,
+    );
+  });
+
+  test("Fix All is feature-flagged: config default off, when-clause gated", function () {
+    const contributes = loadContributes();
+    const configSections = Array.isArray(contributes?.configuration)
+      ? contributes.configuration
+      : [contributes?.configuration].filter(Boolean) as ConfigurationContribution[];
+    const flag = configSections
+      .map((section) => section.properties?.["basilisk.experimental.fixAll"])
+      .find((prop) => prop !== undefined);
+    assert.ok(flag, "basilisk.experimental.fixAll setting must be declared");
+    assert.strictEqual(flag.type, "boolean");
+    assert.strictEqual(flag.default, false, "Fix All must be off by default");
+
+    const fixAllEntry = (contributes?.menus?.["view/title"] ?? []).find(
+      (entry) =>
+        entry.command === "basilisk.fixWorkspace" &&
+        entry.when.includes("view == basilisk.moduleExplorer"),
+    );
+    assert.ok(fixAllEntry, "fixWorkspace must be contributed to the Modules toolbar");
+    assert.ok(
+      fixAllEntry.when.includes("config.basilisk.experimental.fixAll"),
+      `fixWorkspace must be gated on the experimental flag, got: ${fixAllEntry.when}`,
+    );
+    assert.ok(
+      fixAllEntry.when.includes("basilisk.serverState == 'running'"),
+      "fixWorkspace must stay gated on the server running",
+    );
   });
 
   // Defect 3 of issue #103: Server Info went stale — the provider only

--- a/vscode-extension/src/test/suite/process-explorer.test.ts
+++ b/vscode-extension/src/test/suite/process-explorer.test.ts
@@ -9,7 +9,12 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { type LanguageClient } from "vscode-languageclient/node";
-import { PythonProcessesProvider, type ProcessInfo } from "../../process-explorer";
+import {
+  PythonProcessesProvider,
+  memoryTrackProcess,
+  profileProcess,
+  type ProcessInfo,
+} from "../../process-explorer";
 import { createStore, type Store } from "../../store";
 
 const MB = 1024 * 1024;
@@ -160,5 +165,118 @@ suite("Python Processes Panel — launcher visibility", () => {
     const pids = rows.map(pidOf);
     assert.ok(!pids.includes(300), "the uvicorn launcher must be hidden");
     assert.ok(pids.includes(100) && pids.includes(200), "bare interpreters remain visible");
+  });
+});
+
+// ── Inline action target resolution (issue #79) [PROFILE-PROCESSES-PANEL] ──
+//
+// Clicking the inline flame / database icon on a process row must profile
+// THAT row. At runtime VS Code has been observed to invoke the command with
+// `item === undefined`; the handler must fall back to the tree view's current
+// selection before warning "Select a Python process to profile."
+
+suite("Python Processes Panel — inline action target (issue #79)", () => {
+  /** Capture LSP executeCommand calls made through the store's client. */
+  function storeCapturing(
+    processes: readonly ProcessInfo[],
+    calls: { command: string; pid: number | undefined }[],
+  ): Store {
+    const store = createStore();
+    const client = {
+      isRunning: (): boolean => true,
+      onDidChangeState: (): vscode.Disposable => ({ dispose: (): undefined => undefined }),
+      sendRequest: async (
+        _method: string,
+        params: { command?: string; arguments?: { pid?: number }[] },
+      ): Promise<unknown> => {
+        // The panel's own row fetch is also an executeCommand — serve it.
+        if (params?.command?.endsWith(".processes") === true) {
+          return { processes };
+        }
+        if (params?.command !== undefined) {
+          calls.push({ command: params.command, pid: params.arguments?.[0]?.pid });
+        }
+        return undefined;
+      },
+    } as unknown as LanguageClient;
+    store.setClient({ subscriptions: [] } as unknown as vscode.ExtensionContext, client);
+    return store;
+  }
+
+  /** Run fn with showWarningMessage stubbed, returning captured warnings. */
+  async function captureWarnings(fn: () => Promise<void>): Promise<string[]> {
+    const warnings: string[] = [];
+    const original = vscode.window.showWarningMessage;
+    (vscode.window as { showWarningMessage: unknown }).showWarningMessage = async (
+      message: string,
+    ): Promise<undefined> => {
+      warnings.push(message);
+      return Promise.resolve(undefined);
+    };
+    try {
+      await fn();
+    } finally {
+      (vscode.window as { showWarningMessage: unknown }).showWarningMessage = original;
+    }
+    return warnings;
+  }
+
+  test("undefined item falls back to the tree selection and profiles that PID", async () => {
+    const calls: { command: string; pid: number | undefined }[] = [];
+    const store = storeCapturing(STUB_PROCESSES, calls);
+    const provider = new PythonProcessesProvider(store);
+    try {
+      const rows = await provider.getChildren();
+      const selected = rows.find((row) => pidOf(row) === 100);
+      assert.ok(selected, "expected the PID 100 row");
+
+      const fakeView = { selection: [selected] } as unknown as vscode.TreeView<vscode.TreeItem>;
+      const warnings = await captureWarnings(async () => {
+        await profileProcess(store, undefined, fakeView);
+      });
+
+      assert.deepStrictEqual(warnings, [], "must not warn when a row is selected");
+      const start = calls.find((c) => c.command.includes("profiler"));
+      assert.ok(start, `profiler start must be requested, got: ${JSON.stringify(calls)}`);
+      assert.strictEqual(start.pid, 100, "must profile the selected row's PID");
+    } finally {
+      provider.dispose();
+    }
+  });
+
+  test("memory tracking falls back to the tree selection the same way", async () => {
+    const calls: { command: string; pid: number | undefined }[] = [];
+    const store = storeCapturing(STUB_PROCESSES, calls);
+    const provider = new PythonProcessesProvider(store);
+    try {
+      const rows = await provider.getChildren();
+      const selected = rows.find((row) => pidOf(row) === 200);
+      assert.ok(selected, "expected the PID 200 row");
+
+      const fakeView = { selection: [selected] } as unknown as vscode.TreeView<vscode.TreeItem>;
+      const warnings = await captureWarnings(async () => {
+        await memoryTrackProcess(store, undefined, fakeView);
+      });
+
+      assert.deepStrictEqual(warnings, [], "must not warn when a row is selected");
+      const start = calls.find((c) => c.command.includes("profiler"));
+      assert.ok(start, `profiler start must be requested, got: ${JSON.stringify(calls)}`);
+      assert.strictEqual(start.pid, 200, "must memory-track the selected row's PID");
+    } finally {
+      provider.dispose();
+    }
+  });
+
+  test("warns only when there is neither an item nor a selection", async () => {
+    const calls: { command: string; pid: number | undefined }[] = [];
+    const store = storeCapturing(STUB_PROCESSES, calls);
+
+    const fakeView = { selection: [] } as unknown as vscode.TreeView<vscode.TreeItem>;
+    const warnings = await captureWarnings(async () => {
+      await profileProcess(store, undefined, fakeView);
+    });
+
+    assert.strictEqual(warnings.length, 1, "must warn exactly once");
+    assert.deepStrictEqual(calls, [], "must not start profiling without a target");
   });
 });

--- a/vscode-extension/src/test/suite/store-reactivity.test.ts
+++ b/vscode-extension/src/test/suite/store-reactivity.test.ts
@@ -1,0 +1,147 @@
+// Tests for [EXTACT-REACTIVE-STATE]. See docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md#EXTACT-REACTIVE-STATE
+//
+// Issue #58: the Modules panel must update automatically — no manual Refresh —
+// when (a) the server reaches Running, (b) re-analysis completes
+// (`basilisk/moduleChanged`), and (c) diagnostics change. Reactivity is
+// centralized in the store as the `analysisRevision` signal; panels subscribe
+// via a signals effect instead of hand-rolled polling.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { State, type LanguageClient } from "vscode-languageclient/node";
+import { ModuleExplorerProvider, wireReactiveRefresh } from "../../module-explorer";
+import { createStore, type Store } from "../../store";
+
+type StateListener = (event: { newState: State; oldState: State }) => void;
+type NotificationListener = () => void;
+
+/** A fake client that exposes its state + notification listeners to the test. */
+interface FakeClientHandles {
+  client: LanguageClient;
+  fireState: (state: State) => void;
+  fireNotification: (method: string) => void;
+}
+
+function fakeClient(): FakeClientHandles {
+  const stateListeners: StateListener[] = [];
+  const notificationListeners = new Map<string, NotificationListener>();
+  const client = {
+    isRunning: (): boolean => true,
+    onDidChangeState: (listener: StateListener): vscode.Disposable => {
+      stateListeners.push(listener);
+      return { dispose: (): undefined => undefined };
+    },
+    onNotification: (method: string, listener: NotificationListener): vscode.Disposable => {
+      notificationListeners.set(method, listener);
+      return { dispose: (): undefined => undefined };
+    },
+    sendRequest: async (): Promise<unknown> => ({ modules: [], workspace: undefined }),
+    initializeResult: { capabilities: {} },
+  } as unknown as LanguageClient;
+  return {
+    client,
+    fireState: (state: State): void => {
+      for (const listener of stateListeners) {
+        listener({ newState: state, oldState: State.Starting });
+      }
+    },
+    fireNotification: (method: string): void => {
+      notificationListeners.get(method)?.();
+    },
+  };
+}
+
+function storeWithFakeClient(): { store: Store; handles: FakeClientHandles } {
+  const store = createStore();
+  const handles = fakeClient();
+  store.setClient({ subscriptions: [] } as unknown as vscode.ExtensionContext, handles.client);
+  return { store, handles };
+}
+
+suite("Centralized analysis reactivity (issue #58)", () => {
+  /**
+   * Run fn with command registration stubbed: the store's Running handler
+   * registers real client commands, which the already-activated extension
+   * owns — the stub keeps this component test from colliding with it.
+   */
+  function withStubbedCommands(fn: () => void): void {
+    const original = vscode.commands.registerCommand;
+    (vscode.commands as { registerCommand: unknown }).registerCommand = (): vscode.Disposable => ({
+      dispose: (): undefined => undefined,
+    });
+    try {
+      fn();
+    } finally {
+      (vscode.commands as { registerCommand: unknown }).registerCommand = original;
+    }
+  }
+
+  test("analysisRevision bumps when the server reaches Running", () => {
+    withStubbedCommands(() => {
+      const { store, handles } = storeWithFakeClient();
+      const before = store.analysisRevision.value;
+      handles.fireState(State.Running);
+      assert.ok(
+        store.analysisRevision.value > before,
+        "reaching Running must bump analysisRevision so panels leave 'Waiting for analysis...'",
+      );
+    });
+  });
+
+  test("analysisRevision bumps on basilisk/moduleChanged", () => {
+    withStubbedCommands(() => {
+      const { store, handles } = storeWithFakeClient();
+      handles.fireState(State.Running);
+      const before = store.analysisRevision.value;
+      handles.fireNotification("basilisk/moduleChanged");
+      assert.ok(
+        store.analysisRevision.value > before,
+        "re-analysis completion must bump analysisRevision",
+      );
+    });
+  });
+
+  test("Modules panel refreshes automatically when analysisRevision bumps", async () => {
+    const { store } = storeWithFakeClient();
+    const provider = new ModuleExplorerProvider(store);
+    try {
+      wireReactiveRefresh(store, provider);
+
+      const fired = new Promise<void>((resolve) => {
+        const sub = provider.onDidChangeTreeData(() => {
+          sub.dispose();
+          resolve();
+        });
+      });
+      store.bumpAnalysisRevision();
+      await fired;
+    } finally {
+      provider.dispose();
+    }
+  });
+
+  test("diagnostics changes bump analysisRevision (debounced)", async function () {
+    this.timeout(10_000);
+    const { store } = storeWithFakeClient();
+    const before = store.analysisRevision.value;
+
+    // Drive a REAL diagnostics change through the VS Code API.
+    const collection = vscode.languages.createDiagnosticCollection("bsk-issue58-test");
+    try {
+      collection.set(vscode.Uri.parse("untitled:issue58-test.py"), [
+        new vscode.Diagnostic(new vscode.Range(0, 0, 0, 1), "issue58 probe"),
+      ]);
+      // The bump is debounced — poll briefly.
+      const deadline = Date.now() + 5000;
+      while (store.analysisRevision.value === before && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      assert.ok(
+        store.analysisRevision.value > before,
+        "a diagnostics change must bump analysisRevision per EXTACT-HEALTH-REFRESH",
+      );
+    } finally {
+      collection.dispose();
+    }
+  });
+});

--- a/website/src/docs/rules/index.md
+++ b/website/src/docs/rules/index.md
@@ -181,6 +181,7 @@ checker source (`scripts/gen_rules_reference.py`) — it is the authoritative li
 | `BSK-E0152` | Missing type stubs for installed package |
 | `BSK-E0153` | Invalid call to a constructor-derived callable |
 | `BSK-E0154` | Access to a module attribute the local stub does not declare |
+| `BSK-E0155` | PEP 695 syntax used below the configured target Python version |
 | `BSK-W0011` | Undeclared dependency import |
 | `BSK-W0012` | Unused dependency |
 | `BSK-W0013` | Stale uv lock file |

--- a/website/src/zh/docs/rules/index.md
+++ b/website/src/zh/docs/rules/index.md
@@ -174,6 +174,8 @@ Basilisk 内置 **151 个诊断代码**（146 个错误，5 个警告），覆�
 | `BSK-E0151` | Invalid `TypeAliasType(...)` call |
 | `BSK-E0152` | Missing type stubs for installed package |
 | `BSK-E0153` | Invalid call to a constructor-derived callable |
+| `BSK-E0154` | Access to a module attribute the local stub does not declare |
+| `BSK-E0155` | PEP 695 syntax used below the configured target Python version |
 | `BSK-W0011` | Undeclared dependency import |
 | `BSK-W0012` | Unused dependency |
 | `BSK-W0013` | Stale uv lock file |


### PR DESCRIPTION
Fixes every open `critical`/`showstopper` issue, each via the test-first bug-fix workflow (failing test confirmed before each fix).

## #110 — BSK-W0050 corrupts Pydantic/dataclass models (data loss)
The rule no longer fires on annotated fields of `pydantic.BaseModel` subclasses (direct or transitive) or `@dataclass`/`@dataclasses.dataclass`/attrs (`@define`, `@attr.s`, …) classes — there the annotation is what makes the assignment a field, and the autofix was silently deleting fields (6 files / 14 fields in the reported run). Plain classes still warn. Tests: `w0050_tests.rs` (+7).

## #93 — Rules are now Python-version-aware ([CHKARCH-VERSION-TARGET])
- `python_version` / `python_platform` flow from `BasiliskConfig` (`pyproject.toml [tool.basilisk]`, `basilisk.json`) into a typed `CheckContext` threaded through `rules::run_all` into **every** rule. The 3.12 default is centralized in one constant; malformed versions fall back to it.
- `BSK-E0150` dead-branch analysis uses the configured target (a 3.9 target now flags the *else* branch of `if sys.version_info < (3, 10)`, not the if-body).
- New **BSK-E0155**: PEP 695 syntax (`type X = …`, `class C[T]`, `def f[T]`) on a sub-3.12 target is an error with remediation.
- When the config doesn't pin a version, the CLI and LSP resolve it per `[LSPUV-PYTHON-VERSION-RESOLUTION-ORDER]`: `.python-version` → `[project].requires-python` lower bound → `uv.lock` (`resolve_target_python_version`, previously dead code).
- Specs updated (`CHKARCH-VERSION-TARGET`/`-NARROWING`, LSP-UV §4.2 reconciled); website rule tables updated (en + zh, also backfilled missing E0154 in zh). Tests: `version_target_tests.rs` (9).

## #94 — uv failures: classified toast instead of raw resolver dump ([LSPUV-COMMAND-FAILURE-UX])
`uv add org` now toasts *"Package `org` couldn't be found or has no compatible version. Check the package name for a typo…"* instead of the resolver tree. Categories: package-not-found, resolution-conflict, network, uv-not-on-PATH, generic (→ points at Output channel). Full stderr stays in the Output channel. Failure logs gain structured `command`, `package`, `exit_code`, `failure_category`, `duration_ms`. Spec §9.1 added. Tests: 2 new e2e against real uv.

## #81 — profiler attach failures are diagnosable
The helper now sends `Message::AttachFailed { reason }` over the socket before exiting (protocol addition), and the LSP classifies it: target-process-exited, permission-denied (elevation hint), or the verbatim py-spy error. A bare EOF from an old helper harvests the helper's exit status. The undiagnosable *"helper closed the connection before confirming attach"* is gone. Tests: new dead-PID e2e + strengthened #61 test.

## #79 — inline "Profile CPU" flame icon works
`basilisk.profileProcess` / `basilisk.memoryTrackProcess` fall back to the tree view's current selection when VS Code invokes the inline button with `item === undefined`, instead of warning "Select a Python process to profile" on a click that was ON a process row. Tests: 3 component e2e (selection fallback CPU + memory, warn-only-when-truly-no-target).

## #113 — MODULES toolbar contract ([VSIX-MODULE-EXPLORER-TOOLBAR])
- Deterministic `navigation@1..5` ordering: refresh, collapse, tree/flat, filter, sort (read-only actions only, inline).
- Mutating actions (`organizeImports`, `fixWorkspace`) and `restartServer` moved to divided overflow groups — which also removes the `$(refresh)` / `$(debug-restart)` near-duplicate glyph pair from the icon row.
- **Fix All is feature-flagged**: `basilisk.experimental.fixAll` (boolean, default `false`) added to the `when` clause.
- Spec section added; 2 contract tests enforce order, glyph uniqueness, and the flag.

## #58 — panels are reactive ([EXTACT-REACTIVE-STATE])
The store owns a single `analysisRevision` Preact signal bumped on server-Running, `basilisk/moduleChanged`, and (debounced) diagnostics changes. The Modules panel subscribes via `effect()`; its hand-rolled `setInterval` poll is deleted. "Waiting for analysis…" now resolves without a manual Refresh. Spec mandate added; 4 reactivity tests.

## Infra fixes found along the way
- `vscode-extension/.vscode-test.mjs`: falls back to a short tmp `--user-data-dir` when the checkout path exceeds macOS's 104-byte AF_UNIX socket limit (VS Code died with `listen EINVAL` in deep checkouts).
- `scripts/conformance.sh --fetch-only` now respects the pinned-ref cache instead of force-refetching on every `make test` (offline-safe; `--fetch` still forces).

## Validation
- `make lint` ✓ (clippy strict, ESLint, Deslop duplication gate)
- `make test`: Rust + coverage thresholds ✓, VSIX 334+ tests with 89% ≥ 87% coverage ✓, Zed ✓. The Neovim phase fails locally with "15/16 spec files produced a summary" — **verified pre-existing**: the identical failure reproduces on the untouched base commit (91a1511) with a stashed tree; all 25 tests inside the affected spec pass, only plenary's summary line is swallowed in this environment.

Fixes #110. Fixes #93. Fixes #94. Fixes #81. Fixes #79. Fixes #113. Fixes #58.