### PR TITLE
build(deps): promote cargo bumps from dependabot-upgrades to main (#155)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "shipwright"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b66a7e9aa82b0e124a3b5416e62a5c593955a9074778a8745c2717ab569a21"
+checksum = "44e64d9067b1b69ed2ee282294d6671df7b0f3185e41ac28bc78a76576a4c1b8"
 dependencies = [
  "serde_json",
  "shipwright-manifest",
@@ -2478,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "shipwright-manifest"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2389d704c2149fdd45f8c8eae968e54d4000b18ee42f606ad9fd144d0911e2"
+checksum = "e90748d7c705f11412d8f2f3ee18364eb4d71e51b358c1260ef29a014960245d"
 dependencies = [
  "serde",
  "serde_json",
@@ -2572,9 +2572,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/basilisk-cli/Cargo.toml
+++ b/crates/basilisk-cli/Cargo.toml
@@ -21,8 +21,8 @@ basilisk-uv.workspace       = true
 basilisk-stubs.workspace    = true
 clap.workspace              = true
 # Shipwright `--version` / `--version --json` contract emitter.
-shipwright                  = "0.9.0"
-shipwright-manifest         = "0.9.0"
+shipwright                  = "0.10.0"
+shipwright-manifest         = "0.10.0"
 colored.workspace           = true
 tower-lsp                   = "0.20"
 walkdir.workspace           = true

--- a/crates/basilisk-profiler-helper/Cargo.toml
+++ b/crates/basilisk-profiler-helper/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/main.rs"
 basilisk-common.workspace = true
 basilisk-profiler-protocol.workspace = true
 # Shipwright `--version` / `--version --json` contract emitter.
-shipwright          = "0.9.0"
-shipwright-manifest = "0.9.0"
+shipwright          = "0.10.0"
+shipwright-manifest = "0.10.0"
 py-spy = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Consolidation PR from the `dependabot-upgrades` staging branch → `main` (the SharpLsp flow set up in #154).

Dependabot's cargo bump (#155, 3 updates) auto-merged into the staging branch with **no CI** (staging PRs don't trigger `ci.yml`). This single PR runs the **full** Rust/extension/mutation matrix once to validate them before they reach `main`.

Net change is the cargo bumps only:
- two workspace crates `0.9.0 → 0.10.0`
- a serde-family crate `2.0.117 → 2.0.118`

(`vscode-extension` files shown in the branch are just `main` merged in to keep the PR up to date; they're already on `main` via #156 and aren't part of the net diff.)