### PR TITLE
Fix 7 more bugs and lock 4 already-fixed ones (#108, #107, #64, #36, #37, #25, #24, #56, #26, #39, #22, #13)

### DIFF
--- a/benchmarks/status/darwin-arm64-apple-m4.csv
+++ b/benchmarks/status/darwin-arm64-apple-m4.csv
@@ -3,25 +3,25 @@
 # arch: arm64
 # os: Darwin 25.0.0
 # cores: 10
-# tools: basilisk=basilisk 0.0.0-dev+gd38d794-dirty
+# tools: basilisk=basilisk 0.0.0-dev+g3f0f423-dirty
 # runs: 10 (hyperfine mean wall-clock, milliseconds)
-# generated: 2026-06-13T07:55:06+0500
+# generated: 2026-06-13T11:12:24+0500
 # note: <tool>_ms = COLD full-file CLI check from scratch. <tool>-warm_ms = a repeat run using that tool's own cache. basilisk-warm = --cache result-cache hit; mypy-warm = incremental .mypy_cache hit (cold mypy = --no-incremental). pyright/ty/pyrefly keep NO cross-run result cache, so their warm ~= cold (every run is a full check).
 fixture,basilisk_ms,basilisk-warm_ms,pyright_ms,pyright-warm_ms,mypy_ms,mypy-warm_ms,ty_ms,ty-warm_ms,pyrefly_ms,pyrefly-warm_ms
-e0001_missing_param,390.6,243.7,,,,,,,,
-e0002_missing_return,275.1,101.5,,,,,,,,
-e0010_unresolved_import,151.7,70.8,,,,,,,,
-e0011_explicit_any,386.4,123.3,,,,,,,,
-e0012_argument_type_mismatch,166.9,55.3,,,,,,,,
-e0014_assignment_incompatibility,102.9,61.3,,,,,,,,
-e0016_incompatible_override,155.2,35.5,,,,,,,,
-e0018_undefined_name,271.8,142.4,,,,,,,,
-e0022_unhashable_dict_key,239.3,109.6,,,,,,,,
-e0023_nonexhaustive_match,129.5,39.0,,,,,,,,
-e0026_typevar_single_constraint,134.8,79.1,,,,,,,,
-e0036_classvar_misuse,280.2,102.7,,,,,,,,
-e0038_typeddict_readonly_inheritance,121.2,28.7,,,,,,,,
-e0050_newtype_name_mismatch,139.4,86.9,,,,,,,,
-e0054_final_reassignment,52.1,25.6,,,,,,,,
-e0056_readonly_typeddict_mutation,80.5,28.4,,,,,,,,
-e0093_typeddict_invalid_key,77.1,27.5,,,,,,,,
+e0001_missing_param,403.6,250.3,,,,,,,,
+e0002_missing_return,282.7,101.6,,,,,,,,
+e0010_unresolved_import,154.5,73.0,,,,,,,,
+e0011_explicit_any,391.9,123.1,,,,,,,,
+e0012_argument_type_mismatch,174.8,55.5,,,,,,,,
+e0014_assignment_incompatibility,102.5,63.7,,,,,,,,
+e0016_incompatible_override,155.9,35.5,,,,,,,,
+e0018_undefined_name,273.9,141.6,,,,,,,,
+e0022_unhashable_dict_key,238.9,109.5,,,,,,,,
+e0023_nonexhaustive_match,127.7,38.5,,,,,,,,
+e0026_typevar_single_constraint,134.7,78.6,,,,,,,,
+e0036_classvar_misuse,281.9,103.0,,,,,,,,
+e0038_typeddict_readonly_inheritance,122.1,28.7,,,,,,,,
+e0050_newtype_name_mismatch,139.8,87.7,,,,,,,,
+e0054_final_reassignment,51.6,25.5,,,,,,,,
+e0056_readonly_typeddict_mutation,81.2,28.5,,,,,,,,
+e0093_typeddict_invalid_key,77.6,27.5,,,,,,,,

--- a/benchmarks/status/darwin-arm64-apple-m4.csv
+++ b/benchmarks/status/darwin-arm64-apple-m4.csv
@@ -1,0 +1,27 @@
+# machine: Apple M4
+# cpu: Apple M4
+# arch: arm64
+# os: Darwin 25.0.0
+# cores: 10
+# tools: basilisk=basilisk 0.0.0-dev+g84610fd-dirty
+# runs: 10 (hyperfine mean wall-clock, milliseconds)
+# generated: 2026-06-13T00:11:41+0500
+# note: <tool>_ms = COLD full-file CLI check from scratch. <tool>-warm_ms = a repeat run using that tool's own cache. basilisk-warm = --cache result-cache hit; mypy-warm = incremental .mypy_cache hit (cold mypy = --no-incremental). pyright/ty/pyrefly keep NO cross-run result cache, so their warm ~= cold (every run is a full check).
+fixture,basilisk_ms,basilisk-warm_ms,pyright_ms,pyright-warm_ms,mypy_ms,mypy-warm_ms,ty_ms,ty-warm_ms,pyrefly_ms,pyrefly-warm_ms
+e0001_missing_param,380.8,241.7,,,,,,,,
+e0002_missing_return,266.3,100.1,,,,,,,,
+e0010_unresolved_import,151.0,69.7,,,,,,,,
+e0011_explicit_any,379.8,123.7,,,,,,,,
+e0012_argument_type_mismatch,158.0,54.9,,,,,,,,
+e0014_assignment_incompatibility,98.5,59.8,,,,,,,,
+e0016_incompatible_override,150.5,35.6,,,,,,,,
+e0018_undefined_name,263.6,141.6,,,,,,,,
+e0022_unhashable_dict_key,229.7,109.4,,,,,,,,
+e0023_nonexhaustive_match,120.0,38.8,,,,,,,,
+e0026_typevar_single_constraint,129.1,79.4,,,,,,,,
+e0036_classvar_misuse,272.9,102.9,,,,,,,,
+e0038_typeddict_readonly_inheritance,116.6,28.7,,,,,,,,
+e0050_newtype_name_mismatch,134.1,88.4,,,,,,,,
+e0054_final_reassignment,49.4,25.0,,,,,,,,
+e0056_readonly_typeddict_mutation,76.4,28.5,,,,,,,,
+e0093_typeddict_invalid_key,73.4,25.2,,,,,,,,

--- a/benchmarks/status/darwin-arm64-apple-m4.csv
+++ b/benchmarks/status/darwin-arm64-apple-m4.csv
@@ -3,25 +3,25 @@
 # arch: arm64
 # os: Darwin 25.0.0
 # cores: 10
-# tools: basilisk=basilisk 0.0.0-dev+g84610fd-dirty
+# tools: basilisk=basilisk 0.0.0-dev+gd38d794-dirty
 # runs: 10 (hyperfine mean wall-clock, milliseconds)
-# generated: 2026-06-13T00:11:41+0500
+# generated: 2026-06-13T07:55:06+0500
 # note: <tool>_ms = COLD full-file CLI check from scratch. <tool>-warm_ms = a repeat run using that tool's own cache. basilisk-warm = --cache result-cache hit; mypy-warm = incremental .mypy_cache hit (cold mypy = --no-incremental). pyright/ty/pyrefly keep NO cross-run result cache, so their warm ~= cold (every run is a full check).
 fixture,basilisk_ms,basilisk-warm_ms,pyright_ms,pyright-warm_ms,mypy_ms,mypy-warm_ms,ty_ms,ty-warm_ms,pyrefly_ms,pyrefly-warm_ms
-e0001_missing_param,380.8,241.7,,,,,,,,
-e0002_missing_return,266.3,100.1,,,,,,,,
-e0010_unresolved_import,151.0,69.7,,,,,,,,
-e0011_explicit_any,379.8,123.7,,,,,,,,
-e0012_argument_type_mismatch,158.0,54.9,,,,,,,,
-e0014_assignment_incompatibility,98.5,59.8,,,,,,,,
-e0016_incompatible_override,150.5,35.6,,,,,,,,
-e0018_undefined_name,263.6,141.6,,,,,,,,
-e0022_unhashable_dict_key,229.7,109.4,,,,,,,,
-e0023_nonexhaustive_match,120.0,38.8,,,,,,,,
-e0026_typevar_single_constraint,129.1,79.4,,,,,,,,
-e0036_classvar_misuse,272.9,102.9,,,,,,,,
-e0038_typeddict_readonly_inheritance,116.6,28.7,,,,,,,,
-e0050_newtype_name_mismatch,134.1,88.4,,,,,,,,
-e0054_final_reassignment,49.4,25.0,,,,,,,,
-e0056_readonly_typeddict_mutation,76.4,28.5,,,,,,,,
-e0093_typeddict_invalid_key,73.4,25.2,,,,,,,,
+e0001_missing_param,390.6,243.7,,,,,,,,
+e0002_missing_return,275.1,101.5,,,,,,,,
+e0010_unresolved_import,151.7,70.8,,,,,,,,
+e0011_explicit_any,386.4,123.3,,,,,,,,
+e0012_argument_type_mismatch,166.9,55.3,,,,,,,,
+e0014_assignment_incompatibility,102.9,61.3,,,,,,,,
+e0016_incompatible_override,155.2,35.5,,,,,,,,
+e0018_undefined_name,271.8,142.4,,,,,,,,
+e0022_unhashable_dict_key,239.3,109.6,,,,,,,,
+e0023_nonexhaustive_match,129.5,39.0,,,,,,,,
+e0026_typevar_single_constraint,134.8,79.1,,,,,,,,
+e0036_classvar_misuse,280.2,102.7,,,,,,,,
+e0038_typeddict_readonly_inheritance,121.2,28.7,,,,,,,,
+e0050_newtype_name_mismatch,139.4,86.9,,,,,,,,
+e0054_final_reassignment,52.1,25.6,,,,,,,,
+e0056_readonly_typeddict_mutation,80.5,28.4,,,,,,,,
+e0093_typeddict_invalid_key,77.1,27.5,,,,,,,,

--- a/crates/basilisk-checker/src/rules/e0018.rs
+++ b/crates/basilisk-checker/src/rules/e0018.rs
@@ -1,13 +1,17 @@
 //! Implements [BSK-E0018] from [CHKARCH-DIAG-TYPESAFETY]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#chkarch-diag-typesafety
 //! BSK-E0018: Undefined variable used in a return statement.
 //!
-//! When a function contains a `return <name>` statement and the name is not
-//! defined anywhere in the function scope (not a parameter, not assigned via
-//! `=`, `for`, `with`, or a nested `def`), it is flagged as undefined.
+//! Flags any name referenced in a `return` expression — bare (`return x`), the
+//! base of an attribute/subscript chain (`return x.y`), a call argument, or the
+//! **callee of a call** (`return x()`) — that is not defined in scope. A name is
+//! considered defined if it is a parameter, a local assignment (`=`, `for`,
+//! `with`), a module-level function, class, variable, or import, an enclosing
+//! scope's binding, a cross-module imported symbol, or a builtin.
 //!
 //! ```python
 //! def compute() -> int:
-//!     return undefined_name   # undefined_name is never assigned → E0018
+//!     return undefined_name     # never defined → E0018
+//!     return undefined_fn()     # undefined callee → E0018
 //! ```
 
 use basilisk_resolver::{FunctionInfo, ResolvedModule, Span};
@@ -48,18 +52,30 @@ impl Rule for UndefinedVariable {
         // Collect module-level variable names so functions can reference them.
         let module_var_names: Vec<&str> = basilisk_resolver::collect_names(&module.module_vars);
 
+        // Module-level class names are in scope for any function body, just like
+        // module-level functions, variables, and imports.
+        let class_names: Vec<&str> = module.classes.iter().map(|c| c.name.as_str()).collect();
+
+        let scope = ModuleScope {
+            import_names: &import_names,
+            module_var_names: &module_var_names,
+            class_names: &class_names,
+            imported_symbols: &module.imported_symbols,
+        };
+
         module.functions.iter().for_each(|func| {
-            check_function(
-                func,
-                &module.functions,
-                &import_names,
-                &module_var_names,
-                &module.imported_symbols,
-                &module.path,
-                diagnostics,
-            );
+            check_function(func, &module.functions, &scope, &module.path, diagnostics);
         });
     }
+}
+
+/// Module-scope names visible to every function body.
+struct ModuleScope<'a> {
+    import_names: &'a [&'a str],
+    module_var_names: &'a [&'a str],
+    class_names: &'a [&'a str],
+    imported_symbols:
+        &'a std::collections::HashMap<String, basilisk_resolver::scope::ExternalSymbol>,
 }
 
 /// Check whether `name` is defined in any enclosing function's scope.
@@ -203,9 +219,7 @@ const BUILTINS: &[&str] = &[
 fn check_function(
     func: &FunctionInfo,
     all_functions: &[FunctionInfo],
-    import_names: &[&str],
-    module_var_names: &[&str],
-    imported_symbols: &std::collections::HashMap<String, basilisk_resolver::scope::ExternalSymbol>,
+    scope: &ModuleScope<'_>,
     path: &str,
     out: &mut Vec<Diagnostic>,
 ) {
@@ -217,9 +231,14 @@ fn check_function(
             || func.vararg.as_ref().is_some_and(|v| v.name == name_str)
             || func.kwarg.as_ref().is_some_and(|k| k.name == name_str)
             || func.all_local_assigns.iter().any(|a| a == name)
-            || import_names.contains(&name_str)
-            || module_var_names.contains(&name_str)
-            || imported_symbols.contains_key(name_str)
+            || scope.import_names.contains(&name_str)
+            || scope.module_var_names.contains(&name_str)
+            || scope.class_names.contains(&name_str)
+            || scope.imported_symbols.contains_key(name_str)
+            // Any function defined in the module (sibling, nested, or the function
+            // itself for recursion) is a name in scope — `return helper()` and
+            // `return helper` must not be flagged for a real `def helper`.
+            || all_functions.iter().any(|f| f.name == name_str)
             || is_in_enclosing_scope(name_str, func, all_functions)
             || BUILTINS.contains(&name_str)
         {

--- a/crates/basilisk-checker/src/rules/e0131/yield_scan.rs
+++ b/crates/basilisk-checker/src/rules/e0131/yield_scan.rs
@@ -90,8 +90,14 @@ pub(super) fn find_yield_expressions(body: &str, body_offset: usize) -> Vec<Yiel
 }
 
 /// Extract the expression text after a yield keyword.
+///
+/// Only horizontal whitespace is skipped: a bare `yield` at end of line must
+/// yield the empty expression (`None`), never the next statement's text.
 fn extract_yield_expr(body: &str, start: usize) -> String {
-    let rest = body.get(start..).unwrap_or("").trim_start();
+    let rest = body
+        .get(start..)
+        .unwrap_or("")
+        .trim_start_matches([' ', '\t']);
     // Find the end of the expression: newline, comment, or end of string
     let mut depth = 0i32;
     let mut end = rest.len();

--- a/crates/basilisk-checker/tests/checker/e0014_tests.rs
+++ b/crates/basilisk-checker/tests/checker/e0014_tests.rs
@@ -265,3 +265,40 @@ x, y = "wrong", 42
     let _msgs = messages_for(&diags, "BSK-E0014");
     Ok(())
 }
+
+#[test]
+fn e0014_no_false_positive_on_variadic_tuple_of_tuples_annotation(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Regression for issue #26: a concrete-length tuple literal of homogeneous
+    // element types is assignable to the variadic `tuple[T, ...]` annotation.
+    let source = r#"
+_DIRECT_TENANT_TABLES: tuple[tuple[str, str], ...] = (
+    ("tenants", "id"),
+    ("agent_configs", "tenant_id"),
+)
+"#;
+    let diags = run(source)?;
+    let msgs = messages_for(&diags, "BSK-E0014");
+    assert!(
+        msgs.is_empty(),
+        "tuple[tuple[str, str], ...] = (..matching pairs..) should NOT fire E0014, got: {msgs:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn e0014_variadic_tuple_of_tuples_element_mismatch_fires() -> Result<(), Box<dyn std::error::Error>>
+{
+    // The true-positive pair for issue #26: an element violating the variadic
+    // element type must still be flagged.
+    let source = r#"
+_BAD: tuple[tuple[str, str], ...] = (("a", 1), ("c", "d"))
+"#;
+    let diags = run(source)?;
+    let msgs = messages_for(&diags, "BSK-E0014");
+    assert!(
+        !msgs.is_empty(),
+        "a (str, int) element must still fire E0014 against tuple[tuple[str, str], ...]"
+    );
+    Ok(())
+}

--- a/crates/basilisk-checker/tests/checker/e0018_tests.rs
+++ b/crates/basilisk-checker/tests/checker/e0018_tests.rs
@@ -92,3 +92,69 @@ def _patch_jwt(claims: dict[str, object]) -> object:
     );
     Ok(())
 }
+
+#[test]
+fn e0018_undefined_callee_in_return_call_fires() -> Result<(), Box<dyn std::error::Error>> {
+    // The callee of a call in a return must be checked, not just bare names:
+    // `return undefined_fn()` references `undefined_fn`.
+    let source = "def f() -> object:\n    return undefined_fn()\n";
+    let diags = run(source)?;
+    assert!(
+        codes(&diags).contains(&"BSK-E0018"),
+        "an undefined callee in a return call should fire E0018, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}
+
+#[test]
+fn e0018_sibling_function_call_no_false_positive() -> Result<(), Box<dyn std::error::Error>> {
+    // Calling a sibling module-level function must not fire — it is in scope.
+    let source = "def helper() -> int:\n    return 1\n\n\ndef use() -> int:\n    return helper()\n";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0018"),
+        "`return helper()` for a module-level function must not fire E0018, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}
+
+#[test]
+fn e0018_bare_sibling_function_no_false_positive() -> Result<(), Box<dyn std::error::Error>> {
+    // Returning a sibling module-level function by name is valid (it IS defined).
+    let source = "def helper() -> int:\n    return 1\n\n\ndef use() -> object:\n    return helper\n";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0018"),
+        "`return helper` for a module-level function must not fire E0018, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}
+
+#[test]
+fn e0018_class_instantiation_no_false_positive() -> Result<(), Box<dyn std::error::Error>> {
+    // Instantiating a module-level class must not fire.
+    let source = "class Foo:\n    pass\n\n\ndef make() -> Foo:\n    return Foo()\n";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0018"),
+        "`return Foo()` for a module-level class must not fire E0018, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}
+
+#[test]
+fn e0018_builtin_call_no_false_positive() -> Result<(), Box<dyn std::error::Error>> {
+    // A builtin callee must not fire.
+    let source = "def f() -> int:\n    return len([1, 2])\n";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0018"),
+        "`return len(...)` (builtin callee) must not fire E0018, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}

--- a/crates/basilisk-checker/tests/checker/e0018_tests.rs
+++ b/crates/basilisk-checker/tests/checker/e0018_tests.rs
@@ -68,3 +68,27 @@ fn e0018_diagnostic_has_help() -> Result<(), Box<dyn std::error::Error>> {
     assert!(diag.help.is_some(), "E0018 should have help text");
     Ok(())
 }
+
+#[test]
+fn e0018_aliased_module_import_in_return_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // Issues #107/#64: `from <pkg> import <mod> as <alias>` binds `<alias>` at
+    // module scope; using it in a nested function's return expression is valid.
+    let source = r#"
+from unittest.mock import patch
+from nap.api import auth as auth_mod
+
+def _patch_jwt(claims: dict[str, object]) -> object:
+    return patch.object(auth_mod, "_decode_supabase_jwt", return_value=claims)
+"#;
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0018"),
+        "aliased module import used in a return expression must not fire E0018, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0018")
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}

--- a/crates/basilisk-checker/tests/checker/e0018_tests.rs
+++ b/crates/basilisk-checker/tests/checker/e0018_tests.rs
@@ -123,7 +123,8 @@ fn e0018_sibling_function_call_no_false_positive() -> Result<(), Box<dyn std::er
 #[test]
 fn e0018_bare_sibling_function_no_false_positive() -> Result<(), Box<dyn std::error::Error>> {
     // Returning a sibling module-level function by name is valid (it IS defined).
-    let source = "def helper() -> int:\n    return 1\n\n\ndef use() -> object:\n    return helper\n";
+    let source =
+        "def helper() -> int:\n    return 1\n\n\ndef use() -> object:\n    return helper\n";
     let diags = run(source)?;
     assert!(
         !codes(&diags).contains(&"BSK-E0018"),

--- a/crates/basilisk-checker/tests/checker/e0120_tests.rs
+++ b/crates/basilisk-checker/tests/checker/e0120_tests.rs
@@ -84,3 +84,146 @@ def gen() -> Iterable[str]:
     );
     Ok(())
 }
+
+#[test]
+fn e0120_asynccontextmanager_async_iterator_not_flagged() -> Result<(), Box<dyn std::error::Error>>
+{
+    // Issue #36: async generators decorated with @asynccontextmanager are the
+    // canonical async-context-manager pattern and must be accepted.
+    let source = r"
+from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator
+
+@asynccontextmanager
+async def lifespan() -> AsyncIterator[None]:
+    yield
+";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0120"),
+        "@asynccontextmanager async generator with AsyncIterator[None] must not fire E0120, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0120")
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn e0120_asynccontextmanager_async_generator_annotation_not_flagged(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Issue #36: the AsyncGenerator[T, None] spelling is equally valid.
+    let source = r"
+from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator
+
+@asynccontextmanager
+async def session() -> AsyncGenerator[int, None]:
+    yield 1
+";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0120"),
+        "@asynccontextmanager async generator with AsyncGenerator[int, None] must not fire E0120, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0120")
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn e0120_dotted_async_iterator_annotation_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // Issue #36: a dotted generator annotation (`typing.AsyncIterator[None]`)
+    // is the same valid type as the unqualified spelling.
+    let source = r"
+import contextlib
+import typing
+
+@contextlib.asynccontextmanager
+async def lifespan() -> typing.AsyncIterator[None]:
+    yield
+";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0120"),
+        "typing.AsyncIterator[None] async generator must not fire E0120, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0120")
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn e0120_collections_abc_dotted_annotation_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // Issue #36: `collections.abc.AsyncIterator[None]`, no decorator — the
+    // false positive is independent of @asynccontextmanager.
+    let source = r"
+import collections.abc
+
+async def agen() -> collections.abc.AsyncIterator[None]:
+    yield
+";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0120"),
+        "collections.abc.AsyncIterator[None] must not fire E0120, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0120")
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn e0120_string_annotation_async_iterator_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // Issue #36: a string (forward-reference) generator annotation is valid.
+    let source = r#"
+from collections.abc import AsyncIterator
+
+async def agen() -> "AsyncIterator[None]":
+    yield
+"#;
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0120"),
+        "string annotation AsyncIterator[None] must not fire E0120, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0120")
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}
+
+#[test]
+fn e0120_dotted_sync_iterator_annotation_not_flagged() -> Result<(), Box<dyn std::error::Error>> {
+    // Issue #36: same defect for sync generators with `typing.Iterator[int]`.
+    let source = r"
+import typing
+
+def gen() -> typing.Iterator[int]:
+    yield 1
+";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0120"),
+        "typing.Iterator[int] sync generator must not fire E0120, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0120")
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}

--- a/crates/basilisk-checker/tests/checker/e0131_tests.rs
+++ b/crates/basilisk-checker/tests/checker/e0131_tests.rs
@@ -65,3 +65,32 @@ def outer() -> Generator[int, None, None]:
     let _ = codes(&diags);
     Ok(())
 }
+
+#[test]
+fn e0131_bare_yield_in_iterator_none_generator_not_flagged(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Issue #108: a bare `yield` yields `None`, which is compatible with
+    // `Iterator[None]`. The checker must not associate the value of the
+    // NEXT statement (`_purge()`) with the bare yield.
+    let source = r"
+from collections.abc import Iterator
+
+def _purge() -> None: ...
+
+def _restore_workspace_modules() -> Iterator[None]:
+    _purge()
+    yield
+    _purge()
+";
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"BSK-E0131"),
+        "bare yield in an Iterator[None] generator must not fire E0131, got: {:?}",
+        diags
+            .iter()
+            .filter(|d| d.code.code == "BSK-E0131")
+            .map(|d| d.message.as_str())
+            .collect::<Vec<_>>()
+    );
+    Ok(())
+}

--- a/crates/basilisk-checker/tests/checker/w0050_tests.rs
+++ b/crates/basilisk-checker/tests/checker/w0050_tests.rs
@@ -200,3 +200,20 @@ fn test_w0050_plain_class_attribute_still_flagged() {
     let diags = run("class Plain:\n    x: int = 42\n").unwrap();
     assert!(diags.iter().any(|d| d.code.code == "BSK-W0050"));
 }
+
+#[test]
+fn test_w0050_pydantic_dataclasses_dotted_decorator_field_not_flagged() {
+    // Regression for issue #39: `@pydantic.dataclasses.dataclass` fields need
+    // their annotation to be fields at all — never redundant.
+    let diags = run(concat!(
+        "import pydantic\n",
+        "@pydantic.dataclasses.dataclass\n",
+        "class ChatTurnInput:\n",
+        "    tool_results_already_persisted: bool = False\n",
+    ))
+    .unwrap();
+    assert!(
+        !diags.iter().any(|d| d.code.code == "BSK-W0050"),
+        "W0050 must not fire on pydantic dataclass fields (issue #39)"
+    );
+}

--- a/crates/basilisk-checker/tests/checker_tests.rs
+++ b/crates/basilisk-checker/tests/checker_tests.rs
@@ -474,6 +474,20 @@ fn e0015_list_empty_brackets() {
 }
 
 #[test]
+fn deeply_nested_source_rejected_not_crashed() {
+    // [CHKARCH-ARCH-PARSEDEPTH]: a 5000-deep bracket file overflows the recursive
+    // parser/visitors. The parse guard must turn it into a parse error so the
+    // whole pipeline (parse -> resolve -> check) returns cleanly instead of
+    // aborting the process.
+    let src = format!("x = {}1{}\n", "(".repeat(5000), ")".repeat(5000));
+    let err = run(&src).expect_err("pathologically nested source must be rejected, not crash");
+    assert!(
+        err.to_string().contains("too many nested parentheses"),
+        "the depth-guard rejection must propagate through the pipeline, got: {err}"
+    );
+}
+
+#[test]
 fn e0015_correct_list_does_not_fire() -> Result<(), Box<dyn std::error::Error>> {
     let src = "def foo(x: list[int]) -> None: pass\n";
     let diags = run(src)?;

--- a/crates/basilisk-cli/src/main.rs
+++ b/crates/basilisk-cli/src/main.rs
@@ -48,8 +48,9 @@ enum Transport {
 enum Command {
     /// Type check one or more files or directories.
     Check {
-        /// Paths to check. Directories are traversed recursively for `.py` files.
-        #[arg(default_value = ".")]
+        /// Paths to check. Directories are traversed recursively for `.py`
+        /// files. Defaults to the configured `[tool.basilisk] include` roots,
+        /// else the current directory.
         paths: Vec<String>,
         /// Output format: text (default, human-readable) or json (machine-readable).
         #[arg(long, default_value = "text")]
@@ -469,6 +470,26 @@ fn run_check(paths: &[String], format: OutputFormat, cache: &cache_check::CacheO
     }
 }
 
+/// Resolve the paths a check run walks. Implements [CHKARCH-CONFIG-INCLUDE]:
+/// explicit CLI paths win, then the configured `include` roots, then `.`.
+fn effective_check_paths(
+    paths: &[String],
+    config: &basilisk_config::BasiliskConfig,
+    config_root: &std::path::Path,
+) -> Vec<String> {
+    if !paths.is_empty() {
+        return paths.to_vec();
+    }
+    if config.include.is_empty() {
+        return vec![".".to_owned()];
+    }
+    config
+        .include
+        .iter()
+        .map(|inc| config_root.join(inc).to_string_lossy().into_owned())
+        .collect()
+}
+
 fn collect_and_check(
     paths: &[String],
     cache: &cache_check::CacheOptions,
@@ -501,6 +522,9 @@ fn collect_and_check(
         config_root.display()
     );
 
+    // Implements [CHKARCH-CONFIG-INCLUDE] (issue #37): a no-args run walks
+    // only the configured include roots, never the whole repository.
+    let paths = &effective_check_paths(paths, &config, &config_root);
     let python_files = collect_python_files(paths, &excluded)?;
 
     // Build import search paths (venv, uv registry, workspace members).

--- a/crates/basilisk-cli/tests/e2e_import_resolution.rs
+++ b/crates/basilisk-cli/tests/e2e_import_resolution.rs
@@ -1,0 +1,179 @@
+//! Tests for [LSPUV-DIAGNOSTICS-MODULE-NOT-FOUND], [LSPUV-LOCK-IMPORT-MAPPING],
+//! and [LSPUV-WORKSPACE-IMPORT-RESOLUTION]. See docs/specs/LSP-UV-SPEC.md.
+#![allow(
+    clippy::allow_attributes,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+//! Coarse end-to-end tests for import-resolution classification (issue #25)
+//! and src-layout first-party resolution in the CLI (issue #24).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A throwaway directory unique to this process and call.
+fn unique_dir(prefix: &str) -> PathBuf {
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("bsk_imres_{prefix}_{}_{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Run `basilisk check <args...>` from inside `dir` with no ambient venv.
+fn check(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_basilisk"))
+        .arg("check")
+        .args(args)
+        .current_dir(dir)
+        .env_remove("VIRTUAL_ENV")
+        .output()
+        .expect("spawn basilisk")
+}
+
+/// Issue #25: an unsynced-but-declared dependency whose import name differs
+/// from its distribution name (Pillow → PIL) must be classified as
+/// "declared but the environment is not synced", not "not a dependency".
+#[test]
+fn declared_unsynced_pillow_classified_as_needs_sync() {
+    let dir = unique_dir("pillow");
+    std::fs::write(
+        dir.join("pyproject.toml"),
+        "[project]\nname = \"x\"\nversion = \"0.1.0\"\ndependencies = [\"pillow>=11.0.0\"]\n",
+    )
+    .expect("write pyproject");
+    std::fs::write(
+        dir.join("uv.lock"),
+        "version = 1\nrequires-python = \">=3.12\"\n\n[[package]]\nname = \"pillow\"\nversion = \"11.0.0\"\n",
+    )
+    .expect("write lock");
+    std::fs::create_dir_all(dir.join("src")).expect("mkdir src");
+    std::fs::write(dir.join("src/app.py"), "from PIL import Image\n").expect("write app");
+
+    let output = check(&dir, &["src"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("not a dependency in pyproject.toml"),
+        "PIL is declared (as pillow) — must not be classified NotInstalled, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("declared but the environment is not synced"),
+        "PIL should be classified as needs-sync, got: {stdout}"
+    );
+}
+
+/// Issue #24: in a src-layout project, both `tests.helpers` and the src
+/// package must resolve when checking from the project root.
+#[test]
+fn src_layout_first_party_imports_resolve() {
+    let dir = unique_dir("srclayout");
+    std::fs::write(
+        dir.join("pyproject.toml"),
+        "[project]\nname = \"agent-backend\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write pyproject");
+    std::fs::create_dir_all(dir.join("src/agent_backend/db")).expect("mkdir pkg");
+    std::fs::create_dir_all(dir.join("tests")).expect("mkdir tests");
+    std::fs::write(dir.join("src/agent_backend/__init__.py"), "").expect("write init");
+    std::fs::write(dir.join("src/agent_backend/db/__init__.py"), "").expect("write db init");
+    std::fs::write(
+        dir.join("src/agent_backend/db/models.py"),
+        "class AgentConfig:\n    pass\n",
+    )
+    .expect("write models");
+    std::fs::write(
+        dir.join("tests/helpers.py"),
+        "from agent_backend.db.models import AgentConfig\n",
+    )
+    .expect("write helpers");
+    std::fs::write(
+        dir.join("tests/test_foo.py"),
+        "from tests.helpers import AgentConfig\n",
+    )
+    .expect("write test_foo");
+
+    let output = check(&dir, &["."]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("BSK-E0010"),
+        "first-party src-layout imports must resolve, got: {stdout}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "src-layout project must check clean, stdout: {stdout}"
+    );
+}
+
+/// Issue #22: a bare `import foo` where `foo.py` is a sibling file in the
+/// same scripts directory (no `__init__.py`) must resolve via the importing
+/// file's own directory (sys.path[0] semantics) — even when the check is
+/// pointed at the project ROOT, not the scripts directory.
+#[test]
+fn sibling_script_import_resolves_from_project_root() {
+    let dir = unique_dir("sibling");
+    std::fs::create_dir_all(dir.join("scripts")).expect("mkdir scripts");
+    std::fs::write(
+        dir.join("scripts/configure_agent_backend.py"),
+        "def main() -> None:\n    pass\n",
+    )
+    .expect("write sibling");
+    std::fs::write(
+        dir.join("scripts/configure_agent_backend_test.py"),
+        "from configure_agent_backend import main\nimport configure_agent_backend as subject\n",
+    )
+    .expect("write importer");
+
+    let output = check(&dir, &["."]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("BSK-E0010"),
+        "sibling-module script imports must resolve (issue #22), got: {stdout}"
+    );
+}
+
+/// Issue #13: packages shipping a PEP 561 `py.typed` marker are typed — no
+/// stub diagnostic; a genuinely untyped package still fires, and its help must
+/// not fabricate a nonexistent `types-X` distribution.
+#[test]
+fn py_typed_packages_not_flagged_untyped_ones_still_fire() {
+    let dir = unique_dir("pytyped");
+    let site = dir.join(".venv/lib/python3.12/site-packages");
+    std::fs::create_dir_all(site.join("typedpkg_fake/orm")).expect("mkdir typed");
+    std::fs::create_dir_all(site.join("untypedpkg_fake")).expect("mkdir untyped");
+    std::fs::write(site.join("typedpkg_fake/__init__.py"), "").expect("write init");
+    std::fs::write(site.join("typedpkg_fake/py.typed"), "").expect("write marker");
+    std::fs::write(
+        site.join("typedpkg_fake/orm/__init__.py"),
+        "class Session:\n    pass\n",
+    )
+    .expect("write orm");
+    std::fs::write(site.join("untypedpkg_fake/__init__.py"), "").expect("write untyped");
+    std::fs::create_dir_all(dir.join("src")).expect("mkdir src");
+    std::fs::write(
+        dir.join("src/app.py"),
+        "import typedpkg_fake\nfrom typedpkg_fake.orm import Session\nimport untypedpkg_fake\n",
+    )
+    .expect("write app");
+
+    let output = check(&dir, &["src"]);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains("`typedpkg_fake`"),
+        "a py.typed package must not be flagged as untyped (issue #13), got: {stdout}"
+    );
+    assert!(
+        stdout.contains("`untypedpkg_fake`"),
+        "a genuinely untyped package must still be flagged, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("types-untypedpkg_fake"),
+        "help text must not fabricate a nonexistent types-X distribution, got: {stdout}"
+    );
+}

--- a/crates/basilisk-cli/tests/e2e_include_config.rs
+++ b/crates/basilisk-cli/tests/e2e_include_config.rs
@@ -1,0 +1,126 @@
+//! Tests for [CHKARCH-CONFIG-INCLUDE]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CONFIG-INCLUDE
+#![allow(
+    clippy::allow_attributes,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+//! Coarse end-to-end tests for `[tool.basilisk] include` as the default check
+//! roots (issue #37): a no-args `basilisk check` must walk only the configured
+//! include roots instead of the whole repository, so files the user excluded
+//! by omission (vendored/generated trees) can no longer crash the process.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A throwaway directory unique to this process and call.
+fn unique_dir(prefix: &str) -> PathBuf {
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("bsk_include_{prefix}_{}_{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Run `basilisk check` with no path arguments from inside `dir`.
+fn check_no_args(dir: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_basilisk"))
+        .arg("check")
+        .current_dir(dir)
+        .env_remove("VIRTUAL_ENV")
+        .output()
+        .expect("spawn basilisk")
+}
+
+/// Lay down a project with `[tool.basilisk] include = ["src/", "tests/"]`,
+/// clean included sources, and `gen/` content OUTSIDE the include roots.
+fn write_include_project(dir: &Path, generated: &str) {
+    std::fs::write(
+        dir.join("pyproject.toml"),
+        "[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk]\ninclude = [\"src/\", \"tests/\"]\nexclude = [\"**/migrations/**\"]\n",
+    )
+    .expect("write pyproject");
+    std::fs::create_dir_all(dir.join("src")).expect("mkdir src");
+    std::fs::create_dir_all(dir.join("tests")).expect("mkdir tests");
+    std::fs::create_dir_all(dir.join("gen")).expect("mkdir gen");
+    std::fs::write(
+        dir.join("src/main.py"),
+        "def add(a: int, b: int) -> int:\n    return a + b\n",
+    )
+    .expect("write src");
+    std::fs::write(
+        dir.join("tests/test_main.py"),
+        "def test_add() -> None:\n    assert 1 + 1 == 2\n",
+    )
+    .expect("write tests");
+    std::fs::write(dir.join("gen/deep.py"), generated).expect("write gen");
+}
+
+/// Issue #37 repro: a deeply nested expression in a file outside the include
+/// roots overflowed the stack because the no-args run walked the whole repo.
+#[test]
+fn no_args_honors_include_and_does_not_overflow() {
+    let dir = unique_dir("overflow");
+    let deep = format!("x = {}1{}\n", "(".repeat(20000), ")".repeat(20000));
+    write_include_project(&dir, &deep);
+
+    let output = check_no_args(&dir);
+
+    // A stack-overflow abort yields no exit code on Unix; the fixed binary
+    // must exit cleanly without ever parsing gen/deep.py.
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "no-args check must honor include and exit 0, got status {:?}, stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The assertive pair for the include semantics: diagnostics inside include
+/// roots still fire, and files outside them are not checked at all.
+#[test]
+fn no_args_checks_include_roots_only() {
+    let dir = unique_dir("roots");
+    write_include_project(&dir, "def broken() -> int:\n    return \"nope\"\n");
+    // Add a real error inside an include root.
+    std::fs::write(
+        dir.join("src/bad.py"),
+        "def bad() -> int:\n    return \"oops\"\n",
+    )
+    .expect("write bad");
+
+    let output = check_no_args(&dir);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("bad.py"),
+        "errors inside include roots must still be reported, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("deep.py"),
+        "files outside include roots must not be checked, got: {stdout}"
+    );
+}
+
+/// Explicit CLI paths override the configured include roots.
+#[test]
+fn explicit_paths_override_include() {
+    let dir = unique_dir("explicit");
+    write_include_project(&dir, "def broken() -> int:\n    return \"nope\"\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_basilisk"))
+        .arg("check")
+        .arg("gen")
+        .current_dir(&dir)
+        .env_remove("VIRTUAL_ENV")
+        .output()
+        .expect("spawn basilisk");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("deep.py"),
+        "explicit paths must win over include, got: {stdout}"
+    );
+}

--- a/crates/basilisk-config/src/parse.rs
+++ b/crates/basilisk-config/src/parse.rs
@@ -22,6 +22,12 @@ pub struct BasiliskConfig {
     /// regardless of this list.
     pub exclude: Vec<String>,
 
+    /// Roots scanned when no paths are given on the CLI ([CHKARCH-CONFIG-INCLUDE]).
+    ///
+    /// Empty means "check the current directory". Explicit CLI paths always
+    /// override this list; `exclude` applies within the include roots.
+    pub include: Vec<String>,
+
     /// Additional directories to search for `.pyi` stubs.
     pub stub_paths: Vec<PathBuf>,
 
@@ -88,6 +94,7 @@ impl Default for BasiliskConfig {
                 .iter()
                 .map(|s| (*s).to_owned())
                 .collect(),
+            include: Vec::new(),
             stub_paths: Vec::new(),
             rules: HashMap::new(),
             per_module_overrides: HashMap::new(),
@@ -123,6 +130,29 @@ impl BasiliskConfig {
     }
 }
 
+/// Collect the string elements of a JSON array field, if present.
+fn json_string_array(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<Vec<String>> {
+    let arr = obj.get(key)?.as_array()?;
+    Some(
+        arr.iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect(),
+    )
+}
+
+/// Collect the string elements of a TOML array field, if present.
+fn toml_string_array(table: &toml::Table, key: &str) -> Option<Vec<String>> {
+    let arr = table.get(key)?.as_array()?;
+    Some(
+        arr.iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect(),
+    )
+}
+
 /// Load configuration from `basilisk.json`.
 pub fn load_from_json(path: &Path) -> Option<BasiliskConfig> {
     let content = std::fs::read_to_string(path).ok()?;
@@ -131,12 +161,12 @@ pub fn load_from_json(path: &Path) -> Option<BasiliskConfig> {
 
     let mut cfg = BasiliskConfig::default();
 
-    // exclude
-    if let Some(arr) = obj.get("exclude").and_then(|v| v.as_array()) {
-        cfg.exclude = arr
-            .iter()
-            .filter_map(|v| v.as_str().map(String::from))
-            .collect();
+    if let Some(exclude) = json_string_array(obj, "exclude") {
+        cfg.exclude = exclude;
+    }
+    // [CHKARCH-CONFIG-INCLUDE]
+    if let Some(include) = json_string_array(obj, "include") {
+        cfg.include = include;
     }
 
     // stub-paths / stubPaths
@@ -252,12 +282,12 @@ pub fn load_from_pyproject(path: &Path) -> Option<BasiliskConfig> {
 
     let mut cfg = BasiliskConfig::default();
 
-    // exclude
-    if let Some(arr) = basilisk.get("exclude").and_then(|v| v.as_array()) {
-        cfg.exclude = arr
-            .iter()
-            .filter_map(|v| v.as_str().map(String::from))
-            .collect();
+    if let Some(exclude) = toml_string_array(basilisk, "exclude") {
+        cfg.exclude = exclude;
+    }
+    // [CHKARCH-CONFIG-INCLUDE]
+    if let Some(include) = toml_string_array(basilisk, "include") {
+        cfg.include = include;
     }
 
     // stub-paths

--- a/crates/basilisk-lsp/src/cross_module.rs
+++ b/crates/basilisk-lsp/src/cross_module.rs
@@ -262,6 +262,12 @@ pub fn populate_cross_module_symbols(index: &WorkspaceIndex) {
 
         let mut resolved = Arc::try_unwrap(resolved_arc).unwrap_or_else(|arc| (*arc).clone());
 
+        // Repopulate from current exports: clear stale entries first so a
+        // renamed or removed export disappears from importers. Without this the
+        // old name lingers and keeps suppressing its now-undefined references,
+        // leaving dependents green after an export edit (GitHub #56).
+        resolved.imported_symbols.clear();
+
         for import in &resolved.imports {
             let Some(resolved_path) = &import.resolved_path else {
                 continue;

--- a/crates/basilisk-lsp/src/import_resolver.rs
+++ b/crates/basilisk-lsp/src/import_resolver.rs
@@ -68,8 +68,11 @@ impl ImportSearchPaths {
         Self {
             roots: roots.to_vec(),
             extra_paths: config.extra_paths.clone(),
+            // Discover uv workspace members / `src/` layouts here so every
+            // consumer (CLI and LSP) resolves first-party imports the same
+            // way. Implements [LSPUV-WORKSPACE-IMPORT-RESOLUTION] (issue #24).
+            workspace_members: basilisk_uv::discover_workspace_members(roots),
             stub_paths,
-            workspace_members: Vec::new(),
             site_packages,
             registry,
         }
@@ -86,10 +89,13 @@ pub fn classify_unresolved(
         return UnresolvedReason::Unknown;
     };
 
+    // The registry is keyed by import name (issue #25): look the module up
+    // directly — full dotted name first (`google.protobuf`), then the root.
     let root_module = module_name.split('.').next().unwrap_or(module_name);
-    let import_name = basilisk_uv::import_map::package_to_import_name(root_module);
-
-    if let Some(info) = registry.lookup(&import_name) {
+    if let Some(info) = registry
+        .lookup(module_name)
+        .or_else(|| registry.lookup(root_module))
+    {
         if info.kind == basilisk_uv::DepKind::Transitive {
             return UnresolvedReason::NotInDeps;
         }
@@ -606,10 +612,13 @@ fn enrich_package_metadata(
         return;
     }
 
+    // The registry is keyed by import name (issue #25): look the module up
+    // directly — full dotted name first (`google.protobuf`), then the root.
     let root_module = import.module.split('.').next().unwrap_or(&import.module);
-    let import_name = basilisk_uv::import_map::package_to_import_name(root_module);
-
-    let Some(info) = registry.lookup(&import_name) else {
+    let Some(info) = registry
+        .lookup(&import.module)
+        .or_else(|| registry.lookup(root_module))
+    else {
         return;
     };
 

--- a/crates/basilisk-lsp/src/server/document.rs
+++ b/crates/basilisk-lsp/src/server/document.rs
@@ -188,18 +188,22 @@ pub(super) async fn did_change_watched_files(
         }
     }
 
-    // If uv.lock or pyproject.toml changed, rebuild the package registry and
-    // re-resolve all imports so diagnostics update without an LSP restart.
-    let needs_registry_rebuild = params.changes.iter().any(|change| {
+    // A change to any project config file must update diagnostics without an LSP
+    // restart: reload each root's checker config so version-aware rules and
+    // severity overrides take effect (issue #93 reactivity), then rebuild the uv
+    // package registry and re-resolve + re-check every file.
+    let needs_config_refresh = params.changes.iter().any(|change| {
         let path = change.uri.path();
-        path.ends_with("uv.lock") || path.ends_with("pyproject.toml")
+        path.ends_with("uv.lock")
+            || path.ends_with("pyproject.toml")
+            || path.ends_with("basilisk.json")
+            || path.ends_with(".python-version")
     });
 
-    if needs_registry_rebuild {
-        log_uv_config_changes(&params);
+    log_uv_config_changes(&params);
+    if needs_config_refresh {
+        reload_index_configs(server).await;
         super::init::rebuild_registry_and_resolve(server).await;
-    } else {
-        log_uv_config_changes(&params);
     }
 
     // Classify the incoming changes, filtering to Python files only.
@@ -294,6 +298,16 @@ pub(super) async fn did_change_watched_files(
         old.abort();
     }
     *debounce = Some(abort_handle);
+}
+
+/// Re-read each workspace root's checker config from disk after a watched config
+/// file changed, so version-aware rules and severity overrides update without an
+/// LSP restart. Implements [CHKARCH-VERSION-TARGET] reactivity.
+async fn reload_index_configs(server: &LspServer) {
+    let mut guard = server.index.write().await;
+    if let Some(index) = guard.as_mut() {
+        index.reload_root_configs();
+    }
 }
 
 /// Log changes to uv-related configuration files.

--- a/crates/basilisk-lsp/src/server/document.rs
+++ b/crates/basilisk-lsp/src/server/document.rs
@@ -54,9 +54,13 @@ pub(super) async fn did_change(server: &LspServer, params: DidChangeTextDocument
 
     let guard = server.index.read().await;
     let Some(index) = guard.as_ref() else { return };
-    let diags = index.set_open(&uri, &text, version);
+    // In cross-module mode an export-changing edit must refresh dependents live,
+    // even though the edited file is open (GitHub #56). [ANALYSIS-SYMBOLS-INVAL]
+    let results = index.set_open_refresh_dependents(&uri, &text, version);
     drop(guard);
-    server.client.publish_diagnostics(uri, diags, None).await;
+    for (target, diags) in results {
+        server.client.publish_diagnostics(target, diags, None).await;
+    }
 }
 
 /// Handle `textDocument/didSave`: re-run the pipeline on the cached text.
@@ -68,12 +72,11 @@ pub(super) async fn did_save(server: &LspServer, params: DidSaveTextDocumentPara
     let Some(text) = index.get_text(&uri) else {
         return;
     };
-    let diags = index.set_open(&uri, &text, 0);
+    let results = index.set_open_refresh_dependents(&uri, &text, 0);
     drop(guard);
-    server
-        .client
-        .publish_diagnostics(uri.clone(), diags, None)
-        .await;
+    for (target, diags) in results {
+        server.client.publish_diagnostics(target, diags, None).await;
+    }
 
     // Notify activity panels that this module changed.
     super::activity_panel::send_module_changed(server, &uri).await;

--- a/crates/basilisk-lsp/src/server/document.rs
+++ b/crates/basilisk-lsp/src/server/document.rs
@@ -250,15 +250,25 @@ pub(super) async fn did_change_watched_files(
         let guard = index_lock.read().await;
         let Some(index) = guard.as_ref() else { return };
 
+        // Reload changed files while diffing their exported symbol sets: in
+        // cross-module mode an export change must refresh dependents' stale
+        // symbol diagnostics. Implements [ANALYSIS-SYMBOLS-INVAL] (GitHub #56).
+        let mut exports_changed = false;
+        let cross_module = matches!(index.mode, crate::config::AnalysisMode::CrossModule);
         let reload_results: Vec<_> = reload_targets
             .iter()
-            .filter_map(|uri| index.reload_from_disk(uri))
+            .filter_map(|uri| {
+                let (result, changed) = index.reload_and_diff_exports(uri)?;
+                exports_changed |= changed && cross_module;
+                Some(result)
+            })
             .collect();
 
         // When a new module appeared, its dependents may now resolve imports
         // that were previously unresolved. Re-resolve the whole workspace so
         // their stale BSK-E0010 clears without an LSP reload (GitHub #53).
-        let publish_set = if has_created_module {
+        // Likewise when an edited module's exports changed (GitHub #56).
+        let publish_set = if has_created_module || exports_changed {
             // Drop deleted entries first so the recheck cannot resurrect them.
             for uri in &delete_targets {
                 index.forget_file(uri);

--- a/crates/basilisk-lsp/src/server/init.rs
+++ b/crates/basilisk-lsp/src/server/init.rs
@@ -482,9 +482,8 @@ fn scan_resolve_and_check_with_roots(
 
     // Detect uv project, build package registry and discover workspace members.
     let registry = build_uv_registry(roots);
-    let mut search_paths =
+    let search_paths =
         crate::import_resolver::ImportSearchPaths::from_config(roots, &config, registry);
-    search_paths.workspace_members = discover_workspace_members(roots);
     info!(
         site_packages = ?search_paths.site_packages,
         workspace_members = search_paths.workspace_members.len(),
@@ -579,101 +578,6 @@ fn recheck_with_cross_module_symbols(
     results
 }
 
-/// Discover uv workspace member source directories.
-///
-/// Parses `[tool.uv.workspace]` from `pyproject.toml` at each workspace root
-/// and returns the resolved member directory paths. For each member, looks for
-/// a `src/` subdirectory (common Python project layout) and adds it; otherwise
-/// adds the member directory itself.
-///
-/// In monorepo layouts (e.g. `ai_cms/agent-backend/`), `pyproject.toml` may
-/// not be at the workspace root itself. If no uv workspace is found at a root,
-/// we search one level of subdirectories for `pyproject.toml` with `src/`
-/// layouts and add those as source roots.
-///
-/// Returns an empty vec if no workspace members are found.
-pub(crate) fn discover_workspace_members(roots: &[std::path::PathBuf]) -> Vec<std::path::PathBuf> {
-    let mut members = Vec::new();
-
-    for root in roots {
-        // Try uv workspace at this root first.
-        if let Ok(Some(workspace)) = basilisk_uv::parse_uv_workspace(root) {
-            for member_dir in &workspace.members {
-                add_source_root(&mut members, member_dir);
-            }
-
-            if !workspace.members.is_empty() {
-                info!(
-                    root = %root.display(),
-                    member_count = workspace.members.len(),
-                    "discovered uv workspace members"
-                );
-                continue;
-            }
-        }
-
-        // Root itself is a Python project (pyproject.toml at the workspace
-        // root, not inside a uv workspace). Add its source root so first-party
-        // imports resolve under a `src/` layout.
-        if root.join("pyproject.toml").is_file() {
-            add_source_root(&mut members, root);
-            info!(
-                root = %root.display(),
-                "discovered project at workspace root"
-            );
-        }
-
-        // Also search subdirectories for projects. This handles monorepos
-        // where the IDE root (e.g. `ai_cms/`) is a parent of the actual
-        // Python project (e.g. `ai_cms/agent-backend/`).
-        let Ok(entries) = std::fs::read_dir(root) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.is_dir() || !path.join("pyproject.toml").is_file() {
-                continue;
-            }
-
-            // Try uv workspace in the subdirectory.
-            if let Ok(Some(workspace)) = basilisk_uv::parse_uv_workspace(&path) {
-                for member_dir in &workspace.members {
-                    add_source_root(&mut members, member_dir);
-                }
-                if !workspace.members.is_empty() {
-                    info!(
-                        root = %path.display(),
-                        member_count = workspace.members.len(),
-                        "discovered uv workspace members in subdirectory"
-                    );
-                    continue;
-                }
-            }
-
-            // No uv workspace, but has pyproject.toml — treat as a project.
-            add_source_root(&mut members, &path);
-            info!(
-                path = %path.display(),
-                "discovered project subdirectory"
-            );
-        }
-    }
-
-    members
-}
-
-/// Add a project directory's source root to the member list.
-///
-/// Prefers `src/` layout if it exists, otherwise adds the directory itself.
-fn add_source_root(members: &mut Vec<std::path::PathBuf>, project_dir: &std::path::Path) {
-    let src_dir = project_dir.join("src");
-    if src_dir.is_dir() {
-        members.push(src_dir);
-    } else {
-        members.push(project_dir.to_path_buf());
-    }
-}
-
 /// Detect a uv project and build a [`PackageRegistry`] from its lock file.
 ///
 /// Returns `None` if this is not a uv project, if there is no lock file, or
@@ -731,9 +635,8 @@ pub(super) async fn rebuild_registry_and_resolve(server: &LspServer) {
         .unwrap_or_default();
 
     let registry = build_uv_registry(&roots);
-    let mut search_paths =
+    let search_paths =
         crate::import_resolver::ImportSearchPaths::from_config(&roots, &config, registry);
-    search_paths.workspace_members = discover_workspace_members(&roots);
     crate::import_resolver::resolve_workspace_imports(index, &search_paths);
     // Refresh the cached search paths so subsequent incremental re-checks pick
     // up the rebuilt registry / venv. Implements [ANALYSIS-INCR-IMPORTS].
@@ -915,49 +818,4 @@ pub(super) async fn shutdown(server: &LspServer) -> LspResult<()> {
     server.debug_manager.stop_all().await;
     server.profiler_manager.stop_all().await;
     Ok(())
-}
-
-#[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    reason = "test-only code: unwrap acceptable in unit tests"
-)]
-mod tests {
-    use super::discover_workspace_members;
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    static TEST_CTR: AtomicU64 = AtomicU64::new(0);
-
-    fn unique_tmp(prefix: &str) -> std::path::PathBuf {
-        let n = TEST_CTR.fetch_add(1, Ordering::Relaxed);
-        std::env::temp_dir().join(format!("{prefix}_{n}_{}", std::process::id()))
-    }
-
-    /// Regression: when the workspace root itself is a Python project with a
-    /// `src/` layout (no uv workspace, no subdirectory projects), the `src/`
-    /// directory must be added to workspace members so first-party imports
-    /// like `from agent_backend.config import settings` resolve.
-    #[test]
-    fn root_src_layout_project_is_discovered() {
-        let root = unique_tmp("bsk_init_root_src");
-        let src = root.join("src");
-        let pkg = src.join("mypkg");
-        std::fs::create_dir_all(&pkg).unwrap();
-        std::fs::write(pkg.join("__init__.py"), "").unwrap();
-        std::fs::write(pkg.join("config.py"), "settings = 1\n").unwrap();
-        std::fs::write(
-            root.join("pyproject.toml"),
-            "[project]\nname = \"mypkg\"\nversion = \"0.1.0\"\n",
-        )
-        .unwrap();
-
-        let members = discover_workspace_members(std::slice::from_ref(&root));
-
-        assert!(
-            members.iter().any(|m| m == &src),
-            "expected src/ to be in workspace_members, got: {members:?}"
-        );
-
-        let _ = std::fs::remove_dir_all(&root);
-    }
 }

--- a/crates/basilisk-lsp/src/server/init.rs
+++ b/crates/basilisk-lsp/src/server/init.rs
@@ -397,6 +397,10 @@ async fn register_file_watchers(client: &Client) {
             glob_pattern: GlobPattern::String("**/pyproject.toml".into()),
             kind: None,
         },
+        FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/basilisk.json".into()),
+            kind: None,
+        },
     ];
 
     let registration_options =
@@ -419,7 +423,7 @@ async fn register_file_watchers(client: &Client) {
     if let Err(err) = client.register_capability(vec![registration]).await {
         tracing::warn!("failed to register uv file watchers: {err}");
     } else {
-        info!("registered uv file watchers (uv.lock, .python-version, pyproject.toml)");
+        info!("registered config file watchers (uv.lock, .python-version, pyproject.toml, basilisk.json)");
     }
 }
 

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -355,6 +355,32 @@ impl WorkspaceIndex {
         lsp_diags
     }
 
+    /// Like [`Self::set_open`], but in cross-module mode also refreshes
+    /// dependents when the edited (open) file's exported symbol set changes — so
+    /// editing an OPEN module updates its importers live. `set_open` alone
+    /// re-analyses only the edited file, and the file-watcher path skips open
+    /// files (`reload_from_disk` bails when `is_open`), so without this an
+    /// in-editor export edit leaves dependents stale until the file is closed.
+    /// Implements [ANALYSIS-SYMBOLS-INVAL] for the open-file path (GitHub #56).
+    #[must_use]
+    pub fn set_open_refresh_dependents(
+        &self,
+        uri: &Url,
+        text: &str,
+        version: i32,
+    ) -> Vec<(Url, Vec<tower_lsp::lsp_types::Diagnostic>)> {
+        let path = uri.to_file_path().unwrap_or_default();
+        let track_exports = matches!(self.mode, AnalysisMode::CrossModule);
+        let before = track_exports.then(|| self.exported_symbol_names(&path));
+        let own_diags = self.set_open(uri, text, version);
+        if before.is_some_and(|prev| self.exported_symbol_names(&path) != prev) {
+            // Exports changed: re-resolve + re-check so importers' stale symbol
+            // diagnostics refresh without closing the file or reloading the server.
+            return self.reresolve_imports_and_recheck();
+        }
+        vec![(uri.clone(), own_diags)]
+    }
+
     /// Re-read a file from disk (called on `didClose` or file-watcher events).
     ///
     /// If the file is currently open, this is a no-op (editor text is
@@ -483,6 +509,19 @@ impl WorkspaceIndex {
         Some((result, changed))
     }
 
+    /// The directories to scan under `root`: the configured `[tool.basilisk]
+    /// include` roots (relative to `root`) if any, else `root` itself. Mirrors
+    /// the CLI's `effective_check_paths` so the editor and `basilisk check`
+    /// agree on which files are analysed. Implements [CHKARCH-CONFIG-INCLUDE].
+    fn scan_dirs_for(&self, root: &std::path::Path) -> Vec<PathBuf> {
+        match self.root_configs.get(root) {
+            Some(cfg) if !cfg.include.is_empty() => {
+                cfg.include.iter().map(|inc| root.join(inc)).collect()
+            }
+            _ => vec![root.to_path_buf()],
+        }
+    }
+
     /// Scan all workspace roots and populate the index.
     ///
     /// Returns a list of `(Uri, diagnostics)` pairs ready for publishing.
@@ -499,7 +538,9 @@ impl WorkspaceIndex {
 
         for root in &self.roots {
             let cfg = crate::config::load_config(root);
-            collect_python_files(root, &mut all_files, &cfg.exclude, root);
+            for scan_dir in self.scan_dirs_for(root) {
+                collect_python_files(&scan_dir, &mut all_files, &cfg.exclude, root);
+            }
         }
 
         // Prefer .pyi over .py when both exist for the same stem.
@@ -2158,6 +2199,52 @@ mod tests {
             !codes.contains(&"BSK-E0001".to_owned()),
             "set_closed must apply checker_config — disabled E0001 should be absent"
         );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scan_honors_include_roots() {
+        // [CHKARCH-CONFIG-INCLUDE] The LSP workspace scan must walk only the
+        // configured `[tool.basilisk] include` roots, like `basilisk check` —
+        // a file outside them (e.g. generated code) must not be scanned.
+        let dir = unique_tmp("bsk_scan_include");
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::create_dir_all(dir.join("gen")).unwrap();
+        std::fs::write(
+            dir.join("pyproject.toml"),
+            "[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk]\ninclude = [\"src\"]\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("src/ok.py"),
+            "def add(a: int, b: int) -> int:\n    return a + b\n",
+        )
+        .unwrap();
+        // A file OUTSIDE the include roots — must not be scanned.
+        std::fs::write(
+            dir.join("gen/outside.py"),
+            "def bad() -> int:\n    return undefined_name\n",
+        )
+        .unwrap();
+
+        let idx = WorkspaceIndex::new(
+            vec![dir.clone()],
+            AnalysisMode::WholeModule,
+            BasiliskConfig::default(),
+        );
+        let (results, file_count, _errors) = idx.scan();
+        let scanned: Vec<String> = results.iter().map(|(u, _)| u.to_string()).collect();
+
+        assert!(
+            scanned.iter().any(|u| u.ends_with("src/ok.py")),
+            "files inside include roots must be scanned, got: {scanned:?}"
+        );
+        assert!(
+            !scanned.iter().any(|u| u.ends_with("gen/outside.py")),
+            "files outside include roots must NOT be scanned, got: {scanned:?}"
+        );
+        assert_eq!(file_count, 1, "only the included file should be scanned");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -444,7 +444,26 @@ impl WorkspaceIndex {
         if let Some(search_paths) = self.search_paths_snapshot() {
             crate::import_resolver::resolve_workspace_imports(self, &search_paths);
         }
+        // Implements [ANALYSIS-SYMBOLS-INVAL] (GitHub #56): refresh dependents'
+        // imported symbols so symbol-level diagnostics don't go stale.
+        if matches!(self.mode, AnalysisMode::CrossModule) {
+            crate::cross_module::populate_cross_module_symbols(self);
+            self.build_import_graph();
+        }
         self.recheck_all_files()
+    }
+
+    /// Reload one file from disk, reporting whether its exported top-level
+    /// symbol set changed. Implements [ANALYSIS-SYMBOLS-INVAL] (GitHub #56).
+    pub fn reload_and_diff_exports(
+        &self,
+        uri: &Url,
+    ) -> Option<((Url, Vec<tower_lsp::lsp_types::Diagnostic>), bool)> {
+        let path = uri.to_file_path().ok()?;
+        let before = self.exported_symbol_names(&path);
+        let result = self.reload_from_disk(uri)?;
+        let changed = self.exported_symbol_names(&path) != before;
+        Some((result, changed))
     }
 
     /// Scan all workspace roots and populate the index.
@@ -1389,14 +1408,11 @@ mod tests {
         let test_uri = Url::from_file_path(&test_path).unwrap();
         let _ = idx.set_open(&test_uri, "from tests.helpers import AgentConfig\n", 1);
 
-        // Mirror the LSP init flow: workspace_members get added (src/ for
-        // src-layout projects), then imports are resolved.
-        let mut search_paths = crate::import_resolver::ImportSearchPaths::from_config(
+        // Mirror the LSP init flow: from_config discovers workspace_members
+        // (src/ for src-layout projects), then imports are resolved.
+        let search_paths = crate::import_resolver::ImportSearchPaths::from_config(
             &roots, &config, /*registry=*/ None,
         );
-        // Use the real init.rs discovery helper so this test exercises the
-        // production path, not a hand-built workspace_members list.
-        search_paths.workspace_members = crate::server::init::discover_workspace_members(&roots);
         crate::import_resolver::resolve_workspace_imports(&idx, &search_paths);
         recheck_all(&idx);
 

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -189,12 +189,13 @@ impl WorkspaceIndex {
         let config = self.config_for_file(path);
         let (mut entry, lsp_diags) = analyse_with_config(text, path, config);
 
-        // Excluded files (vendored/bundled) are parsed so navigation still
-        // works, but never contribute diagnostics — the editor's per-file path
-        // must match the bulk workspace scan and `basilisk check`, which skip
-        // them. Without this, opening a `bundled/` file squiggles every line.
-        // Implements [CHKARCH-CONFIG-EXCLUDE].
-        if self.is_path_excluded(path) {
+        // Excluded files, and files outside the configured `include` roots, are
+        // parsed so navigation still works but never contribute diagnostics — the
+        // per-file path must match the bulk scan and `basilisk check`, which skip
+        // them. Without this, opening a `bundled/` or out-of-include file
+        // squiggles every line. Implements [CHKARCH-CONFIG-EXCLUDE] /
+        // [CHKARCH-CONFIG-INCLUDE].
+        if self.is_path_excluded(path) || self.is_outside_include_roots(path) {
             entry.diagnostics.clear();
             return (entry, Vec::new());
         }
@@ -255,6 +256,33 @@ impl WorkspaceIndex {
             .exclude
             .iter()
             .any(|pattern| basilisk_config::path_matches_pattern(relative, pattern))
+    }
+
+    /// Whether `file_path` lies outside the owning root's `[tool.basilisk]
+    /// include` roots. When `include` is empty the whole root is included, so
+    /// nothing is "outside". Mirrors the scan's `scan_dirs_for` for the per-file
+    /// path, so an opened file outside the include roots is suppressed just like
+    /// an excluded one. Implements [CHKARCH-CONFIG-INCLUDE].
+    #[must_use]
+    fn is_outside_include_roots(&self, file_path: &std::path::Path) -> bool {
+        let Some(root) = self
+            .roots
+            .iter()
+            .filter(|root| file_path.starts_with(root))
+            .max_by_key(|root| root.components().count())
+        else {
+            return false;
+        };
+        let Some(config) = self.root_configs.get(root) else {
+            return false;
+        };
+        if config.include.is_empty() {
+            return false;
+        }
+        !config
+            .include
+            .iter()
+            .any(|inc| file_path.starts_with(root.join(inc)))
     }
 
     /// Return the `FileEntry` for a URI, if present.
@@ -459,9 +487,17 @@ impl WorkspaceIndex {
         self.files
             .iter_mut()
             .filter_map(|mut entry| {
+                // Excluded / out-of-include files never publish diagnostics, even
+                // on a re-resolve — otherwise an open out-of-scope file's errors
+                // reappear. [CHKARCH-CONFIG-EXCLUDE] / [CHKARCH-CONFIG-INCLUDE].
+                let suppressed = self.is_path_excluded(entry.key())
+                    || self.is_outside_include_roots(entry.key());
                 let resolved = entry.resolved.clone()?;
-                let file_config = self.config_for_file(entry.key());
-                let checker_diags = basilisk_checker::check_with_config(&resolved, file_config);
+                let checker_diags = if suppressed {
+                    Vec::new()
+                } else {
+                    basilisk_checker::check_with_config(&resolved, self.config_for_file(entry.key()))
+                };
                 let lsp_diags: Vec<tower_lsp::lsp_types::Diagnostic> = checker_diags
                     .iter()
                     .map(|d| bsk_to_lsp(d, &entry.text))
@@ -2245,6 +2281,42 @@ mod tests {
             "files outside include roots must NOT be scanned, got: {scanned:?}"
         );
         assert_eq!(file_count, 1, "only the included file should be scanned");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn open_file_outside_include_roots_is_suppressed() {
+        // [CHKARCH-CONFIG-INCLUDE] A file outside the include roots must show no
+        // diagnostics even when opened on demand — consistent with `exclude`.
+        let dir = unique_tmp("bsk_open_outside_include");
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::create_dir_all(dir.join("gen")).unwrap();
+        std::fs::write(
+            dir.join("pyproject.toml"),
+            "[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk]\ninclude = [\"src\"]\n",
+        )
+        .unwrap();
+        let idx = WorkspaceIndex::new(
+            vec![dir.clone()],
+            AnalysisMode::WholeModule,
+            BasiliskConfig::default(),
+        );
+        let src = "def f() -> int:\n    return undefined_name\n";
+
+        // Inside the include roots: diagnosed even when opened.
+        let inside = Url::from_file_path(dir.join("src/inside.py")).unwrap();
+        assert!(
+            !idx.set_open(&inside, src, 1).is_empty(),
+            "a file inside include roots must be diagnosed when opened"
+        );
+
+        // Outside the include roots: suppressed when opened.
+        let outside = Url::from_file_path(dir.join("gen/outside.py")).unwrap();
+        assert!(
+            idx.set_open(&outside, src, 1).is_empty(),
+            "a file outside include roots must NOT be diagnosed even when opened"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -98,30 +98,7 @@ impl WorkspaceIndex {
     /// the fallback for that root.
     #[must_use]
     pub fn new(roots: Vec<PathBuf>, mode: AnalysisMode, checker_config: BasiliskConfig) -> Self {
-        // Load per-root configs. Each root may have its own pyproject.toml.
-        // If a root has no config file, fall back to the provided checker_config.
-        let root_configs: std::collections::HashMap<PathBuf, BasiliskConfig> = roots
-            .iter()
-            .map(|root| {
-                let has_config =
-                    root.join("pyproject.toml").is_file() || root.join("basilisk.json").is_file();
-                let mut cfg = if has_config {
-                    basilisk_config::load_basilisk_config(root)
-                } else {
-                    checker_config.clone()
-                };
-                // [CHKARCH-VERSION-TARGET] An explicit `python-version` in the
-                // checker config wins; otherwise detect the project's target
-                // from `.python-version` / `requires-python` / `uv.lock` so
-                // version-aware rules follow the real target (issue #93).
-                if cfg.python_version.is_none() {
-                    cfg.python_version =
-                        basilisk_uv::python_version::resolve_target_python_version(root);
-                }
-                (root.clone(), cfg)
-            })
-            .collect();
-
+        let root_configs = Self::load_root_configs(&roots, &checker_config);
         Self {
             roots,
             files: DashMap::new(),
@@ -132,6 +109,46 @@ impl WorkspaceIndex {
             checker_config,
             search_paths: std::sync::RwLock::new(None),
         }
+    }
+
+    /// Load each root's `BasiliskConfig` from its `pyproject.toml` /
+    /// `basilisk.json`, falling back to `fallback` for roots without a config
+    /// file.
+    ///
+    /// [CHKARCH-VERSION-TARGET] An explicit `python-version` in the config wins;
+    /// otherwise the project's target is detected from `.python-version` /
+    /// `requires-python` / `uv.lock` so version-aware rules follow the real
+    /// target (issue #93).
+    fn load_root_configs(
+        roots: &[PathBuf],
+        fallback: &BasiliskConfig,
+    ) -> std::collections::HashMap<PathBuf, BasiliskConfig> {
+        roots
+            .iter()
+            .map(|root| {
+                let has_config =
+                    root.join("pyproject.toml").is_file() || root.join("basilisk.json").is_file();
+                let mut cfg = if has_config {
+                    basilisk_config::load_basilisk_config(root)
+                } else {
+                    fallback.clone()
+                };
+                if cfg.python_version.is_none() {
+                    cfg.python_version =
+                        basilisk_uv::python_version::resolve_target_python_version(root);
+                }
+                (root.clone(), cfg)
+            })
+            .collect()
+    }
+
+    /// Re-read every root's `BasiliskConfig` from disk so a change to a watched
+    /// config file (`pyproject.toml` / `basilisk.json` / `.python-version`)
+    /// takes effect — version-aware rules and severity overrides — without an
+    /// LSP restart. The caller re-checks open files afterwards (e.g. via
+    /// [`Self::recheck_all_files`]). Implements [CHKARCH-VERSION-TARGET].
+    pub fn reload_root_configs(&mut self) {
+        self.root_configs = Self::load_root_configs(&self.roots, &self.checker_config);
     }
 
     /// Cache the import search paths built during the workspace scan.
@@ -2057,6 +2074,66 @@ mod tests {
         assert!(
             !codes.contains(&"BSK-E0001".to_owned()),
             "reload_from_disk must apply checker_config — disabled E0001 should be absent"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn reload_root_configs_applies_changed_python_version() {
+        // [CHKARCH-VERSION-TARGET] Editing `[tool.basilisk] python-version` must
+        // make version-aware rules (the BSK-E0155 PEP 695 gate) update without an
+        // LSP restart: reload_root_configs re-reads the target, and the next
+        // recheck reflects it.
+        let dir = unique_tmp("bsk_cfg_pyver");
+        std::fs::create_dir_all(&dir).unwrap();
+        let write_version = |v: &str| {
+            std::fs::write(
+                dir.join("pyproject.toml"),
+                format!("[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk]\npython-version = \"{v}\"\n"),
+            )
+            .unwrap();
+        };
+        write_version("3.11");
+        let src = "type Alias = int\n";
+        let file_path = dir.join("pep695.py");
+        std::fs::write(&file_path, src).unwrap();
+
+        let mut idx = WorkspaceIndex::new(
+            vec![dir.clone()],
+            AnalysisMode::WholeModule,
+            BasiliskConfig::default(),
+        );
+        let uri = Url::from_file_path(&file_path).unwrap();
+        let recheck_has_e0155 = |idx: &WorkspaceIndex| {
+            idx.recheck_all_files()
+                .into_iter()
+                .find(|(u, _)| *u == uri)
+                .is_some_and(|(_, d)| lsp_codes(&d).contains(&"BSK-E0155".to_owned()))
+        };
+
+        // 3.11 target: PEP 695 `type` syntax is gated.
+        let initial = idx.set_open(&uri, src, 1);
+        assert!(
+            lsp_codes(&initial).contains(&"BSK-E0155".to_owned()),
+            "PEP 695 on a 3.11 target must fire BSK-E0155"
+        );
+
+        // Switch the configured target to 3.12 on disk.
+        write_version("3.12");
+
+        // A recheck WITHOUT reloading config reuses the target cached at
+        // construction — still stale 3.11 (the bug this guards against).
+        assert!(
+            recheck_has_e0155(&idx),
+            "without reload, the recheck still uses the stale 3.11 target"
+        );
+
+        // Reloading per-root config picks up 3.12, where PEP 695 is native.
+        idx.reload_root_configs();
+        assert!(
+            !recheck_has_e0155(&idx),
+            "reload_root_configs must apply the new python-version (3.12 allows PEP 695)"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -496,7 +496,10 @@ impl WorkspaceIndex {
                 let checker_diags = if suppressed {
                     Vec::new()
                 } else {
-                    basilisk_checker::check_with_config(&resolved, self.config_for_file(entry.key()))
+                    basilisk_checker::check_with_config(
+                        &resolved,
+                        self.config_for_file(entry.key()),
+                    )
                 };
                 let lsp_diags: Vec<tower_lsp::lsp_types::Diagnostic> = checker_diags
                     .iter()

--- a/crates/basilisk-lsp/tests/lsp/ws_test_cross_module.rs
+++ b/crates/basilisk-lsp/tests/lsp/ws_test_cross_module.rs
@@ -787,6 +787,93 @@ async fn changed_module_exports_refresh_dependent_diagnostics() -> TestResult<()
     Ok(())
 }
 
+/// Whether main.py's most recently published diagnostics flag `thing` undefined.
+async fn main_reports_thing_undefined(fixture: &mut WsTestFixture, main_uri: &str) -> bool {
+    collect_all_diagnostics(fixture).await.get(main_uri).is_some_and(|d| {
+        d["params"]["diagnostics"]
+            .as_array()
+            .is_some_and(|arr| arr.iter().any(is_thing_undefined))
+    })
+}
+
+/// Send a full-text `didChange` for `uri`.
+async fn did_change_full(
+    fixture: &mut WsTestFixture,
+    uri: &str,
+    version: i64,
+    text: &str,
+) -> TestResult<()> {
+    fixture
+        .send_json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didChange",
+            "params": {
+                "textDocument": { "uri": uri, "version": version },
+                "contentChanges": [{ "text": text }]
+            }
+        }))
+        .await?;
+    Ok(())
+}
+
+/// [ANALYSIS-SYMBOLS-INVAL] open-file path (#56): editing an OPEN module's
+/// exports must refresh dependents live, in BOTH directions. The file watcher
+/// skips open files (`reload_from_disk` bails when `is_open`), so the in-editor
+/// `didChange` path drives the cross-module re-resolve. Critically, a renamed or
+/// removed export must STOP suppressing its now-undefined references — a stale
+/// export lingering in `imported_symbols` left dependents green after a rename.
+#[tokio::test]
+async fn open_module_export_edit_refreshes_dependent_diagnostics() -> TestResult<()> {
+    let with_thing = "def thing() -> int:\n    return 1\n";
+    // lib EXPORTS `thing`; main.py uses it cross-module, so it is clean at startup.
+    let (dir, root_uri) = setup_cross_module_workspace(&[
+        ("lib.py", with_thing),
+        (
+            "main.py",
+            "import lib\n\ndef use() -> int:\n    return thing\n",
+        ),
+    ]);
+
+    let mut fixture = WsTestFixture::new().await?;
+    let _ = initialize_with_root(&mut fixture, &root_uri, "crossModule").await?;
+
+    let main_uri = format!("{root_uri}/main.py");
+    let lib_uri = format!("{root_uri}/lib.py");
+
+    // Startup: lib exports `thing`, so main.py is clean.
+    assert!(
+        !main_reports_thing_undefined(&mut fixture, &main_uri).await,
+        "precondition: main.py should be clean while lib.py exports `thing`"
+    );
+
+    // OPEN lib.py, then EDIT it to RENAME the export away. The dependent must
+    // report `thing` undefined LIVE — the stale export must not keep it green.
+    fixture
+        .send_json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": { "textDocument": {
+                "uri": lib_uri, "languageId": "python", "version": 1, "text": with_thing
+            }}
+        }))
+        .await?;
+    did_change_full(&mut fixture, &lib_uri, 2, "def renamed() -> int:\n    return 1\n").await?;
+    assert!(
+        main_reports_thing_undefined(&mut fixture, &main_uri).await,
+        "renaming `thing` away in the OPEN lib.py must make main.py report it undefined live"
+    );
+
+    // Restore the export in the OPEN file: the dependent must clear again.
+    did_change_full(&mut fixture, &lib_uri, 3, with_thing).await?;
+    assert!(
+        !main_reports_thing_undefined(&mut fixture, &main_uri).await,
+        "restoring `thing` in the OPEN lib.py must clear main.py's diagnostic live"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}
+
 /// True iff the diagnostic reports `thing` as undefined/unresolved.
 fn is_thing_undefined(d: &serde_json::Value) -> bool {
     d["message"].as_str().unwrap_or("").contains("`thing`")

--- a/crates/basilisk-lsp/tests/lsp/ws_test_cross_module.rs
+++ b/crates/basilisk-lsp/tests/lsp/ws_test_cross_module.rs
@@ -720,3 +720,74 @@ async fn cross_module_wildcard_import() -> TestResult<()> {
     let _ = std::fs::remove_dir_all(&dir);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Regression: EDITING an existing module's top-level symbols must refresh
+// dependents' cross-module diagnostics live, exactly like module creation
+// (GitHub #56). The file-watcher CHANGED event must re-populate cross-module
+// symbols and re-check dependents when the exported symbol set changes.
+// Implements [ANALYSIS-SYMBOLS-INVAL].
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn changed_module_exports_refresh_dependent_diagnostics() -> TestResult<()> {
+    let (dir, root_uri) = setup_cross_module_workspace(&[
+        ("lib.py", ""),
+        (
+            "main.py",
+            "import lib\n\ndef use() -> int:\n    return thing\n",
+        ),
+    ]);
+
+    let mut fixture = WsTestFixture::new().await?;
+    let _ = initialize_with_root(&mut fixture, &root_uri, "crossModule").await?;
+
+    // Startup scan: main.py SHOULD report `thing` as undefined — lib is empty.
+    let startup = collect_all_diagnostics(&mut fixture).await;
+    let main_uri = format!("{root_uri}/main.py");
+    let startup_has_undefined = startup.get(&main_uri).is_some_and(|d| {
+        d["params"]["diagnostics"]
+            .as_array()
+            .is_some_and(|arr| arr.iter().any(is_thing_undefined))
+    });
+    assert!(
+        startup_has_undefined,
+        "precondition: main.py should report `thing` undefined while lib.py is empty"
+    );
+
+    // EDIT lib.py on disk to export `thing`, then notify via the file watcher.
+    std::fs::write(dir.join("lib.py"), "def thing() -> int:\n    return 1\n")?;
+    let lib_uri = format!("{root_uri}/lib.py");
+    fixture
+        .send_json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "workspace/didChangeWatchedFiles",
+            "params": { "changes": [{ "uri": lib_uri, "type": 2 }] }  // 2 = Changed
+        }))
+        .await?;
+
+    // The dependent (main.py) must be re-checked and re-published WITHOUT the
+    // stale diagnostic — no reload required.
+    let after = collect_all_diagnostics(&mut fixture).await;
+    let main_after = after
+        .get(&main_uri)
+        .ok_or("main.py diagnostics not re-published after lib.py's exports changed")?;
+    let empty = vec![];
+    let diagnostics = main_after["params"]["diagnostics"]
+        .as_array()
+        .unwrap_or(&empty);
+    let still_undefined = diagnostics.iter().any(is_thing_undefined);
+    assert!(
+        !still_undefined,
+        "adding `thing` to lib.py must clear the stale diagnostic in main.py \
+         without a reload — got: {diagnostics:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+    Ok(())
+}
+
+/// True iff the diagnostic reports `thing` as undefined/unresolved.
+fn is_thing_undefined(d: &serde_json::Value) -> bool {
+    d["message"].as_str().unwrap_or("").contains("`thing`")
+}

--- a/crates/basilisk-lsp/tests/lsp/ws_test_cross_module.rs
+++ b/crates/basilisk-lsp/tests/lsp/ws_test_cross_module.rs
@@ -789,11 +789,14 @@ async fn changed_module_exports_refresh_dependent_diagnostics() -> TestResult<()
 
 /// Whether main.py's most recently published diagnostics flag `thing` undefined.
 async fn main_reports_thing_undefined(fixture: &mut WsTestFixture, main_uri: &str) -> bool {
-    collect_all_diagnostics(fixture).await.get(main_uri).is_some_and(|d| {
-        d["params"]["diagnostics"]
-            .as_array()
-            .is_some_and(|arr| arr.iter().any(is_thing_undefined))
-    })
+    collect_all_diagnostics(fixture)
+        .await
+        .get(main_uri)
+        .is_some_and(|d| {
+            d["params"]["diagnostics"]
+                .as_array()
+                .is_some_and(|arr| arr.iter().any(is_thing_undefined))
+        })
 }
 
 /// Send a full-text `didChange` for `uri`.
@@ -857,7 +860,13 @@ async fn open_module_export_edit_refreshes_dependent_diagnostics() -> TestResult
             }}
         }))
         .await?;
-    did_change_full(&mut fixture, &lib_uri, 2, "def renamed() -> int:\n    return 1\n").await?;
+    did_change_full(
+        &mut fixture,
+        &lib_uri,
+        2,
+        "def renamed() -> int:\n    return 1\n",
+    )
+    .await?;
     assert!(
         main_reports_thing_undefined(&mut fixture, &main_uri).await,
         "renaming `thing` away in the OPEN lib.py must make main.py report it undefined live"

--- a/crates/basilisk-parser/src/depth.rs
+++ b/crates/basilisk-parser/src/depth.rs
@@ -1,0 +1,77 @@
+//! Implements [CHKARCH-ARCH-PARSEDEPTH]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-ARCH-PARSEDEPTH
+//!
+//! Pre-parse nesting-depth guard.
+//!
+//! `ruff_python_parser` is a recursive-descent parser, and Basilisk's resolver
+//! and checker walk the resulting AST recursively. Both overflow the thread
+//! stack on pathologically nested input — a ~4000-deep bracket expression aborts
+//! the whole process with `SIGABRT`, which on the language server manifests as a
+//! crash-restart loop. To stay crash-safe — and to match `CPython`, which rejects
+//! such input at the *tokenizer* rather than crashing — [`crate::parse_source`]
+//! runs this guard before handing the source to the recursive parser.
+//!
+//! Depth is measured with ruff's *linear* lexer (`lex` + `next_token`): a flat
+//! byte scan that never recurses, so measuring the depth can never itself
+//! overflow (verified at 20 000 deep). The scan short-circuits at the first
+//! violating token, so a pathological file is only lexed up to the offending
+//! bracket or indent.
+
+use ruff_python_parser::lexer::lex;
+use ruff_python_parser::{Mode, TokenKind};
+
+/// Maximum simultaneously-open brackets (`(`, `[`, `{`), counted cumulatively
+/// across all three kinds. Matches `CPython`'s tokenizer `MAXLEVEL` (200): a depth
+/// of 200 is accepted, the 201st open bracket is rejected.
+const MAX_BRACKET_DEPTH: u32 = 200;
+
+/// Maximum indentation levels. Matches `CPython`'s tokenizer `MAXINDENT` (100):
+/// 99 levels are accepted, the 100th is rejected.
+const MAX_INDENT_DEPTH: u32 = 99;
+
+/// `CPython`'s `SyntaxError` message for exceeding the bracket nesting limit.
+const TOO_MANY_BRACKETS: &str = "too many nested parentheses";
+
+/// `CPython`'s `SyntaxError` message for exceeding the indentation limit.
+const TOO_MANY_INDENTS: &str = "too many levels of indentation";
+
+/// Reject source whose bracket or indentation nesting would overflow the
+/// recursive parser, returning the `CPython`-equivalent message for the first
+/// offending token.
+///
+/// # Errors
+///
+/// Returns the message for the limit that was exceeded first in token order, or
+/// `Ok(())` when the source is within both limits.
+pub(crate) fn check_nesting(source: &str) -> Result<(), &'static str> {
+    let mut lexer = lex(source, Mode::Module);
+    let mut bracket_depth: u32 = 0;
+    let mut indent_depth: u32 = 0;
+    loop {
+        let kind = lexer.next_token();
+        if kind.is_eof() {
+            break;
+        }
+        match kind {
+            TokenKind::Lpar | TokenKind::Lsqb | TokenKind::Lbrace => {
+                bracket_depth = bracket_depth.saturating_add(1);
+                if bracket_depth > MAX_BRACKET_DEPTH {
+                    return Err(TOO_MANY_BRACKETS);
+                }
+            }
+            TokenKind::Rpar | TokenKind::Rsqb | TokenKind::Rbrace => {
+                bracket_depth = bracket_depth.saturating_sub(1);
+            }
+            TokenKind::Indent => {
+                indent_depth = indent_depth.saturating_add(1);
+                if indent_depth > MAX_INDENT_DEPTH {
+                    return Err(TOO_MANY_INDENTS);
+                }
+            }
+            TokenKind::Dedent => {
+                indent_depth = indent_depth.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/crates/basilisk-parser/src/lib.rs
+++ b/crates/basilisk-parser/src/lib.rs
@@ -5,6 +5,7 @@
 //! entire Basilisk workspace. All other crates receive a [`ParsedModule`]
 //! and work exclusively with `ruff_python_ast` types.
 
+mod depth;
 pub mod error;
 
 pub use error::ParseError;
@@ -25,8 +26,19 @@ pub struct ParsedModule {
 ///
 /// # Errors
 ///
-/// Returns [`ParseError::Syntax`] if the source contains syntax errors.
+/// Returns [`ParseError::Syntax`] if the source contains syntax errors or is
+/// nested too deeply to parse without overflowing the stack
+/// ([CHKARCH-ARCH-PARSEDEPTH]).
 pub fn parse_source(source: String, path: String) -> Result<ParsedModule, ParseError> {
+    // Implements [CHKARCH-ARCH-PARSEDEPTH]: reject pathologically nested source
+    // (measured by the linear lexer) before the recursive parser — and the
+    // recursive AST visitors downstream — can overflow the stack.
+    if let Err(message) = depth::check_nesting(&source) {
+        return Err(ParseError::Syntax {
+            path,
+            message: message.to_owned(),
+        });
+    }
     ruff_python_parser::parse_module(&source)
         .map(|parsed| ParsedModule {
             ast: parsed.into_syntax(),

--- a/crates/basilisk-parser/tests/parse_tests.rs
+++ b/crates/basilisk-parser/tests/parse_tests.rs
@@ -51,3 +51,124 @@ fn returns_io_error_for_missing_file() {
         "missing file should return ParseError::Io"
     );
 }
+
+// Tests for [CHKARCH-ARCH-PARSEDEPTH]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-ARCH-PARSEDEPTH
+//
+// The recursive-descent parser (and our recursive AST visitors) overflow the
+// stack on deeply nested input — a ~4000-deep bracket file aborts the process
+// with SIGABRT. parse_source must reject pathologically nested source as a
+// `ParseError::Syntax` (measured by the linear lexer, never the recursive
+// parser), matching CPython's tokenizer limits, instead of crashing.
+
+/// `n` nested `if True:` blocks ending in `pass` — a non-bracket nesting vector.
+fn nested_if_blocks(depth: usize) -> String {
+    let mut source = String::new();
+    for level in 0..depth {
+        source.push_str(&"    ".repeat(level));
+        source.push_str("if True:\n");
+    }
+    source.push_str(&"    ".repeat(depth));
+    source.push_str("pass\n");
+    source
+}
+
+#[test]
+fn deeply_nested_brackets_are_rejected_not_crashed() {
+    // 5000-deep brackets overflow ruff's recursive parser; the guard must turn
+    // this into a clean syntax error rather than a stack-overflow abort.
+    let source = format!("x = {}1{}\n", "(".repeat(5000), ")".repeat(5000));
+    let result = parse_source(source, "deep.py".to_owned());
+    assert!(
+        matches!(result, Err(ParseError::Syntax { .. })),
+        "deeply nested brackets must be a syntax error, not a crash"
+    );
+}
+
+// --- Bracket-depth boundary (pins MAX_BRACKET_DEPTH = 200 and the `>` test) ---
+
+#[test]
+fn brackets_at_limit_parse() {
+    // Exactly 200 simultaneously-open brackets is accepted (CPython MAXLEVEL).
+    let source = format!("x = {}1{}\n", "(".repeat(200), ")".repeat(200));
+    assert!(
+        parse_source(source, "ok.py".to_owned()).is_ok(),
+        "200-deep bracket nesting is at the limit and must parse"
+    );
+}
+
+#[test]
+fn brackets_one_over_limit_report_cpython_message() {
+    // The 201st simultaneously-open bracket is rejected, matching CPython.
+    let source = format!("x = {}1{}\n", "(".repeat(201), ")".repeat(201));
+    match parse_source(source, "deep.py".to_owned()) {
+        Err(ParseError::Syntax { message, .. }) => assert!(
+            message.contains("too many nested parentheses"),
+            "bracket-depth rejection should match CPython's message, got: {message}"
+        ),
+        other => panic!("expected ParseError::Syntax at depth 201, got {other:?}"),
+    }
+}
+
+#[test]
+fn mixed_bracket_kinds_share_one_depth_counter() {
+    // 67 of each kind opened simultaneously = 201 cumulative depth (one past the
+    // limit). Pins cross-kind counting and that all three openers increment.
+    let opens = "([{".repeat(67);
+    let closes = "}])".repeat(67);
+    let source = format!("x = {opens}1{closes}\n");
+    assert!(
+        matches!(
+            parse_source(source, "deep.py".to_owned()),
+            Err(ParseError::Syntax { .. })
+        ),
+        "201 cumulative mixed-kind brackets must be rejected"
+    );
+}
+
+#[test]
+fn sequential_brackets_do_not_accumulate_depth() {
+    // 300 each of empty tuple/list/dict in a list: 901 cumulative opens but a
+    // simultaneous depth of only 2. Only passes if every close-bracket arm
+    // (`)`, `]`, `}`) decrements — deleting any one would falsely reject this.
+    let row = "(), [], {}, ";
+    let source = format!("x = [{}]\n", row.repeat(300));
+    assert!(
+        parse_source(source, "ok.py".to_owned()).is_ok(),
+        "shallow-but-wide bracket nesting must not accumulate depth"
+    );
+}
+
+// --- Indentation boundary (pins MAX_INDENT_DEPTH = 99 and the Dedent arm) ---
+
+#[test]
+fn indentation_at_limit_parses() {
+    // 99 indentation levels is accepted (CPython MAXINDENT); the body sits at 99.
+    assert!(
+        parse_source(nested_if_blocks(99), "ok.py".to_owned()).is_ok(),
+        "99 indentation levels is at the limit and must parse"
+    );
+}
+
+#[test]
+fn indentation_one_over_limit_reports_cpython_message() {
+    // The 100th indentation level is rejected, matching CPython.
+    match parse_source(nested_if_blocks(100), "deep.py".to_owned()) {
+        Err(ParseError::Syntax { message, .. }) => assert!(
+            message.contains("too many levels of indentation"),
+            "indentation rejection should match CPython's message, got: {message}"
+        ),
+        other => panic!("expected ParseError::Syntax at 100 levels, got {other:?}"),
+    }
+}
+
+#[test]
+fn sequential_indents_do_not_accumulate() {
+    // 200 sibling `if` blocks: 200 cumulative Indent tokens but a simultaneous
+    // depth of only 1. Only passes if the Dedent arm decrements — deleting it
+    // would push the counter past 99 and falsely reject this valid file.
+    let source = "if True:\n    pass\n".repeat(200);
+    assert!(
+        parse_source(source, "ok.py".to_owned()).is_ok(),
+        "many shallow sibling blocks must not accumulate indentation depth"
+    );
+}

--- a/crates/basilisk-resolver/src/visitor/class_info_ext.rs
+++ b/crates/basilisk-resolver/src/visitor/class_info_ext.rs
@@ -397,8 +397,13 @@ pub(super) fn import_from_infos_from(node: &StmtImportFrom) -> Vec<ImportInfo> {
     }]
 }
 
+/// The locally bound name of an import alias: `asname` when present
+/// (`from X import Y as Z` binds `Z`), otherwise the imported name.
 pub(super) fn alias_name(alias: &Alias) -> String {
-    alias.name.to_string()
+    alias
+        .asname
+        .as_ref()
+        .map_or_else(|| alias.name.to_string(), ToString::to_string)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/basilisk-resolver/src/visitor/function_info.rs
+++ b/crates/basilisk-resolver/src/visitor/function_info.rs
@@ -260,10 +260,41 @@ pub(super) fn collect_return_name_refs(stmts: &[Stmt]) -> Vec<(String, Span)> {
         if let Stmt::Return(ret) = stmt {
             if let Some(val) = ret.value.as_deref() {
                 collect_name_refs_with_spans(val, &mut out);
+                collect_callee_name_refs(val, &mut out);
             }
         }
     });
     out
+}
+
+/// Collect the base name of every CALLEE in a return expression — `f` in
+/// `f(...)`, `obj` in `obj.method()` — which [`collect_name_refs_with_spans`]
+/// deliberately skips (it walks call *arguments*, not the callee). E0018 uses
+/// this so `return f()` is checked for an undefined `f`, not just bare
+/// `return f`. Kept separate from the shared collector so PEP 695 scoping and
+/// E0149 (which want value references, not callees) are unaffected.
+fn collect_callee_name_refs(expr: &Expr, out: &mut Vec<(String, Span)>) {
+    match expr {
+        Expr::Call(call) => {
+            collect_name_refs_with_spans(&call.func, out);
+            for arg in &call.arguments.args {
+                collect_callee_name_refs(arg, out);
+            }
+        }
+        Expr::BinOp(bin) => {
+            collect_callee_name_refs(&bin.left, out);
+            collect_callee_name_refs(&bin.right, out);
+        }
+        Expr::Tuple(tup) => {
+            for elt in &tup.elts {
+                collect_callee_name_refs(elt, out);
+            }
+        }
+        Expr::Subscript(sub) => collect_callee_name_refs(&sub.value, out),
+        Expr::Attribute(attr) => collect_callee_name_refs(&attr.value, out),
+        Expr::Starred(starred) => collect_callee_name_refs(&starred.value, out),
+        _ => {}
+    }
 }
 
 /// Collects `return <name>` references from the TOP LEVEL of a function body only.

--- a/crates/basilisk-resolver/src/visitor/module_level.rs
+++ b/crates/basilisk-resolver/src/visitor/module_level.rs
@@ -9,7 +9,9 @@ use crate::scope::{FloatParamIntAttrAccess, FunctionInfo, Span};
 use super::class_info_ext::expr_simple_name;
 use super::core::{source_slice_range, source_slice_span, text_range_to_span};
 use super::enum_checks::INT_ONLY_FLOAT_ATTRS;
-use super::protocol_ext::{base_type_name, ASYNC_GENERATOR_TYPES, SYNC_GENERATOR_TYPES};
+use super::protocol_ext::{
+    base_type_name, unqualified_base, ASYNC_GENERATOR_TYPES, SYNC_GENERATOR_TYPES,
+};
 
 pub(crate) fn collect_float_param_int_attr_accesses(
     stmts: &[Stmt],
@@ -247,7 +249,7 @@ pub(super) fn collect_generator_violations(
         let Some(ann_text) = source_slice_span(source, ann_span) else {
             continue;
         };
-        let base = base_type_name(ann_text);
+        let base = unqualified_base(base_type_name(ann_text));
 
         let valid_types = if func.is_async {
             ASYNC_GENERATOR_TYPES

--- a/crates/basilisk-resolver/src/visitor/protocol_ext.rs
+++ b/crates/basilisk-resolver/src/visitor/protocol_ext.rs
@@ -417,3 +417,12 @@ pub(super) fn base_type_name(annotation: &str) -> &str {
         .map_or(annotation, |idx| &annotation[..idx])
         .trim()
 }
+
+/// Strip string-annotation quotes and dotted module prefixes:
+/// `"collections.abc.AsyncIterator` → `AsyncIterator` (issue #36).
+pub(super) fn unqualified_base(base: &str) -> &str {
+    let trimmed = base
+        .trim_matches(|quote: char| quote == '"' || quote == '\'')
+        .trim();
+    trimmed.rsplit('.').next().unwrap_or(trimmed)
+}

--- a/crates/basilisk-resolver/tests/resolver/test_mutant_alias.rs
+++ b/crates/basilisk-resolver/tests/resolver/test_mutant_alias.rs
@@ -39,3 +39,21 @@ fn alias_name_single_name_is_correct() -> Result<(), Box<dyn std::error::Error>>
     );
     Ok(())
 }
+
+#[test]
+fn alias_name_uses_asname_when_present() -> Result<(), Box<dyn std::error::Error>> {
+    // Issues #107/#64: `from X import Y as Z` binds `Z`, not `Y`.
+    let src = "from nap.api import auth as auth_mod\n".to_owned();
+    let resolved = resolve_src(&src)?;
+    let import = resolved
+        .imports
+        .iter()
+        .find(|i| i.module == "nap.api")
+        .ok_or("no import")?;
+    assert_eq!(
+        import.names,
+        vec!["auth_mod".to_owned()],
+        "the bound alias name must be recorded, not the original"
+    );
+    Ok(())
+}

--- a/crates/basilisk-uv/src/lib.rs
+++ b/crates/basilisk-uv/src/lib.rs
@@ -21,4 +21,4 @@ pub use error::UvError;
 pub use lockfile::{parse_lock_file, LockFile};
 pub use pyproject::extract_pyproject_deps;
 pub use registry::{DepKind, PackageInfo, PackageRegistry};
-pub use workspace::{parse_uv_workspace, UvWorkspace};
+pub use workspace::{discover_workspace_members, parse_uv_workspace, UvWorkspace};

--- a/crates/basilisk-uv/src/workspace.rs
+++ b/crates/basilisk-uv/src/workspace.rs
@@ -245,3 +245,145 @@ exclude = ["packages/beta"]
         assert!(result.is_none());
     }
 }
+
+/// Discover uv workspace member source directories.
+///
+/// Implements [LSPUV-WORKSPACE-IMPORT-RESOLUTION]. Parses
+/// `[tool.uv.workspace]` from `pyproject.toml` at each workspace root and
+/// returns the resolved member directory paths. For each member, looks for a
+/// `src/` subdirectory (common Python project layout) and adds it; otherwise
+/// adds the member directory itself.
+///
+/// In monorepo layouts (e.g. `ai_cms/agent-backend/`), `pyproject.toml` may
+/// not be at the workspace root itself. If no uv workspace is found at a root,
+/// we search one level of subdirectories for `pyproject.toml` with `src/`
+/// layouts and add those as source roots.
+///
+/// Returns an empty vec if no workspace members are found.
+#[must_use]
+pub fn discover_workspace_members(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut members = Vec::new();
+
+    for root in roots {
+        // Try uv workspace at this root first.
+        if let Ok(Some(workspace)) = parse_uv_workspace(root) {
+            for member_dir in &workspace.members {
+                add_source_root(&mut members, member_dir);
+            }
+
+            if !workspace.members.is_empty() {
+                tracing::info!(
+                    root = %root.display(),
+                    member_count = workspace.members.len(),
+                    "discovered uv workspace members"
+                );
+                continue;
+            }
+        }
+
+        // Root itself is a Python project (pyproject.toml at the workspace
+        // root, not inside a uv workspace). Add its source root so first-party
+        // imports resolve under a `src/` layout.
+        if root.join("pyproject.toml").is_file() {
+            add_source_root(&mut members, root);
+            tracing::info!(
+                root = %root.display(),
+                "discovered project at workspace root"
+            );
+        }
+
+        // Also search subdirectories for projects. This handles monorepos
+        // where the IDE root (e.g. `ai_cms/`) is a parent of the actual
+        // Python project (e.g. `ai_cms/agent-backend/`).
+        let Ok(entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() || !path.join("pyproject.toml").is_file() {
+                continue;
+            }
+
+            // Try uv workspace in the subdirectory.
+            if let Ok(Some(workspace)) = parse_uv_workspace(&path) {
+                for member_dir in &workspace.members {
+                    add_source_root(&mut members, member_dir);
+                }
+                if !workspace.members.is_empty() {
+                    tracing::info!(
+                        root = %path.display(),
+                        member_count = workspace.members.len(),
+                        "discovered uv workspace members in subdirectory"
+                    );
+                    continue;
+                }
+            }
+
+            // No uv workspace, but has pyproject.toml — treat as a project.
+            add_source_root(&mut members, &path);
+            tracing::info!(
+                path = %path.display(),
+                "discovered project subdirectory"
+            );
+        }
+    }
+
+    members
+}
+
+/// Add a project directory's source root to the member list.
+///
+/// Prefers `src/` layout if it exists, otherwise adds the directory itself.
+fn add_source_root(members: &mut Vec<PathBuf>, project_dir: &Path) {
+    let src_dir = project_dir.join("src");
+    if src_dir.is_dir() {
+        members.push(src_dir);
+    } else {
+        members.push(project_dir.to_path_buf());
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    reason = "test-only code: unwrap acceptable in unit tests"
+)]
+mod discovery_tests {
+    use super::discover_workspace_members;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_CTR: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_tmp(prefix: &str) -> std::path::PathBuf {
+        let n = TEST_CTR.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("{prefix}_{n}_{}", std::process::id()))
+    }
+
+    /// Regression: when the workspace root itself is a Python project with a
+    /// `src/` layout (no uv workspace, no subdirectory projects), the `src/`
+    /// directory must be added to workspace members so first-party imports
+    /// like `from agent_backend.config import settings` resolve.
+    #[test]
+    fn root_src_layout_project_is_discovered() {
+        let root = unique_tmp("bsk_uv_root_src");
+        let src = root.join("src");
+        let pkg = src.join("mypkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("__init__.py"), "").unwrap();
+        std::fs::write(pkg.join("config.py"), "settings = 1\n").unwrap();
+        std::fs::write(
+            root.join("pyproject.toml"),
+            "[project]\nname = \"mypkg\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+
+        let members = discover_workspace_members(std::slice::from_ref(&root));
+
+        assert!(
+            members.iter().any(|m| m == &src),
+            "expected src/ to be in workspace_members, got: {members:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -889,6 +889,52 @@ All stages are backed by:
 +------------------+
 ```
 
+### Parse Nesting-Depth Guard {#CHKARCH-ARCH-PARSEDEPTH}
+
+`ruff_python_parser` is a recursive-descent parser, and the resolver and checker
+walk the resulting AST recursively (as does the AST's own `Drop`). All three
+overflow the thread stack on pathologically nested input: a bracket expression
+nested past roughly 4 000 levels aborts the process with `SIGABRT`. On the
+language server this manifested as a crash-restart loop the moment a workspace
+containing such a file was scanned. (A single 20 000-deep parenthesised
+expression in a generated file is the canonical trigger.)
+
+To stay crash-safe — and to match CPython, which rejects this input at the
+*tokenizer* rather than crashing — `parse_source` (the workspace's single entry
+point into `ruff_python_parser`) runs a nesting-depth guard **before** handing
+the source to the recursive parser. The guard:
+
+- Measures depth with ruff's **linear lexer** (`lex` + `next_token`), a flat byte
+  scan that never recurses, so the measurement itself can never overflow. It
+  short-circuits at the first violating token, so a pathological file is only
+  lexed up to the offending bracket/indent.
+- Rejects **bracket nesting** (`(`, `[`, `{`, cumulative) deeper than **200**,
+  matching CPython's tokenizer `MAXLEVEL`; the message is CPython's verbatim
+  `too many nested parentheses`.
+- Rejects **indentation** deeper than **99 levels**, matching CPython's
+  `MAXINDENT`; the message is CPython's verbatim `too many levels of
+  indentation`.
+
+Both limits sit one to two orders of magnitude below the ~4 000 stack-overflow
+floor and far above any non-pathological source (real code rarely nests beyond
+~15 brackets / ~10 indents), so the guard is crash-proof without false
+positives. The rejection surfaces as a `ParseError::Syntax` and follows the
+existing parse-error path (`BSK-PARSE` in the LSP).
+
+**Known residual (out of scope for this tokenizer-level guard):** an extremely
+long *un-bracketed* expression — e.g. a 30 000-term `1+1+...` operator chain or a
+deeply nested ternary/`lambda` — parses successfully in ruff but produces an AST
+deep enough to overflow on any later recursive traversal (resolver, checker, or
+`Drop`). This is the class CPython itself bounds only at its *parser* C-stack
+guard (a build-dependent `MemoryError`), not the tokenizer, and a complete fix
+would require iterative AST traversal/teardown rather than a parse-time check.
+Such input does not occur in real or generated code (deep generated data is
+bracketed, and is covered above).
+
+Implemented in `crates/basilisk-parser/src/depth.rs` and `…/src/lib.rs`
+(`parse_source`); covered by `crates/basilisk-parser/tests/parse_tests.rs` and
+the propagation test in `crates/basilisk-checker/tests/checker_tests.rs`.
+
 ### Rust Crate Structure {#CHKARCH-ARCH-CRATES}
 
 ```

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -1200,10 +1200,13 @@ the current directory is scanned. Entries are resolved relative to the
 directory of the configuration file. This keeps vendored or generated trees
 the user excluded by omission out of the walk entirely (issue #37).
 
-The **LSP workspace scan** honors the same `include` roots
-(`WorkspaceIndex::scan_dirs_for`), so the editor analyses exactly the files
-`basilisk check` would: a generated tree outside the include roots is neither
-scanned nor diagnosed in the editor, matching the CLI.
+The **LSP** honors the same `include` roots on both paths, so the editor
+analyses exactly the files `basilisk check` would. The bulk scan walks only the
+include roots (`WorkspaceIndex::scan_dirs_for`), and the per-file/open path
+suppresses diagnostics for any file outside them
+(`WorkspaceIndex::is_outside_include_roots`, applied in `analyse_and_resolve` and
+`recheck_all_files`) — so a file in a generated tree shows no diagnostics even
+when opened, exactly like an `exclude`d file.
 
 ### Exclude Semantics {#CHKARCH-CONFIG-EXCLUDE}
 

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -1145,6 +1145,15 @@ disabled = ["BSK-E0011"]
 rules."BSK-E0010" = "warning"
 ```
 
+### Include Semantics {#CHKARCH-CONFIG-INCLUDE}
+
+`include` lists the roots scanned when no paths are given on the CLI
+(`basilisk check` with no arguments). Explicit CLI paths always override it;
+`exclude` applies within the include roots. When `include` is absent or empty,
+the current directory is scanned. Entries are resolved relative to the
+directory of the configuration file. This keeps vendored or generated trees
+the user excluded by omission out of the walk entirely (issue #37).
+
 ### Exclude Semantics {#CHKARCH-CONFIG-EXCLUDE}
 
 `exclude` (and the `per-path-overrides` keys) use **gitignore-style globs**,

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -1200,6 +1200,11 @@ the current directory is scanned. Entries are resolved relative to the
 directory of the configuration file. This keeps vendored or generated trees
 the user excluded by omission out of the walk entirely (issue #37).
 
+The **LSP workspace scan** honors the same `include` roots
+(`WorkspaceIndex::scan_dirs_for`), so the editor analyses exactly the files
+`basilisk check` would: a generated tree outside the include roots is neither
+scanned nor diagnosed in the editor, matching the CLI.
+
 ### Exclude Semantics {#CHKARCH-CONFIG-EXCLUDE}
 
 `exclude` (and the `per-path-overrides` keys) use **gitignore-style globs**,

--- a/docs/specs/CHECKER-TYPE-INFERENCE-SPEC.md
+++ b/docs/specs/CHECKER-TYPE-INFERENCE-SPEC.md
@@ -72,6 +72,9 @@ This rule applies to:
 - `TypedDict` fields — annotation is always required
 - `NamedTuple` fields — annotation is always required
 - `Protocol` member signatures — annotation is always required
+- `@dataclass` / `@pydantic.dataclasses.dataclass` / attrs (`@define`, `@attr.s`) /
+  pydantic `BaseModel` fields — the annotation is what makes the assignment a
+  field; never redundant (issues #110, #39)
 - `ClassVar` and `Final` — the qualifier itself is non-redundant even if the base type is inferrable
 
 **Interaction with conformance**: This rule does not conflict with PEP 526 or any conformance test. The conformance suite tests that annotations are respected when present; it does not require annotations where inference suffices. Basilisk goes further by enforcing that redundant annotations are absent.

--- a/docs/specs/LSP-ANALYSIS-MODES-SPEC.md
+++ b/docs/specs/LSP-ANALYSIS-MODES-SPEC.md
@@ -181,12 +181,18 @@ Each `ResolvedModule` carries `imported_symbols: HashMap<String, ExternalSymbol>
 
 ### Invalidation Cascading {#ANALYSIS-SYMBOLS-INVAL}
 
-When a file changes:
+When a file changes — whether on disk (file watcher) or in the editor
+(`didChange` / `didSave` on an **open** file) — its exports are diffed:
 
-1. Re-analyse the changed file
-2. `exported_symbol_names()` compares old and new exports
-3. If exports changed, `invalidate_dependents()` queues transitive importers for re-analysis
-4. If exports unchanged, skip cascade (most edits don't change public API)
+1. Re-analyse the changed file.
+2. `exported_symbol_names()` compares old and new exports.
+3. If exports changed, re-resolve the workspace and re-check importers
+   (`reresolve_imports_and_recheck`) so their cross-module diagnostics refresh
+   without a reload. The watcher path uses `reload_and_diff_exports`; the
+   open-file path uses `set_open_refresh_dependents` — the watcher's
+   `reload_from_disk` skips open files, so editing an open module would
+   otherwise leave dependents stale (GitHub #56).
+4. If exports unchanged, skip the cascade (most edits don't change public API).
 
 ---
 

--- a/docs/specs/LSP-ARCHITECTURE-SPEC.md
+++ b/docs/specs/LSP-ARCHITECTURE-SPEC.md
@@ -530,7 +530,7 @@ The registry feeds into:
 
 ### Hot Reload {#LSPARCH-UV-HOTRELOAD}
 
-All uv commands trigger `rebuild_registry_and_resolve()` on success — re-parses `uv.lock`, rebuilds the registry, re-resolves all imports, and republishes diagnostics for every indexed file. The same function fires when the file watcher detects `uv.lock` or `pyproject.toml` changes. No LSP restart needed.
+All uv commands trigger `rebuild_registry_and_resolve()` on success — re-parses `uv.lock`, rebuilds the registry, re-resolves all imports, and republishes diagnostics for every indexed file. The same path fires when the file watcher detects a `uv.lock`, `pyproject.toml`, `basilisk.json`, or `.python-version` change — first reloading each root's checker config (`reload_root_configs`) so version-aware rules ([CHKARCH-VERSION-TARGET]) and rule-severity overrides update live, then re-checking. No LSP restart needed.
 
 ### uv Binary Resolution {#LSPARCH-UV-BINRES}
 

--- a/docs/specs/LSP-UV-INTEGRATION-SPEC.md
+++ b/docs/specs/LSP-UV-INTEGRATION-SPEC.md
@@ -440,10 +440,16 @@ The LSP registers additional file watchers for uv projects:
 
 | Pattern | Event | Action |
 |---------|-------|--------|
-| `uv.lock` | Create / Change | Re-parse lock, rebuild `PackageRegistry`, re-resolve imports |
-| `.python-version` | Create / Change | Update Python version, re-check stdlib availability |
-| `pyproject.toml` | Change | Re-detect workspace members, check lock staleness |
+| `uv.lock` | Create / Change | Reload checker config, rebuild `PackageRegistry`, re-resolve imports, re-check |
+| `.python-version` | Create / Change | Reload checker config (version-aware rules — [CHKARCH-VERSION-TARGET]), re-check |
+| `pyproject.toml` | Change | Reload checker config, re-detect workspace members, rebuild registry, re-check |
+| `basilisk.json` | Change | Reload checker config (severity overrides, `python-version`), re-check |
 | `.venv/pyvenv.cfg` | Create / Delete | Re-detect environment manager |
+
+On any of these, the LSP first re-reads each root's `BasiliskConfig` from disk
+(`WorkspaceIndex::reload_root_configs`) so a changed `python-version` or rule
+severity takes effect **without an LSP restart**, then re-checks every indexed
+file and republishes diagnostics.
 
 ---
 


### PR DESCRIPTION
Continues the critical-fix sweep from #117. Every fix followed the test-first bug-fix workflow: the failing test was written and confirmed failing for the right reason before the fix was applied.

Fixes #108
Fixes #107
Fixes #64
Fixes #36
Fixes #37
Fixes #25
Fixes #24
Fixes #56
Fixes #26
Fixes #39
Fixes #22
Fixes #13

## Code fixes

### #108 — BSK-E0131 FP: bare `yield` misread as yielding the next statement
The E0131 byte scanner's `extract_yield_expr` used `trim_start()`, which eats newlines and the next line's indentation — a bare `yield` at end of line captured the NEXT statement's text (`_purge_workspace_modules()`) as its value. It now skips horizontal whitespace only, so a bare yield resolves to the empty expression and hits the existing `Iterator[None]` exemption. Test: `e0131_tests.rs`.

### #107 / #64 — BSK-E0018 FP: aliased module import "not defined in this scope"
`alias_name` in the resolver visitor discarded `asname`, so `from nap.api import auth as auth_mod` recorded `auth` in `ImportInfo.names` while the scope actually binds `auth_mod`. It now returns the bound name. Audited every `names` consumer: scope membership (e0018/e0047/e0045), cascade suppression, scope tree, and completions all want the bound name; the cross-module export lookup fails open for aliased imports exactly as before (no symbol-level import diagnostic exists yet — that is #55). Tests: `e0018_tests.rs`, `test_mutant_alias.rs` (asname branch mutant kill).

### #36 — BSK-E0120 FP: `@asynccontextmanager` async generator return types
The unqualified spelling was already fixed, but dotted (`typing.AsyncIterator[None]`, `collections.abc.AsyncIterator[None]`) and string annotations still false-positived, with or without the decorator: the base name kept its module prefix so it failed the generator-type membership test, and the uppercase user-type escape hatch never applied to a base starting with `typing.`/`"`. New `unqualified_base` helper strips quotes and dotted prefixes before both checks. Tests: `e0120_tests.rs` (+6, covering decorator, dotted sync/async, and string-annotation forms).

### #37 — stack overflow: `basilisk check` ignored `[tool.basilisk] include`
A no-args run walked the entire repository, so a deeply nested expression in a generated file outside the configured roots crashed the process (SIGABRT, reproduced in a fixture). `include` is now parsed into `BasiliskConfig` (pyproject + basilisk.json) and used as the default check roots; explicit CLI paths always win, `exclude` still applies within the roots. New spec section `[CHKARCH-CONFIG-INCLUDE]`. Tests: new `e2e_include_config.rs` (overflow repro, include-only walk, explicit-path override).

### #25 — BSK-E0010 misclassification for import-name ≠ distribution-name
`classify_unresolved` round-tripped the *import* name through `package_to_import_name` (distribution→import direction, lowercasing), so `PIL` became `pil` and missed the registry — which is keyed by import name, case-preserved. Declared-but-unsynced Pillow was reported "not a dependency in pyproject.toml" instead of "declared but the environment is not synced". Both lookup sites now query the registry directly (full dotted name first so keys like `google.protobuf` hit, then the root segment). This also restores package metadata enrichment (W0011/hover) for mixed-case import names (PIL, OpenSSL, PyQt5). Test: `e2e_import_resolution.rs`.

### #24 — CLI cannot resolve src-layout first-party imports
The CLI built `ImportSearchPaths` without ever populating `workspace_members` — src-layout discovery lived only in the LSP's `init.rs`. `discover_workspace_members` + `add_source_root` moved (not copied) into `basilisk-uv` (their only non-std dependency, `parse_uv_workspace`, already lives there) and are now invoked inside `ImportSearchPaths::from_config`, so the CLI, LSP scan, and registry-rebuild paths all share one implementation. The three manual assignment sites were deleted. Test: `e2e_import_resolution.rs` (src-layout project checked from root must be clean).

### #56 — cross-module diagnostics stale after editing an existing module
Only file CREATION refreshed dependents; a watched-file CHANGED event reloaded just the changed file, and nothing after startup ever re-ran `populate_cross_module_symbols`. The Changed path now diffs each reloaded file's exported symbol set (`reload_and_diff_exports`, finally wiring up the dead `exported_symbol_names`) and triggers the full re-resolve when it changed; `reresolve_imports_and_recheck` now also repopulates cross-module symbols and rebuilds the import graph in crossModule mode — fixing the same gap on the Created path. Body-only edits keep the cheap per-file path. Implements `[ANALYSIS-SYMBOLS-INVAL]`, which previously had zero call sites. Test: `ws_test_cross_module.rs` (`changed_module_exports_refresh_dependent_diagnostics`).

## Verified already fixed on main — regression locks added

| Issue | Fixed by | Lock added |
|---|---|---|
| #26 variadic `tuple[T, ...]` vs concrete literal | `homogeneous_tuple_elem` dispatch (PR #54) | FP pin + element-mismatch TP test in `e0014_tests.rs` |
| #39 W0050 on dataclass fields | `annotation_defines_field` (PR #117, #110) | `@pydantic.dataclasses.dataclass` dotted-form test + `[TYPEINF-REDUNDANT]` exceptions list updated |
| #22 sibling script imports | `resolve_module_with_importer` | binary e2e checking from the project ROOT — the only invocation shape that genuinely exercises the importer-directory fallback |
| #13 py.typed packages flagged untyped | W0010→E0152 rework | binary e2e with a fake venv: py.typed suppressed, untyped still fires, no fabricated `types-X` suggestion |

## Validation

- `make lint` clean, including the deslop duplication gate.
- 5,572 tests green across 87 test binaries. `conformance_score` ratchet passes.
- `make bench` PASS — no regression vs baseline; a new `darwin-arm64-apple-m4` baseline CSV is included (first run on this machine). The #36 fix adds a few byte-level string ops per generator function; the #107 fix is one `Option` branch per import alias.
- Pure FP reductions throughout — the conformance and false-positive monotonic ratchets can only improve.
- DRY: config string-array parsing deduplicated into `json_string_array`/`toml_string_array`; workspace-member discovery now has exactly one implementation shared by CLI and LSP.

## Notes for reviewers

- Changing `ImportInfo.names` to bound names (aliased from-imports only) means the cross-module export propagation in `cross_module.rs` now misses aliased symbol imports instead of inserting them under the original (unbound, unusable) key — both behaviors fail open; proper aliased cross-module propagation needs original+bound pairs and belongs with #55.
- Local-only environmental failures on the dev machine, unrelated to this change and identical at `84610fd`: `test_zed_execute_start_debug_session` (times out locally; passes in CI) and `make fmt`'s eslint step (eslint not installed locally). All other suites were run to completion.
- `basilisk fix`/`adopt` still default to `.` rather than the include roots — noted as out of scope in the #37 fix; the unbounded ruff parser recursion on a deep file INSIDE include roots remains an upstream robustness concern.
---

## Follow-up fixes (found while manually testing the above)

Manual end-to-end testing of the fixes above surfaced five further defects — each fixed test-first, all CI gates re-run green (lint, coverage, vsix, zed, mutation, build).

### Parser stack-overflow guard — `[CHKARCH-ARCH-PARSEDEPTH]`
`#37` bounded only the CLI no-args walk; the recursive-descent parser (and the recursive AST visitors) still overflowed the stack — a ~4000-deep bracket file `SIGABRT`-ed, crash-looping the LSP when it scanned such a file. `parse_source` now runs a nesting-depth guard, measured with ruff's linear lexer (no recursion), before parsing: brackets > 200 and indentation > 99 are rejected as a parse error, matching CPython's `MAXLEVEL`/`MAXINDENT`. Crash-proof, no false positives.

### `#93` reactivity — config changes re-check without a reload
Editing `[tool.basilisk] python-version` did not update diagnostics until an LSP restart. New `WorkspaceIndex::reload_root_configs`, wired into `did_change_watched_files`, re-reads each root's config so version-aware rules and severity overrides apply live; `basilisk.json` added to the watcher globs.

### `#56` — cross-module refresh on open-file edits + stale-export clear
The original `#56` fix only fired when the edited module was closed. `set_open_refresh_dependents` now drives the cross-module re-resolve for open files; and `populate_cross_module_symbols` now clears `imported_symbols` before repopulating so a renamed export no longer lingers and keeps the dependent green.

### `#37` — the LSP now honors `include` (scan + open files)
`include` was a CLI-only filter. `scan_dirs_for` restricts the scan to the include roots, and `is_outside_include_roots` suppresses diagnostics for a file outside them even when opened — consistent with `exclude`.

### `BSK-E0018` — check call callees; recognize module-level functions/classes
E0018 only inspected bare-name returns, so `return greet()` was a false negative while `return helper` for a real sibling `def` was a false positive. The resolver now collects call callees for returns and the checker recognizes module functions/classes — an FP reduction plus a gap fill, conformance-neutral (FP gate held at 54).
