### PR TITLE
refactor(extension): shared subscribeRevision reactive-refresh primitive

### DIFF
--- a/vscode-extension/src/module-explorer.ts
+++ b/vscode-extension/src/module-explorer.ts
@@ -8,9 +8,9 @@
  * notifications.
  */
 
-import { effect } from "@preact/signals-core";
 import * as vscode from "vscode";
 import { type Store } from "./store";
+import { subscribeRevision } from "./reactive-refresh";
 import { Logger } from "./logger";
 
 // ── LSP response types ───────────────────────────────────────────────────
@@ -462,14 +462,5 @@ export function registerModuleExplorer(
  * plumbing.
  */
 export function wireReactiveRefresh(store: Store, provider: ModuleExplorerProvider): void {
-  let lastRevision = store.analysisRevision.value;
-  const dispose = effect(() => {
-    const revision = store.analysisRevision.value;
-    // The effect runs once on subscription — only refresh on real bumps.
-    if (revision !== lastRevision) {
-      lastRevision = revision;
-      provider.refresh();
-    }
-  });
-  provider.disposables.push({ dispose });
+  subscribeRevision(store.analysisRevision, provider);
 }

--- a/vscode-extension/src/reactive-refresh.ts
+++ b/vscode-extension/src/reactive-refresh.ts
@@ -1,0 +1,41 @@
+// Implements [EXTACT-REACTIVE-STATE]. See docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md#EXTACT-REACTIVE-STATE
+/**
+ * Shared reactive-refresh wiring for sidebar panels.
+ *
+ * Every panel is a pure projection of centralized store state: it subscribes to
+ * a monotonic revision signal and re-renders on each bump, never owning a timer
+ * or refreshing itself directly. The Modules panel keys off `analysisRevision`;
+ * the Python Processes panel keys off `processesRevision` (whose visibility-gated
+ * poll bumps the signal, since the OS has no push event for process changes,
+ * issue #148). Both share the one subscription primitive below.
+ */
+
+import { effect, type ReadonlySignal } from "@preact/signals-core";
+import type * as vscode from "vscode";
+
+/** A panel that can re-render on demand and tracks its own disposables. */
+export interface RefreshablePanel {
+  refresh(): void;
+  readonly disposables: vscode.Disposable[];
+}
+
+/**
+ * Subscribe `panel` to a centralized revision signal, refreshing on each real
+ * bump. The effect runs once on subscription; the captured baseline suppresses
+ * that initial no-op so only genuine bumps trigger a refresh. The effect's
+ * disposer is tracked on the panel so it is torn down with the panel.
+ */
+export function subscribeRevision(
+  revision: ReadonlySignal<number>,
+  panel: RefreshablePanel,
+): void {
+  let lastRevision = revision.value;
+  const dispose = effect(() => {
+    const next = revision.value;
+    if (next !== lastRevision) {
+      lastRevision = next;
+      panel.refresh();
+    }
+  });
+  panel.disposables.push({ dispose });
+}


### PR DESCRIPTION
## What

Extracts Module Explorer's inlined reactive-refresh effect into a shared `subscribeRevision(revision, panel)` primitive in the new [`reactive-refresh.ts`](vscode-extension/src/reactive-refresh.ts), per the **`EXTACT-REACTIVE-STATE`** spec ("panels share the one subscription primitive"). `wireReactiveRefresh` now delegates to it.

```diff
 export function wireReactiveRefresh(store: Store, provider: ModuleExplorerProvider): void {
-  let lastRevision = store.analysisRevision.value;
-  const dispose = effect(() => {
-    const revision = store.analysisRevision.value;
-    if (revision !== lastRevision) { lastRevision = revision; provider.refresh(); }
-  });
-  provider.disposables.push({ dispose });
+  subscribeRevision(store.analysisRevision, provider);
 }
```

## Why

- **DRY + spec alignment**: gives `EXTACT-REACTIVE-STATE` the shared primitive it describes, so future revision-driven panels (e.g. Python Processes via `processesRevision`) reuse one audited implementation instead of re-inlining the `lastRevision`/`effect` bookkeeping.
- **Behaviour-preserving**: `ModuleExplorerProvider` already implements `refresh()` + `disposables` (the `RefreshablePanel` shape). The existing `store-reactivity.test.ts` test *"Modules panel refreshes automatically when analysisRevision bumps"* exercises this path through `wireReactiveRefresh`, so the extraction is covered with no test changes.

## Scope note

This is the **clean, non-destructive subset** salvaged from stale uncommitted working-tree changes. The rest of that WIP (a parallel, pre-#138 reimplementation of the Python Processes panel) was discarded because it would have reverted the released v0.16.0 profiler/process-panel work (`bindProcessPanelReactivity`, the Stop-button affordance, `[PROFILE-PROCESSES-REACTIVE]`). Only the shared primitive + the Module Explorer rewire are kept here.

Local: `npm ci`, `npm run compile`, `npm run lint` all green.