### PR TITLE
ci/release: sweep all Dependabot bumps to staging, CI cache speedups, no-stored-artifacts policy + VSIX packaging parity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,23 +2,24 @@
 # Dependabot — supply-chain defense without PR spam, and without burning CI on
 # `main` for routine bumps ([GITHUB-DEPENDABOT]).
 #
-# How this kills the spam:
+# How this kills the spam — EVERY bump ends up on the `dependabot-upgrades`
+# STAGING branch, swept there automatically by
+# .github/workflows/dependabot-automerge.yml (latest bump clobbers previous):
 #   * VERSION updates -> `target-branch: dependabot-upgrades`. Every routine bump
-#     PR is opened against the long-lived `dependabot-upgrades` STAGING branch,
-#     never against main. ci.yml / codeql.yml only trigger on
-#     `pull_request: [main]` (the filter matches the PR *base*), so these staging
-#     PRs run NO build/test/CodeQL. They are auto-merged into the staging branch
-#     by .github/workflows/dependabot-automerge.yml. When you want the batch in
-#     main you open ONE `dependabot-upgrades -> main` PR and CI runs exactly once.
-#   * SECURITY updates -> still raised automatically against `main`, untouched by
-#     this file. Per GitHub docs, `target-branch` only redirects *version*
-#     updates; security updates always use the repo's default branch. So a real
-#     CVE still opens a PR against main where you see it and CI runs. That channel
-#     is governed by the repo's "Dependabot security updates" setting, NOT here.
-#   * groups with no `update-types` filter -> each ecosystem collapses ALL bumps
-#     (patch, minor AND major) into ONE grouped PR per run. Majors no longer need
-#     their own review PR because nothing reaches main unattended — review happens
-#     once, at the consolidation PR.
+#     PR is opened against the staging branch, never against main. ci.yml /
+#     codeql.yml only trigger on `pull_request: [main]` (the filter matches the
+#     PR *base*), so these staging PRs run NO build/test/CodeQL.
+#   * SECURITY updates -> GitHub IGNORES `target-branch` for these and always
+#     opens them against the repo's default branch (`main`). The auto-merge
+#     workflow therefore also fires on `main` and folds the security bump into
+#     the SAME staging branch, then retires the PR — so a CVE bump never sits on
+#     main waiting for a human either. (ci.yml/codeql.yml skip Dependabot PRs, so
+#     the matrix never burns on a bump we immediately sweep away.)
+#   * groups -> each ecosystem collapses ALL version bumps (patch, minor AND
+#     major) into ONE PR, and a parallel `*-security` group (`applies-to:
+#     security-updates`) collapses CVE bumps the same way. Majors no longer need
+#     their own review PR because nothing reaches main unattended — review
+#     happens once, at the `dependabot-upgrades -> main` consolidation PR.
 #   * interval: weekly -> one grouped PR per ecosystem each week, not fifty.
 #
 # SHA-pinned actions are a prime supply-chain target ([SWR-SEC-ACTION-PINNING]),
@@ -50,6 +51,10 @@ updates:
     labels: ["dependencies"]
     groups:
       cargo:
+        applies-to: version-updates
+        patterns: ["*"]
+      cargo-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # npm — VS Code extension.
@@ -62,6 +67,10 @@ updates:
     labels: ["dependencies"]
     groups:
       npm-vscode-extension:
+        applies-to: version-updates
+        patterns: ["*"]
+      npm-vscode-extension-security:
+        applies-to: security-updates
         patterns: ["*"]
 
   # npm — documentation website (Eleventy).
@@ -74,4 +83,8 @@ updates:
     labels: ["dependencies"]
     groups:
       npm-website:
+        applies-to: version-updates
+        patterns: ["*"]
+      npm-website-security:
+        applies-to: security-updates
         patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,21 @@ jobs:
       - name: Classify changed paths
         id: classify
         env:
+          ACTOR: ${{ github.actor }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          # Dependabot PRs are swept into `dependabot-upgrades` by
+          # dependabot-automerge.yml and never merge into main directly, so the
+          # heavy matrix would only burn minutes on a bump we discard. CI runs
+          # once, on the consolidation PR. ([GITHUB-DEPENDABOT])
+          if [ "$ACTOR" = "dependabot[bot]" ]; then
+            echo "code=false"    >> "$GITHUB_OUTPUT"
+            echo "website=false" >> "$GITHUB_OUTPUT"
+            echo "Dependabot PR — skipping Rust/extension matrix and website build."
+            exit 0
+          fi
           base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
           changed="$(git diff --name-only "$base" "$HEAD_SHA")"
           echo "Changed files:"; printf '%s\n' "$changed"
@@ -231,14 +242,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/test-rust.sh
 
-      - name: Upload coverage report artifact
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-report
-          path: target/llvm-cov/html/
-          retention-days: 14
-
+      # No artifact upload of the HTML coverage report ([GITHUB-NO-ARTIFACTS]).
+      # Coverage is enforced in-job (test-rust.sh fails below threshold) and
+      # published to Codecov below; the HTML is reproducible locally via
+      # `make test`, so storing it would just bill GB-days for nothing.
       - name: Upload to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -493,13 +500,18 @@ jobs:
         if: env.RUN == 'true'
         run: make mutation-test SHARD="${{ matrix.shard }}" MUTATION_CHECK=0
 
+      # The ONLY artifact CI is allowed to create ([GITHUB-NO-ARTIFACTS]): a
+      # transient in-run hand-off so the `mutation-test` job below can merge the
+      # four shards' outcomes and enforce the score gate. retention-days: 1 is
+      # the floor — it is consumed and auto-deleted within the same run, so it
+      # never accrues stored GB-days. It is NOT a retained build output.
       - name: Upload mutation shard output
         if: always() && env.RUN == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-output-${{ matrix.label }}
           path: mutation_testing/mutants.out.working-shard-${{ matrix.output }}/mutants.out/
-          retention-days: 14
+          retention-days: 1
 
   mutation-test:
     name: Mutation Testing
@@ -530,16 +542,10 @@ jobs:
             mutation_testing/mutants_report.html \
             --scores mutation_testing/mutation_scores.json \
             --scope working
-
-      - name: Upload mutation report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: mutation-report
-          path: |
-            mutation_testing/mutants_report.html
-            mutation_testing/mutants.out.working/mutants.out/
-          retention-days: 14
+          # The merge step ABOVE is the gate: it fails the job if the mutation
+          # score regresses against the committed baseline. The HTML report is
+          # not uploaded as an artifact ([GITHUB-NO-ARTIFACTS]) — it is
+          # reproducible locally via `make mutation-test`.
 
   # ── Build gate (standard job name per repo standards) ──────────────────────
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,18 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@81ee9698f20724138a785d788c7567d40f14cd2d # cargo-llvm-cov
 
+      # The PEP conformance suite is fetched fresh from the upstream typing repo
+      # on every run (network-bound, one HTTP request per test file). Cache it
+      # keyed on conformance.sh, which holds the pinned TYPING_REF — bumping the
+      # ref edits that file and busts the cache; conformance.sh itself re-fetches
+      # whenever the stamped ref differs, so a stale restore self-heals.
+      - name: Cache conformance suite
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: crates/basilisk-cli/tests/conformance
+          key: conformance-suite-${{ hashFiles('scripts/conformance.sh') }}
+          restore-keys: conformance-suite-
+
       - name: Run Rust tests with coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -284,6 +296,17 @@ jobs:
           # libasound2 was renamed to libasound2t64 on Ubuntu 24.04+
           sudo apt-get install -y libasound2 2>/dev/null || sudo apt-get install -y libasound2t64
 
+      # @vscode/test-electron downloads a full VS Code build (~150 MB) into
+      # .vscode-test on every run. Cache it keyed on the test config + manifest
+      # so the pinned editor version is reused instead of re-downloaded; a
+      # version bump (config/manifest change) busts the key and re-fetches.
+      - name: Cache VS Code test build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: vscode-extension/.vscode-test
+          key: vscode-test-${{ runner.os }}-${{ hashFiles('vscode-extension/.vscode-test.mjs', 'vscode-extension/.vscode-test.js', 'vscode-extension/package.json') }}
+          restore-keys: vscode-test-${{ runner.os }}-
+
       - name: Run VS Code extension tests
         run: make _test_vsix
 
@@ -298,9 +321,16 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      # Share one release-profile cache scope with the `build` gate below: both
+      # jobs run `cargo build --release`, so they compile the identical external
+      # dependency graph. A single shared scope (instead of two per-job scopes)
+      # halves this pair's cache footprint — relieving the 10 GB repo-cache limit
+      # that was evicting warm caches — and lets `build` (which runs later, after
+      # the test jobs) restore the dependencies this job already compiled.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          shared-key: release
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -360,6 +390,18 @@ jobs:
         with:
           neovim: true
           version: v0.11.6
+
+      # The nvim e2e harness git-clones plenary/dap/mini into /tmp on every run.
+      # Cache them so the clones become no-ops — test-nvim.sh skips any dir that
+      # already exists. Bump the key suffix to force a refresh of the pins.
+      - name: Cache Neovim test plugins
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            /tmp/plenary.nvim
+            /tmp/nvim-dap
+            /tmp/mini.nvim
+          key: nvim-test-plugins-${{ runner.os }}-v1
 
       - name: Run Neovim extension tests
         run: |
@@ -427,6 +469,10 @@ jobs:
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          # All four shards share one cache scope (identical job name + flags),
+          # so only the first needs to upload the ~290 MB cache. The other three
+          # restore it but skip the redundant save race (last-writer churn).
+          save-if: ${{ env.RUN == 'true' && matrix.shard == '0/4' }}
 
       - if: env.RUN == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -507,9 +553,15 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      # Reuse the release-profile dependency cache that `verify-binaries`
+      # populated earlier in this run (shared scope, same Cargo build). save-if
+      # is false because that job already owns the save — this gate only needs to
+      # restore so its `cargo build --release` is a warm, near-no-op compile.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           cache-on-failure: true
+          shared-key: release
+          save-if: false
 
       - name: Install lld
         run: sudo apt-get update && sudo apt-get install -y lld

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,11 @@ jobs:
     # Code scanning (SARIF upload) requires GitHub Advanced Security on PRIVATE
     # repos. Gating on public visibility lets a private repo skip cleanly (no red
     # X) and self-enable the moment it is made public — no follow-up edit needed.
-    if: github.event.repository.visibility == 'public'
+    # Dependabot PRs are excluded: they are swept into `dependabot-upgrades` by
+    # dependabot-automerge.yml and never merge to main directly, so scanning them
+    # only burns the matrix on a bump we discard — CodeQL runs on the
+    # consolidation PR instead. ([GITHUB-DEPENDABOT])
+    if: github.event.repository.visibility == 'public' && github.actor != 'dependabot[bot]'
     permissions:
       security-events: write
       actions: read

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,42 +1,83 @@
+# agent-pmo:0b21609
 name: Dependabot auto-merge
 
-# Auto-merges Dependabot version-bump PRs INTO the `dependabot-upgrades` staging
-# branch so they never pile up for a human to clear ([GITHUB-DEPENDABOT]).
+# Sweeps EVERY Dependabot PR into the long-lived `dependabot-upgrades` staging
+# branch, no questions asked ([GITHUB-DEPENDABOT]). Two kinds of PR land here:
 #
-# Safe to merge unattended here: nothing reaches `main` this way. The full
-# build/test (ci.yml) + CodeQL (codeql.yml) gate the single
+#   * VERSION updates  -> Dependabot opens them against `dependabot-upgrades`
+#     directly (.github/dependabot.yml `target-branch`).
+#   * SECURITY updates -> GitHub IGNORES `target-branch` for these and ALWAYS
+#     opens them against the default branch (`main`). So this workflow also
+#     triggers on `main` and folds the security bump into the SAME staging
+#     branch — nothing is ever left sitting on `main` waiting for a human.
+#
+# Merge strategy: the incoming branch ALWAYS clobbers what is already staged
+# (`git merge -X theirs`). Successive bumps of the same lock-file never conflict-
+# stall: the latest bump wins, every time. Nothing reaches `main` this way — the
+# full build/test (ci.yml) + CodeQL (codeql.yml) gate the single
 # `dependabot-upgrades -> main` consolidation PR, which is where review and the
-# expensive matrix actually run. This job is a ~10-second merge bot, NOT the CI
-# pipeline.
+# expensive matrix actually run. ci.yml/codeql.yml deliberately SKIP Dependabot
+# PRs (they would only burn the matrix on a bump we immediately sweep away).
 #
-# Lives at the repo root so it is present on `dependabot-upgrades` (which is cut
-# from main): `pull_request` runs the workflow from the PR merge ref, so the
-# staging branch must carry this file for auto-merge to fire.
+# Lives at the repo root so it is present on `dependabot-upgrades` (cut from
+# main): for `pull_request` the workflow is read from the PR's base branch, so
+# BOTH `main` and the staging branch must carry this file.
 on:
   pull_request:
     branches:
       - dependabot-upgrades
+      - main
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  auto-merge:
-    name: Auto-merge into dependabot-upgrades
+  sweep:
+    name: Clobber-merge into dependabot-upgrades
     if: github.actor == 'dependabot[bot]'
-    # Deliberately the standard runner, NOT a larger/paid runner: a trivial merge
-    # bot should not consume CI minutes meant for the real build matrix.
+    # Deliberately the standard runner, NOT a larger/paid one: a trivial merge
+    # bot must not consume CI minutes meant for the real build matrix.
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Squash-merge the bump into the staging branch
+      - name: Check out the staging branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: dependabot-upgrades
+          fetch-depth: 0
+
+      - name: Clobber-merge the bump and retire the PR
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Prefer auto-merge (queues until mergeable); fall back to an immediate
-        # squash merge when the PR is already mergeable (no required checks on the
-        # staging branch, so GitHub may refuse to "enable" auto-merge).
         run: |
-          gh pr merge --auto --squash --delete-branch "$PR_URL" \
-            || gh pr merge --squash --delete-branch "$PR_URL"
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Pull the bump branch into a stable local ref we can re-merge.
+          git fetch origin "+refs/heads/${PR_HEAD}:refs/remotes/origin/${PR_HEAD}"
+          # Re-merge onto the LIVE staging tip and retry: concurrent Dependabot
+          # PRs race to push here, so each run rebases on whatever already landed
+          # and the incoming branch always wins conflicts (-X theirs).
+          for attempt in 1 2 3 4 5; do
+            git fetch origin "+refs/heads/dependabot-upgrades:refs/remotes/origin/dependabot-upgrades"
+            git reset --hard "origin/dependabot-upgrades"
+            git merge -X theirs --no-edit "origin/${PR_HEAD}" \
+              -m "build(deps): clobber-merge ${PR_HEAD} into dependabot-upgrades"
+            if git push origin "HEAD:dependabot-upgrades"; then
+              break
+            fi
+            if [ "$attempt" = "5" ]; then
+              echo "::error::could not push to dependabot-upgrades after 5 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
+          # Retire the PR + its branch: the bump is already staged, so the PR
+          # (whether it targeted main or the staging branch) has served its
+          # purpose. `|| true` — GitHub may have auto-closed it on the push.
+          gh pr close "$PR_URL" --delete-branch \
+            --comment "Swept into \`dependabot-upgrades\` (latest bump clobbers previous)." \
+            || git push origin --delete "$PR_HEAD" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,16 @@ jobs:
         run: |
           Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.binary }}" -DestinationPath "${{ matrix.archive }}"
 
+      # Transient in-run hand-off to the `release` job, which attaches these to
+      # the GitHub Release (the only permanent, free, unlimited store). Pinned to
+      # retention-days: 1 — the floor — instead of the 90-day default so build
+      # outputs never accrue billed storage ([GITHUB-NO-ARTIFACTS]).
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.archive }}
           path: ${{ matrix.archive }}
+          retention-days: 1
 
   release:
     name: Publish binaries to release
@@ -272,23 +277,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          exe=""
-          if [ "${{ matrix.platform }}" = "win32" ]; then exe=".exe"; fi
-          rm -rf vscode-extension/bin
-          mkdir -p "vscode-extension/bin/${{ env.target }}"
-          cp "runtime-bin/basilisk${exe}" "vscode-extension/bin/${{ env.target }}/"
-          if [ "${{ matrix.platform }}" = "darwin" ]; then
-            cp "runtime-bin/basilisk-profiler-helper" "vscode-extension/bin/${{ env.target }}/"
-          fi
-          # Belt-and-suspenders: the release archives already carry the exec bit,
-          # but re-assert it for POSIX targets so a staged binary is always
-          # runnable regardless of the extractor (Windows .exe needs no bit).
-          if [ "${{ matrix.platform }}" != "win32" ]; then
-            chmod +x "vscode-extension/bin/${{ env.target }}/basilisk"
-          fi
-          if [ "${{ matrix.platform }}" = "darwin" ]; then
-            chmod +x "vscode-extension/bin/${{ env.target }}/basilisk-profiler-helper"
-          fi
+          # Stage exactly the manifest-declared bundled binaries for this target
+          # via the shared stage-runtime helper — the SAME single-source staging
+          # the Makefile (_release_vsix / _test_vsix) uses, so the published VSIX
+          # and the e2e-tested bundle can never diverge. stage-runtime clears
+          # bin/, copies each bundled binary from the extracted release archive,
+          # and re-asserts the exec bit on POSIX targets (the archives already
+          # carry it; Windows .exe needs no bit). Implements
+          # [VSIX-PACKAGING-PARITY].
+          node vscode-extension/scripts/stage-runtime.mjs runtime-bin "${{ env.target }}"
           cp shipwright.json vscode-extension/shipwright.json
           cp NOTICES vscode-extension/NOTICES
 
@@ -342,10 +339,14 @@ jobs:
           fi
           node scripts/verify-shipwright.mjs vsix "basilisk-${{ env.target }}.vsix" "${{ env.target }}"
 
+      # Transient in-run hand-off to `release-assets`, which uploads the VSIX to
+      # the GitHub Release (permanent, free). retention-days: 1 (the floor) keeps
+      # build output out of billed storage ([GITHUB-NO-ARTIFACTS]).
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.target }}
           path: vscode-extension/*.vsix
+          retention-days: 1
 
   release-assets:
     name: Attach VSIX + checksums to release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ This codebase is held to a high standard: code here should comfortably pass revi
 
 ⚠️ DO NOT KILL A VS Code PROCESS (including in the browser) — it disrupts active debugging and test sessions. ⚠️
 
+⚠️ NEVER STORE CI ARTIFACTS — they cost money even on this PUBLIC repo (compute on standard runners is free; **storage is billed**). The ONLY artifacts we keep are the **GitHub Releases** (Release assets are free + unlimited). NO `actions/upload-artifact` for coverage HTML, mutation reports, logs, screenshots, or any diagnostic. The sole permitted upload is a transient in-run cross-job hand-off, and it MUST set `retention-days: 1` (the floor) so it is consumed and deleted within the same run. Default retention is 90 days — never rely on it. See [GITHUB-NO-ARTIFACTS]. ⚠️
+
 Key design principles:
 
 - We are building a better Python dev experience

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Exactly 7 standard targets: build, test, lint, fmt, clean, ci, setup
 # =============================================================================
 
-.PHONY: build test lint fmt clean ci setup mutation-test conformance bench reinstall-vsix reinstall-vsix-prerelease
+.PHONY: build test lint fmt clean ci setup mutation-test conformance bench reinstall-vsix reinstall-vsix-macos reinstall-vsix-prerelease
 
 # ---------------------------------------------------------------------------
 # OS Detection
@@ -176,10 +176,21 @@ bench:
 	@cargo build --release --bin basilisk
 	@bash benchmarks/run.sh
 
-## reinstall-vsix: Clean rebuild + reinstall a host-targeted VSIX.
-## Mirrors .github/workflows/release.yml `vsix` job for the host platform.
+## reinstall-vsix: Clean rebuild + reinstall a host-targeted VSIX. Builds the
+## EXACT package the release.yml `vsix` job ships (via the shared _release_vsix
+## recipe) and rebuilds every binary from a clean tree.
+## Implements [VSIX-PACKAGING-PARITY].
 reinstall-vsix: _clean_rust _clean_vsix _release_vsix _uninstall_vsix _install_vsix
 	@echo -e '\033[0;32m✓ reinstall-vsix complete\033[0m'
+
+## reinstall-vsix-macos: Clean rebuild + reinstall the macOS VSIX (darwin-arm64)
+## — byte-for-byte the artifact the release.yml `vsix` darwin job publishes. Pins
+## the target so it matches the shipped macOS package regardless of host, and
+## rebuilds every binary from a clean tree.
+## Implements [VSIX-PACKAGING-PARITY].
+reinstall-vsix-macos: export BSK_VSIX_TARGET := darwin-arm64
+reinstall-vsix-macos: _clean_rust _clean_vsix _release_vsix _uninstall_vsix _install_vsix
+	@echo -e '\033[0;32m✓ reinstall-vsix-macos complete (darwin-arm64)\033[0m'
 
 ## reinstall-vsix-prerelease: Same as reinstall-vsix but packages with
 ## --pre-release so the VSIX matches what the release pipeline builds for
@@ -225,28 +236,43 @@ _build_vsix:
 	cd $(_EXTENSION_DIR) && npm ci && npm run compile && \
 	echo -e '\033[0;32m✓ VS Code extension compiled\033[0m'
 
-# _release_vsix: build a host-targeted VSIX. Mirrors the per-platform steps
-# of the `vsix` job in .github/workflows/release.yml. Single recipe so host
-# detection vars are consistent throughout.
+# _release_vsix: build a host-targeted VSIX — the EXACT artifact the release.yml
+# `vsix` job ships for that platform. Single recipe shared by reinstall-vsix,
+# reinstall-vsix-macos, and the e2e gate (_test_vsix), so tests, local installs,
+# and the published package can never diverge. Set BSK_VSIX_TARGET (e.g.
+# darwin-arm64) to pin the platform regardless of host; unset auto-detects from
+# uname. Implements [VSIX-PACKAGING-PARITY].
 _release_vsix:
 	@set -e; \
-	case "$$(uname -s)" in \
-		Darwin) plat=darwin; exe="" ;; \
-		Linux)  plat=linux;  exe="" ;; \
-		MINGW*|MSYS*|CYGWIN*) plat=win32; exe=".exe" ;; \
-		*) echo "Unsupported OS: $$(uname -s)" >&2; exit 1 ;; \
+	if [ -n "$${BSK_VSIX_TARGET:-}" ]; then \
+		target="$$BSK_VSIX_TARGET"; \
+		plat="$${target%-*}"; arch="$${target##*-}"; \
+	else \
+		case "$$(uname -s)" in \
+			Darwin) plat=darwin ;; \
+			Linux)  plat=linux ;; \
+			MINGW*|MSYS*|CYGWIN*) plat=win32 ;; \
+			*) echo "Unsupported OS: $$(uname -s)" >&2; exit 1 ;; \
+		esac; \
+		case "$$(uname -m)" in \
+			arm64|aarch64) arch=arm64 ;; \
+			x86_64|amd64)  arch=x64 ;; \
+			*) echo "Unsupported arch: $$(uname -m)" >&2; exit 1 ;; \
+		esac; \
+		target="$$plat-$$arch"; \
+	fi; \
+	case "$$arch" in \
+		arm64) rust_arch=aarch64 ;; \
+		x64)   rust_arch=x86_64 ;; \
+		*) echo "Unsupported arch: $$arch" >&2; exit 1 ;; \
 	esac; \
-	case "$$(uname -m)" in \
-		arm64|aarch64) arch=arm64; rust_arch=aarch64 ;; \
-		x86_64|amd64)  arch=x64;   rust_arch=x86_64 ;; \
-		*) echo "Unsupported arch: $$(uname -m)" >&2; exit 1 ;; \
-	esac; \
+	exe=""; \
 	case "$$plat" in \
 		darwin) rust_target="$$rust_arch-apple-darwin" ;; \
 		linux)  rust_target="$$rust_arch-unknown-linux-gnu" ;; \
-		win32)  rust_target="$$rust_arch-pc-windows-msvc" ;; \
+		win32)  rust_target="$$rust_arch-pc-windows-msvc"; exe=".exe" ;; \
+		*) echo "Unsupported platform: $$plat" >&2; exit 1 ;; \
 	esac; \
-	target="$$plat-$$arch"; \
 	echo -e "\033[1m\033[0;36m▶ Building VSIX for $$target ($$rust_target)\033[0m"; \
 	cargo build --release --target "$$rust_target" --bin basilisk; \
 	if [ "$$plat" = "darwin" ]; then \
@@ -257,6 +283,8 @@ _release_vsix:
 	cp NOTICES $(_EXTENSION_DIR)/NOTICES; \
 	repo_root="$$(pwd)"; \
 	cd $(_EXTENSION_DIR) && npm ci && npm run compile && npm run sync:shipwright; \
+	echo -e "\033[1m\033[0;36m▶ Validating Shipwright manifest\033[0m"; \
+	node scripts/verify-shipwright.mjs manifest; \
 	echo -e "\033[1m\033[0;36m▶ Vendoring debugpy into the VSIX bundle\033[0m"; \
 	node scripts/vendor-debugpy.mjs; \
 	prerelease_flag=""; \
@@ -317,29 +345,25 @@ _audit:
 _test_rust:
 	@OPEN=$(OPEN) bash scripts/test-rust.sh
 
+# _test_vsix: run the VS Code E2E suite against the EXACT release bundle. Builds
+# the real per-platform VSIX through the shared _release_vsix recipe — same
+# release binaries, manifest-driven staging, debugpy vendoring, and vsce
+# packaging the release ships — then runs the e2e tests against that staged
+# bundle, so the suite can never validate a different package than what users
+# install. Implements [VSIX-PACKAGING-PARITY].
 _test_vsix:
 	@set -e; \
 	REPO_ROOT="$$(pwd)"; \
-	echo -e '\033[1m\033[0;36m▶ Building bundled runtime binaries (basilisk + profiler-helper)\033[0m'; \
-	cargo build --profile ci --bin basilisk --bin basilisk-profiler-helper; \
-	BASILISK_BIN="$$REPO_ROOT/target/ci/basilisk"; \
-	[ -x "$$BASILISK_BIN" ] || { echo -e '\033[0;31m✗ basilisk binary not found\033[0m'; exit 1; }; \
-	echo -e "\033[0;32m✓ basilisk binary: $$BASILISK_BIN\033[0m"; \
-	echo -e '\033[1m\033[0;36m▶ VS Code extension — compile\033[0m'; \
-	cd $(_EXTENSION_DIR) && npm ci && npm run compile; \
-	echo -e '\033[1m\033[0;36m▶ VS Code extension — stage the REAL release bundle\033[0m'; \
-	node scripts/sync-shipwright-manifest.mjs; \
-	node scripts/stage-runtime.mjs "$$REPO_ROOT/target/ci"; \
-	node scripts/vendor-debugpy.mjs; \
-	node scripts/verify-shipwright.mjs manifest; \
+	echo -e '\033[1m\033[0;36m▶ Building the EXACT release VSIX bundle (shared _release_vsix recipe)\033[0m'; \
+	$(MAKE) --no-print-directory _release_vsix; \
 	echo -e '\033[1m\033[0;36m▶ VS Code extension — ESLint\033[0m'; \
-	npm run lint; \
-	echo -e '\033[1m\033[0;36m▶ VS Code E2E tests\033[0m'; \
+	( cd $(_EXTENSION_DIR) && npm run lint ); \
+	echo -e '\033[1m\033[0;36m▶ VS Code E2E tests (against the staged release bundle)\033[0m'; \
 	VSCODE_TEST_CMD="npm test -- --coverage"; \
 	if [ -z "$${DISPLAY:-}" ] && command -v xvfb-run >/dev/null 2>&1; then \
 	    VSCODE_TEST_CMD="xvfb-run -a $$VSCODE_TEST_CMD"; \
 	fi; \
-	$$VSCODE_TEST_CMD; \
+	( cd $(_EXTENSION_DIR) && $$VSCODE_TEST_CMD ); \
 	echo -e '\033[1m\033[0;36m▶ VS Code extension — coverage threshold\033[0m'; \
 	VSIX_LCOV="$$REPO_ROOT/$(_EXTENSION_DIR)/coverage/lcov.info"; \
 	VSIX_THRESHOLD=$$(python3 -c 'import json; print(json.load(open("'"$$REPO_ROOT"'/$(_COVERAGE_THRESHOLDS_FILE)"))["projects"]["vsix"]["threshold"])'); \

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,8 @@ mutation-test:
 		if [ -n "$$shard" ]; then \
 			echo -e "\033[0;36m  [diag] Shard: $$shard\033[0m"; \
 		fi; \
+		mutation_jobs="$${MUTATION_JOBS:-$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)}"; \
+		echo -e "\033[0;36m  [diag] Parallel jobs: $$mutation_jobs\033[0m"; \
 		out_dir="$(_MUTATION_DIR)/mutants.out.$$mode"; \
 		rm -rf "$$out_dir"; \
 		mutants_count="$$(RUSTFLAGS="$$mutation_rustflags" cargo mutants --list --package "$$package" --re "$$examine_re" $$shard_arg | wc -l | tr -d " ")"; \
@@ -118,14 +120,14 @@ mutation-test:
 		echo -e "\033[0;36m  [diag] Total mutants: $$mutants_count\033[0m"; \
 		if [ -n "$$test_filter" ]; then \
 			RUSTFLAGS="$$mutation_rustflags" cargo mutants \
-				--jobs 4 --timeout 60 --baseline skip --copy-target true \
+				--jobs "$$mutation_jobs" --timeout 60 --baseline skip --copy-target true \
 				--package "$$package" --re "$$examine_re" \
 				$$shard_arg \
 				--output "$$out_dir" \
 				-- --test coverage_boost_33_tests --test mutation_kill_tests "$$test_filter" || true; \
 		else \
 			RUSTFLAGS="$$mutation_rustflags" cargo mutants \
-				--jobs 4 --timeout 60 --baseline skip --copy-target true \
+				--jobs "$$mutation_jobs" --timeout 60 --baseline skip --copy-target true \
 				--package "$$package" --re "$$examine_re" \
 				$$shard_arg \
 				--output "$$out_dir" || true; \

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -1398,6 +1398,35 @@ the other:
 - `BENCH_NO_GATE=1` (baseline reset) is reserved for fixture-set changes and
   must be justified in the PR description.
 
+### CI Artifact Storage Policy {#GITHUB-NO-ARTIFACTS}
+
+Basilisk is a **public** repository. Compute on standard GitHub-hosted runners
+(every CI job — all `ubuntu-24.04`) is **free and unlimited**; what GitHub bills
+for is **stored Actions artifacts** (GB-days). Therefore:
+
+- **CI stores no artifacts.** No `actions/upload-artifact` for coverage HTML,
+  mutation reports, logs, screenshots, or any diagnostic. Gates enforce in-job
+  (coverage threshold, mutation-score merge, benchmarks) and reports are
+  reproducible locally (`make test`, `make mutation-test`). External free
+  services (Codecov) consume `lcov.info` directly without GitHub storage.
+- **The only permanent store is the GitHub Release.** Release *assets* attached
+  to a tag are free and unlimited — release binaries and per-platform VSIX live
+  there, never as retained Actions artifacts.
+- **Transient cross-job hand-offs are the sole exception**, and only because
+  matrix jobs run on separate runners that cannot share a filesystem (the four
+  mutation shards → the merge/score job; the release build matrix → the publish
+  job). Each such upload **must** set `retention-days: 1` — the floor — so it is
+  consumed and auto-deleted within the same run and never accrues stored
+  GB-days. The 90-day default is never acceptable.
+- **Existing artifacts are purged, not left to expire.** When this policy is
+  tightened, delete the back-catalogue
+  (`gh api repos/<owner>/<repo>/actions/artifacts` → `DELETE …/artifacts/{id}`).
+
+Implemented by `.github/workflows/ci.yml` and `.github/workflows/release.yml`
+(every `upload-artifact` carries `retention-days: 1` and a `[GITHUB-NO-ARTIFACTS]`
+reference). The Actions **cache** (`Swatinem/rust-cache`, `actions/cache`) is
+separate and free — it does not count toward billed storage and is unaffected.
+
 ---
 
 ## Migration and Adoption {#CHKARCH-MIGRATION}

--- a/docs/specs/VSIX-SPEC.md
+++ b/docs/specs/VSIX-SPEC.md
@@ -362,3 +362,42 @@ The VSIX bundles pre-compiled `basilisk` binaries per platform:
 - `basilisk-x86_64-unknown-linux-gnu`
 - `basilisk-aarch64-unknown-linux-gnu`
 - `basilisk-x86_64-pc-windows-msvc`
+
+## Build & Packaging Parity {#VSIX-PACKAGING-PARITY}
+
+The VSIX that ships and the VSIX the tests exercise **must be the same artifact**.
+A green test run against a different bundle than users install is worthless, so a
+single recipe owns packaging and every other path routes through it:
+
+| Path | Entry point | Purpose |
+|---|---|---|
+| Release | `.github/workflows/release.yml` `vsix` job | builds & publishes the per-platform VSIX |
+| Local install | `make reinstall-vsix` / `make reinstall-vsix-macos` | clean rebuild + install the exact release VSIX |
+| E2E gate | `make _test_vsix` (→ `_release_vsix`) | runs the e2e suite against the staged release bundle |
+
+Invariants:
+
+- **One packaging recipe.** `_release_vsix` (Makefile) mirrors the release `vsix`
+  job step for step: `cargo build --release --target <triple>` for every bundled
+  binary, `stage-runtime.mjs` to stage exactly the manifest-declared binaries into
+  `bin/<platform>/`, `vendor-debugpy.mjs`, then
+  `vsce package --target <platform> --ignore-other-target-folders`.
+- **One staging helper.** `stage-runtime.mjs` is the only code that decides which
+  binaries enter the bundle — used by the release workflow, `_release_vsix`, and
+  `_test_vsix` alike — so bundle contents are manifest-driven everywhere and cannot
+  drift between the tested and shipped packages.
+- **Tests run the shipped bytes.** `_test_vsix` builds the bundle via `_release_vsix`
+  and then runs the e2e suite against that staged extension directory — the exact
+  tree `vsce package` zips — so the suite validates the release artifact, not a
+  bespoke debug build.
+- **`reinstall-vsix-macos`** pins `darwin-arm64` (the only macOS target the release
+  ships) and rebuilds every binary from a clean tree (`cargo clean`), so a local
+  install is byte-for-byte the published macOS VSIX.
+- **Intentional difference:** local builds keep the `0.0.0-PLACEHOLDER` version (no
+  release tag), whereas `release.yml` runs `stamp-version.sh` first. Package
+  *structure* and *binaries* are identical; only the embedded version string
+  differs, and it stays internally consistent (manifest and binary agree).
+
+`verify-shipwright.mjs vsix` enforces the bundle matches the manifest on every path
+(rejecting missing, unmanifested, or wrong-platform binaries), so drift fails the
+build rather than shipping.

--- a/vscode-extension/scripts/stage-runtime.mjs
+++ b/vscode-extension/scripts/stage-runtime.mjs
@@ -2,10 +2,11 @@
 // extension's `bin/<platform>/`, copying from a build directory.
 //
 // This is the SINGLE source of truth for which binaries the VSIX bundles — used
-// by BOTH the e2e test harness (`_test_vsix`) and the release packager
-// (`_release_vsix`). Keeping one path is what stops the tests from validating a
-// different bundle than what ships (issue #71). Asset components (e.g. debugpy)
-// are vendored separately by `vendor-debugpy.mjs`.
+// by the e2e test harness (`_test_vsix`), the release packager (`_release_vsix`),
+// AND the release.yml `vsix` job. Keeping one path is what stops the tests from
+// validating a different bundle than what ships (issue #71). Asset components
+// (e.g. debugpy) are vendored separately by `vendor-debugpy.mjs`.
+// Implements [VSIX-PACKAGING-PARITY].
 //
 // Usage: node scripts/stage-runtime.mjs <build-dir> [platform]
 import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";


### PR DESCRIPTION
## TLDR
CI/release-infrastructure hardening: sweep **every** Dependabot bump into the `dependabot-upgrades` staging branch (latest clobbers previous), speed up CI with targeted caches and a shared release build scope, and codify a no-stored-artifacts policy alongside single-recipe VSIX packaging parity.

## What Was Added?
- **Dependabot security grouping** (`.github/dependabot.yml`): a parallel `*-security` group (`applies-to: security-updates`) per ecosystem so CVE bumps collapse into one PR each, mirroring the existing version-update groups.
- **CI caches** (`.github/workflows/ci.yml`): the PEP conformance suite (keyed on `conformance.sh`'s pinned ref, self-healing on drift), the `@vscode/test-electron` editor download, and the Neovim e2e plugin clones — each restored instead of re-fetched on every run.
- **`make reinstall-vsix-macos`** (`Makefile`): pins `darwin-arm64` and rebuilds from a clean tree so a local install is byte-for-byte the published macOS VSIX.
- **Two spec sections**: `[GITHUB-NO-ARTIFACTS]` (CI artifact-storage policy) in `CHECKER-ARCHITECTURE-SPEC.md` and `[VSIX-PACKAGING-PARITY]` in `VSIX-SPEC.md`.

## What Was Changed or Deleted?
- **Dependabot sweep automation** (`dependabot-automerge.yml`): now also triggers on `main` (GitHub forces security PRs there regardless of `target-branch`) and folds each bump into `dependabot-upgrades` with `git merge -X theirs` — the newest branch always clobbers the previous one, so a shared lock-file never conflict-stalls — then retires the PR + branch. The push is retried so concurrent bumps serialise.
- **Dependabot PRs skip the heavy gates**: `ci.yml`'s change-scope classifier early-exits (`code=false`/`website=false`), and `codeql.yml` adds `&& github.actor != 'dependabot[bot]'`. The bump never merges to `main` directly, so the matrix/CodeQL would only burn minutes on a discarded PR; CI runs once, on the `dependabot-upgrades → main` consolidation PR. (The `Clobber-merge` job is correctly SKIPPED on this human PR — the actor guard works.)
- **Shared release build cache**: `verify-binaries` and `build` now share the `release` rust-cache scope (both run `cargo build --release` over the same dep graph), halving that pair's footprint and relieving the 10 GB repo-cache eviction; `build` restores with `save-if: false`. Mutation shards share one scope with `save-if` limited to shard `0/4` to kill the last-writer save race.
- **No stored artifacts**: removed the coverage-HTML and mutation-report `upload-artifact` steps; coverage is enforced in-job and pushed to Codecov, mutation score is gated by the merge step. The only remaining uploads — the per-shard mutation hand-off and the release build→publish hand-offs — are pinned to `retention-days: 1` (the floor), so they're consumed and deleted within the run.
- **VSIX packaging parity**: `release.yml`'s `vsix` job now stages binaries through the same `stage-runtime.mjs` helper the Makefile uses, replacing the hand-rolled copy/`chmod` block, so the shipped bundle and the e2e-tested bundle (`_test_vsix` → `_release_vsix`) can never diverge.

## How Do The Automated Tests Prove It Works?
All 20 checks are green against the head commit `e1dda96`:
- **Rust Tests & Coverage** passes with the in-job coverage threshold enforced (proving the removed coverage-artifact upload changed nothing about the gate), and the conformance cache restores without regressing results.
- **Mutation Testing** shards 1–4 + the merge/score job all pass — the `retention-days: 1` hand-off still feeds the score gate, and `save-if` scoping didn't drop a shard.
- **VS Code Extension** e2e passes by running `make _test_vsix` against the bundle built via `_release_vsix` + `stage-runtime.mjs` — i.e. it exercises the *shipped* packaging path, which is exactly the parity invariant.
- **Shipwright Binary Gate**, **Build**, **Neovim/Zed Extension** e2e, **Lint**, **CodeQL/Analyze (actions, rust, javascript-typescript)**, and **security** (dependency-review) all pass; **Website Build** and **Clobber-merge into dependabot-upgrades** are correctly SKIPPED (no website change; non-Dependabot actor).

## Spec / Doc Changes
- `docs/specs/CHECKER-ARCHITECTURE-SPEC.md` — new `[GITHUB-NO-ARTIFACTS]` section (public-repo compute is free, stored artifacts are billed; transient hand-offs only, `retention-days: 1`).
- `docs/specs/VSIX-SPEC.md` — new `[VSIX-PACKAGING-PARITY]` section (one packaging recipe, one staging helper, tests run the shipped bytes).
- `CLAUDE.md` — top-level `[GITHUB-NO-ARTIFACTS]` rule.
- All workflow/automation changes reference `[GITHUB-DEPENDABOT]`, `[GITHUB-NO-ARTIFACTS]`, or `[VSIX-PACKAGING-PARITY]`.

## Breaking Changes
- [x] None
