### PR TITLE
fix(profiler): make wire conversion cross-platform to unblock Windows release

### DIFF
--- a/crates/basilisk-lsp/src/profiler/cooperative.rs
+++ b/crates/basilisk-lsp/src/profiler/cooperative.rs
@@ -38,8 +38,8 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 use tracing::{debug, info, warn};
 
-use super::helper_client::to_pyspy_traces;
 use super::sampler::{SampleBatch, SamplerError, SamplerHandle};
+use super::wire::to_pyspy_traces;
 
 /// How long to wait for the injected thread to write its header line.
 const HEADER_TIMEOUT: Duration = Duration::from_secs(15);

--- a/crates/basilisk-lsp/src/profiler/helper_client/launch.rs
+++ b/crates/basilisk-lsp/src/profiler/helper_client/launch.rs
@@ -1,12 +1,11 @@
 //! Implements [PROFILE-HELPER-SOCKET]. See docs/specs/LSP-PROFILING-SPEC.md#PROFILE-HELPER-SOCKET
 //!
-//! Pure conversion / path / command helpers for the elevated-helper path,
-//! kept separate from the socket orchestration in the parent module.
+//! Elevated-helper launch helpers — the `osascript` elevation command and the
+//! Unix socket path the helper connects back on — kept separate from the
+//! socket orchestration in the parent module.
 
 use std::path::PathBuf;
 use std::time::SystemTime;
-
-use basilisk_profiler_protocol::TraceData;
 
 /// Build the `osascript` command that runs the helper as administrator.
 ///
@@ -18,38 +17,6 @@ use basilisk_profiler_protocol::TraceData;
 #[must_use]
 pub fn build_elevation_script(helper: &str, socket: &str) -> String {
     format!("do shell script \"cd / && '{helper}' '{socket}'\" with administrator privileges")
-}
-
-/// Convert wire-format traces back into the `py_spy` shapes the aggregator eats.
-/// Shared with the cooperative sampler, which produces the same wire shape.
-pub(crate) fn to_pyspy_traces(pid: u32, traces: Vec<TraceData>) -> Vec<py_spy::StackTrace> {
-    let spy_pid = i32::try_from(pid).unwrap_or_default();
-    traces
-        .into_iter()
-        .map(|trace| py_spy::StackTrace {
-            pid: spy_pid,
-            thread_id: trace.thread_id,
-            thread_name: trace.thread_name,
-            owns_gil: trace.owns_gil,
-            active: trace.active,
-            frames: trace
-                .frames
-                .into_iter()
-                .map(|frame| py_spy::Frame {
-                    name: frame.name,
-                    filename: frame.filename,
-                    line: frame.line,
-                    short_filename: None,
-                    module: None,
-                    locals: None,
-                    is_entry: false,
-                    is_shim_entry: false,
-                })
-                .collect(),
-            os_thread_id: None,
-            process_info: None,
-        })
-        .collect()
 }
 
 /// Generate a unique, short Unix socket path for one helper session.
@@ -123,43 +90,5 @@ mod tests {
             display.len() < 104,
             "macOS caps socket paths near 104 bytes: {display}"
         );
-    }
-
-    #[test]
-    fn converts_wire_traces_to_pyspy() {
-        let wire = vec![TraceData {
-            thread_id: 9,
-            thread_name: Some("worker".to_owned()),
-            active: true,
-            owns_gil: true,
-            frames: vec![wire_frame("hot_function", "/app/x.py", 42)],
-        }];
-        let converted = to_pyspy_traces(99, wire);
-        assert_eq!(converted.len(), 1);
-        let frame_names: Vec<&str> = converted
-            .iter()
-            .flat_map(|trace| trace.frames.iter().map(|frame| frame.name.as_str()))
-            .collect();
-        assert_eq!(frame_names, vec!["hot_function"]);
-        let preserved = converted.iter().any(|trace| {
-            trace.thread_id == 9
-                && trace.thread_name.as_deref() == Some("worker")
-                && trace.active
-                && trace.owns_gil
-                && trace
-                    .frames
-                    .iter()
-                    .any(|frame| frame.filename == "/app/x.py" && frame.line == 42)
-        });
-        assert!(preserved, "conversion must preserve every wire field");
-    }
-
-    /// Build a wire frame for the conversion test.
-    fn wire_frame(name: &str, file: &str, line: i32) -> basilisk_profiler_protocol::FrameData {
-        basilisk_profiler_protocol::FrameData {
-            name: name.to_owned(),
-            filename: file.to_owned(),
-            line,
-        }
     }
 }

--- a/crates/basilisk-lsp/src/profiler/helper_client/mod.rs
+++ b/crates/basilisk-lsp/src/profiler/helper_client/mod.rs
@@ -39,10 +39,11 @@ use super::sampler::{
     sampler_error_from_kind, SampleBatch, SamplerConfig, SamplerError, SamplerHandle,
 };
 
-mod wire;
-pub use wire::build_elevation_script;
-use wire::create_socket_path;
-pub(crate) use wire::to_pyspy_traces;
+mod launch;
+pub use launch::build_elevation_script;
+use launch::create_socket_path;
+
+use super::wire::to_pyspy_traces;
 
 /// How long to wait for the helper to connect back to the bound socket.
 const ACCEPT_TIMEOUT: Duration = Duration::from_secs(20);

--- a/crates/basilisk-lsp/src/profiler/mod.rs
+++ b/crates/basilisk-lsp/src/profiler/mod.rs
@@ -26,6 +26,8 @@ pub mod presets;
 pub mod privilege;
 pub mod processes;
 pub mod sampler;
+/// Shared wire-format → `py_spy` conversion for the cooperative and helper paths.
+pub(crate) mod wire;
 
 #[cfg(test)]
 mod benchmarks;

--- a/crates/basilisk-lsp/src/profiler/wire.rs
+++ b/crates/basilisk-lsp/src/profiler/wire.rs
@@ -1,0 +1,93 @@
+//! Implements [PROFILE-COOPERATIVE] and [PROFILE-HELPER-SOCKET].
+//! See docs/specs/LSP-PROFILING-SPEC.md#PROFILE-COOPERATIVE
+//! and docs/specs/LSP-PROFILING-SPEC.md#PROFILE-HELPER-SOCKET
+//!
+//! Shared wire-format conversion. Both sampling paths that stream samples to
+//! the LSP — the cooperative in-process sampler (all platforms) and the
+//! elevated helper over a Unix socket (macOS) — emit the same
+//! [`basilisk_profiler_protocol::TraceData`] wire shape, so the conversion
+//! into the `py_spy` types the aggregator consumes lives here, platform-
+//! agnostic, rather than inside the Unix-only helper module.
+
+use basilisk_profiler_protocol::TraceData;
+
+/// Convert wire-format traces back into the `py_spy` shapes the aggregator eats.
+/// Shared by the cooperative sampler and the elevated helper, which produce the
+/// same wire shape.
+pub(crate) fn to_pyspy_traces(pid: u32, traces: Vec<TraceData>) -> Vec<py_spy::StackTrace> {
+    // `py_spy::StackTrace.pid` is `remoteprocess::Pid` — `i32` on Unix, `u32`
+    // on Windows — so convert our `u32` PID to whichever the platform expects.
+    #[cfg(unix)]
+    let spy_pid = i32::try_from(pid).unwrap_or_default();
+    #[cfg(windows)]
+    let spy_pid = pid;
+    traces
+        .into_iter()
+        .map(|trace| py_spy::StackTrace {
+            pid: spy_pid,
+            thread_id: trace.thread_id,
+            thread_name: trace.thread_name,
+            owns_gil: trace.owns_gil,
+            active: trace.active,
+            frames: trace
+                .frames
+                .into_iter()
+                .map(|frame| py_spy::Frame {
+                    name: frame.name,
+                    filename: frame.filename,
+                    line: frame.line,
+                    short_filename: None,
+                    module: None,
+                    locals: None,
+                    is_entry: false,
+                    is_shim_entry: false,
+                })
+                .collect(),
+            os_thread_id: None,
+            process_info: None,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_wire_traces_to_pyspy() {
+        let wire = vec![TraceData {
+            thread_id: 9,
+            thread_name: Some("worker".to_owned()),
+            active: true,
+            owns_gil: true,
+            frames: vec![wire_frame("hot_function", "/app/x.py", 42)],
+        }];
+        let converted = to_pyspy_traces(99, wire);
+        assert_eq!(converted.len(), 1);
+        let frame_names: Vec<&str> = converted
+            .iter()
+            .flat_map(|trace| trace.frames.iter().map(|frame| frame.name.as_str()))
+            .collect();
+        assert_eq!(frame_names, vec!["hot_function"]);
+        let preserved = converted.iter().any(|trace| {
+            trace.thread_id == 9
+                && trace.thread_name.as_deref() == Some("worker")
+                && trace.active
+                && trace.owns_gil
+                && trace
+                    .frames
+                    .iter()
+                    .any(|frame| frame.filename == "/app/x.py" && frame.line == 42)
+        });
+        assert!(preserved, "conversion must preserve every wire field");
+    }
+
+    /// Build a wire frame for the conversion test.
+    fn wire_frame(name: &str, file: &str, line: i32) -> basilisk_profiler_protocol::FrameData {
+        basilisk_profiler_protocol::FrameData {
+            name: name.to_owned(),
+            filename: file.to_owned(),
+            line,
+        }
+    }
+}

--- a/vscode-extension/src/test/suite/profiler-cpu-e2e.test.ts
+++ b/vscode-extension/src/test/suite/profiler-cpu-e2e.test.ts
@@ -39,6 +39,15 @@ import {
 const BURNER_LIFETIME_SECS = 120;
 /** Sampling window before stopping a profile. */
 const SAMPLE_WINDOW_MS = 2_500;
+/**
+ * Ceiling for the cooperative sampler to attribute the hot loop. That path runs
+ * the debuggee under debugpy line-tracing, so on a slow/contended CI runner the
+ * interpreter can spend several seconds in Python/debugpy startup before the hot
+ * loop dominates the samples. Poll snapshots up to this budget instead of
+ * assuming a fixed window — keeping the assertion strict without being
+ * timing-fragile. The burner spins for BURNER_LIFETIME_SECS, well beyond this.
+ */
+const HOT_ATTRIBUTION_TIMEOUT_MS = 30_000;
 /** Budget for the LSP attach + first progress notification. */
 const PROGRESS_WAIT_MS = 10_000;
 /** Budget for profiler diagnostics to be published after stop. */
@@ -388,7 +397,21 @@ suite("CPU profiling — real end-to-end", () => {
       assert.ok(session.sessionId.length > 0, "cooperative attach must mint a session");
       assert.ok(session.pythonVersion.startsWith("3."), `expected Python 3.x, got ${session.pythonVersion}`);
 
-      await new Promise<void>((resolve) => setTimeout(resolve, SAMPLE_WINDOW_MS));
+      // The debuggee runs under debugpy line-tracing, so the hot loop can take
+      // seconds to dominate on a slow CI runner. Poll snapshots until
+      // `hot_function` is actually attributed rather than assuming a fixed
+      // window (the burner keeps spinning for BURNER_LIFETIME_SECS); this keeps
+      // the assertion strict without being timing-fragile.
+      await pollUntilResult({
+        fn: () =>
+          vscode.commands.executeCommand<ProfileResult>("basilisk.profiler.snapshot", {
+            sessionId: session.sessionId,
+            format: "speedscope",
+          }),
+        predicate: (snap) => snap.hotFunctions.some((fn) => fn.name === "hot_function"),
+        timeoutMs: HOT_ATTRIBUTION_TIMEOUT_MS,
+        intervalMs: SAMPLE_WINDOW_MS,
+      });
 
       const result = await vscode.commands.executeCommand<ProfileResult>("basilisk.profiler.stop", {
         sessionId: session.sessionId,


### PR DESCRIPTION
## TLDR
Fix the Windows release build: move the shared wire→`py_spy` conversion out of the Unix-only profiler module so the all-platform cooperative sampler can compile on `win32`.

## What Was Added?
- `crates/basilisk-lsp/src/profiler/wire.rs` — a new **ungated** module holding the shared `to_pyspy_traces` conversion (both the cooperative sampler and the elevated helper emit the same `TraceData` wire shape). References the existing `[PROFILE-COOPERATIVE]` / `[PROFILE-HELPER-SOCKET]` spec IDs.

## What Was Changed or Deleted?
- **Root cause:** `profiler/cooperative.rs` is compiled on every platform but imported `to_pyspy_traces` from the `#[cfg(unix)]` `helper_client` module, so the v0.15.0 Release failed to compile on both `win32-x64` and `win32-arm64` with `error[E0432]: unresolved import` (macOS/Linux passed, so all publish jobs were skipped).
- `cooperative.rs` and `helper_client/mod.rs` now import `to_pyspy_traces` from the new `super::wire` module.
- Renamed `helper_client/wire.rs` → `helper_client/launch.rs`; it now holds only the elevated-helper launch helpers (`build_elevation_script`, `create_socket_path`). The public path `helper_client::build_elevation_script` is unchanged (still re-exported).
- `profiler/mod.rs` declares the new ungated `wire` module.
- Fixed a **second, latent** error the Release never reached because it died at the import first: `py_spy::StackTrace.pid` is `i32` on Unix but `u32` on Windows, so the PID conversion is now `#[cfg]`-split per platform.
- **Test hardening (separate commit):** the `cooperative sampler: OOTB CPU profile of a debug-launched session` CPU e2e test waited a fixed 2.5s then asserted `hot_function` attribution. Under debugpy line-tracing on a slow CI runner that window elapses during Python startup, so the test flaked (`got: run_file, _run_module_as_main, ...`). Replaced the fixed wait with a bounded poll over `profiler.snapshot` (up to 30s) that waits until `hot_function` is attributed before stopping. All original assertions preserved; the shared `SAMPLE_WINDOW_MS` and the other two CPU e2e tests are untouched.

## How Do The Automated Tests Prove It Works?
- Reproduced the exact Windows failure locally with `cargo check --release --target x86_64-pc-windows-msvc --bin basilisk` (the command the failing Release job runs): it surfaced `E0432`, then `E0308` after the import was fixed, and now reports `Finished`.
- The relocated `profiler::wire::tests::converts_wire_traces_to_pyspy` asserts the conversion preserves every wire field (thread id/name, `active`, `owns_gil`, frame filename/line).
- `helper_client::launch::tests::{elevation_script_guards_cwd, elevation_script_quotes_paths_with_spaces, socket_path_is_short_and_contains_pid}` continue to pass after the rename.
- Full local CI run is green: clippy + eslint + deslop, Rust coverage (`basilisk-lsp 80% ≥ 78%`), Zed (96 tests), VS Code extension (`383 passing`, including the hardened cooperative test at ~4.8s), Neovim (`45% ≥ 39%`), `verify-binaries`, and `cargo build --release`.

## Spec / Doc Changes
None — no spec text changed; the new module cites the existing `[PROFILE-COOPERATIVE]` and `[PROFILE-HELPER-SOCKET]` spec IDs.

## Breaking Changes
- [x] None
