### PR TITLE
revert(profiler): gate profiling UI back to test-only

### DIFF
--- a/vscode-extension/src/profiling-ui.ts
+++ b/vscode-extension/src/profiling-ui.ts
@@ -15,13 +15,9 @@
  * To ship profiling, return `true` here unconditionally and delete this gate.
  */
 
-import type * as vscode from "vscode";
+import * as vscode from "vscode";
 
 /** Whether the profiling UI surfaces should be shown in this session. */
-export function isProfilingUiEnabled(_context: vscode.ExtensionContext): boolean {
-  // Enabled unconditionally: the CPU and memory pipelines are covered by
-  // real end-to-end suites on macOS and Linux (attach, live progress, heat
-  // map, artifacts, courier round-trip) — the reliability bar this gate was
-  // waiting for. The gate function stays so a kill-switch is one line away.
-  return true;
+export function isProfilingUiEnabled(context: vscode.ExtensionContext): boolean {
+  return context.extensionMode === vscode.ExtensionMode.Test;
 }


### PR DESCRIPTION
## TLDR
Reverts the [PROFILE-UI-GATE] flip from #138: `isProfilingUiEnabled` is back to **test-only**, so the profiling surfaces (Python Processes panel, status-bar items, all profiling `when` clauses keyed off `basilisk.profilingEnabled`) are exercised under test but hidden in shipped **Production** and dev-host **Development** sessions.

## What Changed
`vscode-extension/src/profiling-ui.ts` — one function:

```ts
// before (#138)
export function isProfilingUiEnabled(_context: vscode.ExtensionContext): boolean {
  return true;
}
// after
export function isProfilingUiEnabled(context: vscode.ExtensionContext): boolean {
  return context.extensionMode === vscode.ExtensionMode.Test;
}
```

- Restores the runtime `import * as vscode` (the gate again reads the `ExtensionMode` value at runtime, not just its type).
- Restores the now-used `context` parameter (was `_context`).
- Realigns the code with the file's own surviving doc comment, which already describes the test-only / hidden-until-reliable behaviour.

## Why It's Safe
Every profiler e2e suite runs under `ExtensionMode.Test`, where the gate still returns `true` — so the profiling UI stays fully enabled under test and behaviour/coverage there is unchanged. The revert only re-hides the surfaces in Production/Development, which no test exercises. No assertion depends on the production-mode return value (`profiler-entrypoints` asserts the static package.json `when` gating, not the function's runtime value).

## Verification
- `make lint` — Rust check/clippy, VS Code ESLint, deslop duplication gate: all pass.
- `make _test_vsix` — **383 vsix tests pass**, coverage **91% ≥ 87%** threshold.
- No Rust / Zed / Neovim / mutation-scope files touched (TS-only one-line revert); those CI jobs are unaffected.

## Breaking Changes
None — additive/visibility only. The profiling LSP backend and all commands remain wired; only the shipped-user UI visibility reverts to its pre-#138 state.