### PR TITLE
build: declare MIT in Cargo.toml to match LICENSE file + docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = []
 [workspace.package]
 version      = "0.0.0-PLACEHOLDER"
 edition      = "2021"
-license      = "MIT OR Apache-2.0"
+license      = "MIT"
 repository   = "https://github.com/Nimblesite/Basilisk"
 rust-version = "1.87"
 


### PR DESCRIPTION
## TLDR

Aligns `[workspace.package].license` in `Cargo.toml` to **MIT**, matching the repo's MIT-only `LICENSE` file and the README/`package.json`/spec/navigation metadata (set to MIT in 501fe4c3).

## What Was Changed?

`Cargo.toml`: `license = "MIT OR Apache-2.0" → "MIT"` (one line).

## Why

The repo has a single `LICENSE` file (MIT); there is no `LICENSE-APACHE`. The dual-license string was inconsistent with the operative license. The docs and `package.json` were already moved to MIT; this makes `Cargo.toml` consistent. (Supersedes the incorrect dual revert in #134.)

## How Tests Prove It Works

One-line metadata change; full CI (lint/test/build/conformance/mutation) revalidates. No code or behaviour change.

## Breaking Changes
- [x] None