### PR TITLE
Security hardening: CodeQL, dependency-review, SECURITY.md, Dependabot grouping + CI runner routing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,59 @@
-# agent-pmo:f87d349
-# Keeps SHA-pinned GitHub Actions and language dependencies fresh ([SWR-SEC-ACTION-PINNING]).
-# Each ecosystem is grouped into a single combined PR per run to reduce churn.
+# agent-pmo:0b21609
+# Dependabot — supply-chain defense without PR spam ([GITHUB-DEPENDABOT]).
+#
+# Every ecosystem is GROUPED into at most two PRs: <eco>-minor (minor+patch, low
+# risk, merge freely) and <eco>-major (breaking, review individually). Bundling
+# breaking majors with safe patches is avoided on purpose. These group rules also
+# apply to Dependabot security updates, so security fixes land grouped too.
+# SHA-pinned actions are a prime supply-chain target ([SWR-SEC-ACTION-PINNING]),
+# so github-actions is kept current here.
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
     groups:
-      actions:
+      github-actions:
         patterns: ["*"]
 
+  # Cargo / Rust — the type checker + LSP workspace (Cargo.toml at the root).
   - package-ecosystem: cargo
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
     groups:
-      cargo:
-        patterns: ["*"]
+      cargo-minor:
+        update-types: ["minor", "patch"]
+      cargo-major:
+        update-types: ["major"]
 
+  # npm — VS Code extension.
   - package-ecosystem: npm
-    directory: "/vscode-extension"
+    directory: /vscode-extension
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
     groups:
-      npm:
-        patterns: ["*"]
+      npm-minor:
+        update-types: ["minor", "patch"]
+      npm-major:
+        update-types: ["major"]
 
+  # npm — documentation website (Eleventy).
   - package-ecosystem: npm
-    directory: "/website"
+    directory: /website
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
     groups:
-      npm:
-        patterns: ["*"]
+      npm-minor:
+        update-types: ["minor", "patch"]
+      npm-major:
+        update-types: ["major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,10 @@ jobs:
     name: Rust Tests & Coverage
     needs: changes
     if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-24.04
+    # llvm-cov instruments and compiles the whole workspace before running every
+    # target — CPU-bound, so it rides BIG_RUNNER too (see the mutation job for
+    # the opt-in contract). Falls back to the standard runner when unset.
+    runs-on: ${{ vars.BIG_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -377,12 +380,25 @@ jobs:
     # reports success in seconds, satisfying the required checks at ~zero cost.
     env:
       RUN: ${{ needs.changes.outputs.code }}
-    runs-on: ubuntu-24.04
+    # Big-runner opt-in via a single org/repo Actions variable. Set BIG_RUNNER to
+    # the label of the Nimblesite GitHub-hosted larger runner to route the real,
+    # CPU-bound mutation work onto it; leave it unset and the job falls back to
+    # the standard hosted runner so CI never breaks on a missing label. The
+    # variable is the single source of truth — change the machine in one place.
+    #
+    # The `code` guard keeps the larger runner off no-op shards: this job has no
+    # job-level `if` (the four shards must always report as required checks), so
+    # on a docs/config-only PR every shard still starts but every step no-ops.
+    # Only bill BIG_RUNNER when there is actually Rust to mutate; otherwise these
+    # seconds-long no-ops run on the standard runner.
+    runs-on: ${{ (needs.changes.outputs.code == 'true' && vars.BIG_RUNNER) || 'ubuntu-24.04' }}
     # cargo-mutants rebuilds + reruns the test suite once per mutant, so it is
-    # heavily CPU-bound. The 20-minute budget was calibrated for the retired
-    # 8-core larger runners; on the standard hosted runner the slower shards
-    # tip over the limit non-deterministically. 60 min gives ~3x headroom
-    # without weakening the mutation gate (the merge job still enforces score).
+    # heavily CPU-bound — the primary reason BIG_RUNNER exists. The 20-minute
+    # budget was calibrated for an 8-core larger runner; the standard hosted
+    # runner's slower shards tip over it non-deterministically, so 60 min gives
+    # ~3x headroom on the fallback path without weakening the mutation gate (the
+    # merge job still enforces score). On BIG_RUNNER the shards finish well
+    # under it; the ceiling is harmless.
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# agent-pmo:f87d349
+# agent-pmo:0b21609
 name: CI
 
 on:
@@ -516,3 +516,25 @@ jobs:
 
       - name: Build Rust (release)
         run: cargo build --release
+
+  # ── Dependency review ([GITHUB-DEP-REVIEW]) ────────────────────────────────
+  # Blocks PRs that introduce dependencies with known-high vulnerabilities. This
+  # is the repo's ONLY dependency vuln-gate — there is no cargo-deny/osv gate, so
+  # there is no doubling-up. It is SEPARATE from CodeQL (codeql.yml = vulnerable
+  # code) and `make lint` (style/correctness): one owner per concern. PR-only by
+  # construction — dependency-review diffs base vs head — which matches this
+  # workflow's pull_request-only trigger.
+  security:
+    name: security
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write # dependency-review posts its PR summary
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,77 @@
+# agent-pmo:0b21609
+name: CodeQL
+
+# CodeQL static security analysis ([GITHUB-CODE-SCANNING]).
+#
+# SEPARATE from ci.yml on purpose: CodeQL feeds GitHub code-scanning alerts and
+# needs `security-events: write` + a weekly schedule, while ci.yml owns
+# lint/test/build. It does NOT overlap with `make lint` (style/correctness) or
+# the ci.yml `security` job's dependency-review (vulnerable packages) — CodeQL
+# finds vulnerable CODE. Never add security-rule linter plugins that re-cover
+# CodeQL: no doubling up.
+#
+# Matrix = (languages actually in this repo) ∩ (languages CodeQL supports right
+# now). For Basilisk that is `rust` (the type-checker/LSP) and
+# `javascript-typescript` (the VS Code extension + website), plus `actions`
+# (scans the workflow files themselves). Python IS supported by CodeQL, but the
+# only Python in this repo is type-checker test fixtures under conformance/,
+# examples/, and tests/ — deliberately malformed sample code, NOT first-party
+# code that ships or executes. Scanning it would drown the real signal in
+# fixture noise, so it is intentionally excluded. Action SHAs are kept current
+# by the github-actions Dependabot group ([GITHUB-DEPENDABOT]).
+on:
+  pull_request:
+    branches: [main]
+  push:
+    # Run before EVERY release: scan the exact released SHA with the current
+    # query set. A release can ship code last scanned weeks ago — the PR scan
+    # covered the diff, the weekly scan covers drift, this covers the release.
+    tags: ["v*"]
+  schedule:
+    # Weekly, so newly-published CodeQL queries re-scan even without a push.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Code scanning (SARIF upload) requires GitHub Advanced Security on PRIVATE
+    # repos. Gating on public visibility lets a private repo skip cleanly (no red
+    # X) and self-enable the moment it is made public — no follow-up edit needed.
+    if: github.event.repository.visibility == 'public'
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # build-mode: none — Rust and the interpreted langs do not need CodeQL to
+        # drive a compile; ci.yml already builds the Rust workspace.
+        include:
+          - language: actions # scans the workflow files themselves
+            build-mode: none
+          - language: rust
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+<!-- agent-pmo:0b21609 -->
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report privately through GitHub's **private vulnerability reporting**: go to the
+repository's **Security** tab → **Report a vulnerability** (or
+<https://github.com/Nimblesite/Basilisk/security/advisories/new>). This opens a
+private, structured advisory only the maintainers can see.
+
+If you cannot use that channel, email **security@nimblesite.co**.
+
+When reporting, please include:
+
+- The type of issue (e.g. injection, path traversal, auth bypass, secret exposure).
+- The affected version(s), file(s), and any relevant configuration.
+- Steps to reproduce, ideally a minimal proof of concept.
+- The impact: what an attacker can achieve.
+
+## What to Expect
+
+- **Acknowledgement** within **3 business days**.
+- An assessment and a remediation plan (or a reasoned decline) within **10 business days**.
+- Coordinated disclosure: we will agree a disclosure timeline with you and credit
+  you in the advisory unless you prefer to remain anonymous.
+
+## Supported Versions
+
+Security fixes land on the latest released minor version. Older lines are
+supported only as noted below.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.12.x  | ✅        |
+| < 0.12  | ❌        |
+
+## References
+
+- Add a security policy: <https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy>
+- Configure private vulnerability reporting: <https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configure-for-a-repository>


### PR DESCRIPTION
## TLDR
Hardens the repo's security posture (CodeQL code scanning, a dependency-review gate, a security policy, and grouped Dependabot) and routes the CPU-bound Rust coverage + mutation jobs onto an opt-in larger runner.

## What Was Added?
- **`.github/workflows/codeql.yml`** — CodeQL static analysis. Matrix = `rust` + `javascript-typescript` + `actions`, `build-mode: none`, `queries: security-extended`, SHA-pinned actions. Triggers exactly: PR→`main`, weekly schedule, and `v*` release-tag push (scans the released SHA). Public-visibility gated so a private fork skips cleanly. Python is intentionally excluded — the only Python here is type-checker test fixtures (conformance/examples), not first-party code, so scanning it would be noise.
- **`security` job in `ci.yml`** — `actions/dependency-review-action` (`fail-on-severity: high`, SHA-pinned `v4.9.0`). The repo previously had no dependency vulnerability gate; this blocks PRs that introduce known-vulnerable dependencies.
- **`SECURITY.md`** — private-vulnerability-reporting-first policy, `security@nimblesite.co` fallback, ack (3 business days) / assessment (10 business days) SLAs, supported-versions table (`0.12.x`).

## What Was Changed or Deleted?
- **`ci.yml` runner routing ("fix release" commit):** the `Rust Tests & Coverage` job and the four mutation shards now run on `${{ vars.BIG_RUNNER || 'ubuntu-24.04' }}`, opting into the larger hosted runner via a single Actions variable and falling back to the standard runner when unset. Mutation shards only bill the big runner when there's actually Rust to mutate (`code` guard). No-op/docs PRs stay on the standard runner.
- **`dependabot.yml`** re-grouped: each ecosystem (cargo, both npm dirs, github-actions) now splits into `*-minor` (minor+patch) and `*-major` groups, so breaking majors are reviewed separately instead of being bundled with safe patch bumps. All four ecosystems and both npm directories (`/vscode-extension`, `/website`) preserved.

## How Do The Automated Tests Prove It Works?
This PR changes CI configuration and docs only — no Rust/TypeScript source is touched. Validation:
- `codeql.yml`, `ci.yml`, `dependabot.yml` all pass `actionlint` (exit 0) and YAML parse.
- The PR's own GitHub Actions run is the authoritative gate: the existing required checks (Lint, Rust Tests & Coverage, VS Code Extension, Zed/Neovim, Mutation Testing ×4 + merge, Shipwright Binary Gate, Build) must pass before merge, and the new `CodeQL Analyze (rust/javascript-typescript/actions)` + `security` (dependency-review) jobs run on this PR.

## Spec / Doc Changes
Adds `SECURITY.md`. No spec/CLAUDE.md/README changes.

## Breaking Changes
- [x] None