### PR TITLE
security(ci/vsix): fix HIGH insecure-temp-file log + harden Dependabot merge bot (CodeQL on #164)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,24 @@
+# CodeQL configuration ([GITHUB-CODE-SCANNING]).
+#
+# Wired into codeql.yml's `init` step via `config-file:`. Holds query-level
+# tuning that the `queries:` input cannot express (query-filters).
+#
+# Why exclude actions/untrusted-checkout/MEDIUM:
+# `.github/workflows/dependabot-automerge.yml` is a merge bot, not a build.
+# CodeQL's medium untrusted-checkout query assumes a privileged workflow
+# "checks out and runs the build script from a fork"; ours does neither:
+#   * the trigger is plain `pull_request` (NOT `pull_request_target`) — fork PRs
+#     run with a READ-ONLY token and no secrets;
+#   * the job is gated on the unforgeable `dependabot[bot]` actor AND a
+#     `dependabot/*` source branch;
+#   * it runs ONLY git plumbing (fetch / `merge -X theirs` / push) + `gh pr
+#     close` — it never executes any script, hook, or build from the merged tree
+#     (hooks are also disabled via `core.hooksPath=/dev/null`).
+# Adversarially verified non-exploitable (true-pattern, false-exploit), and at
+# MEDIUM severity it is below the codeql.yml release gate (>= 7.0) regardless.
+# We exclude ONLY the `/medium` id; the genuinely-dangerous
+# `actions/untrusted-checkout/high` (the `pull_request_target` case) stays
+# ACTIVE, so a real misconfiguration is still caught.
+query-filters:
+  - exclude:
+      id: actions/untrusted-checkout/medium

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,6 +75,11 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
+          # query-filters live here, not in the `queries:` input. Currently
+          # suppresses the verified false-positive actions/untrusted-checkout/medium
+          # on the Dependabot merge bot — see the file for the full rationale. The
+          # dangerous /high (pull_request_target) variant stays active.
+          config-file: ./.github/codeql/codeql-config.yml
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -22,6 +22,14 @@ name: Dependabot auto-merge
 # Lives at the repo root so it is present on `dependabot-upgrades` (cut from
 # main): for `pull_request` the workflow is read from the PR's base branch, so
 # BOTH `main` and the staging branch must carry this file.
+#
+# ⚠️ SECURITY INVARIANT — the trigger MUST stay `pull_request`, NEVER
+# `pull_request_target`. Under `pull_request` a fork PR runs with a READ-ONLY
+# token and no secrets, so merging fork-controlled content here is inert.
+# `pull_request_target` would hand the write token + secrets to that content and
+# turn this merge bot into a real RCE/exfiltration sink — exactly the
+# actions/untrusted-checkout finding, made true. Do not change it.
+# ([GITHUB-CODE-SCANNING])
 on:
   pull_request:
     branches:
@@ -35,7 +43,10 @@ permissions:
 jobs:
   sweep:
     name: Clobber-merge into dependabot-upgrades
-    if: github.actor == 'dependabot[bot]'
+    # Two independent gates, both required: the (unforgeable) Dependabot actor
+    # AND a `dependabot/*` source branch. actor-AND-source keeps the trust
+    # assumption explicit and resilient if the trigger set is ever widened.
+    if: github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/')
     # Deliberately the standard runner, NOT a larger/paid one: a trivial merge
     # bot must not consume CI minutes meant for the real build matrix.
     runs-on: ubuntu-latest
@@ -56,6 +67,11 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Defense-in-depth: disable git hooks for every git op in this job, so
+          # merging attacker-influenced tree content can never execute a hook by
+          # construction. No hook is reachable today (hooks live in .git, not the
+          # tree), but this holds regardless of any future change.
+          git config --global core.hooksPath /dev/null
           # Pull the bump branch into a stable local ref we can re-merge.
           git fetch origin "+refs/heads/${PR_HEAD}:refs/remotes/origin/${PR_HEAD}"
           # Re-merge onto the LIVE staging tip and retry: concurrent Dependabot

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8,7 +8,7 @@
 
 import * as vscode from "vscode";
 import * as path from "path";
-import * as os from "os";
+import * as fs from "fs";
 import { Logger, bindLogger, CompositeSink, FileLogSink, nullSink } from "./logger";
 import type { LogSink } from "./logger";
 import { startLspClient } from "./lsp-client";
@@ -235,7 +235,15 @@ export function deactivate(): Promise<void> | undefined {
 function initLogging(context: vscode.ExtensionContext, s: Store): void {
   const logChannel = vscode.window.createOutputChannel("Basilisk", { log: true });
   s.setOutputChannel(logChannel);
-  const logFilePath = path.join(os.tmpdir(), "basilisk-debug-trace.log");
+  // Logs live in the extension's PRIVATE per-extension log directory
+  // (context.logUri) — never the world-writable OS temp dir. A predictable name
+  // in shared /tmp is open to symlink redirection and cross-user disclosure
+  // (js/insecure-temporary-file); the per-extension dir is owned by this user
+  // and is where [VSIX-OUTPUT-CHANNELS] expects logs to live. VS Code may not
+  // have created logUri on disk yet, so ensure it exists first.
+  const logDir = context.logUri.fsPath;
+  fs.mkdirSync(logDir, { recursive: true });
+  const logFilePath = path.join(logDir, "basilisk-debug-trace.log");
   const fileSink = new FileLogSink(logFilePath);
   const compositeSink = new CompositeSink([new VscodeLogSink(logChannel), fileSink]);
   s.setLogSink(compositeSink);

--- a/vscode-extension/src/logger.ts
+++ b/vscode-extension/src/logger.ts
@@ -50,14 +50,24 @@ export class CompositeSink implements LogSink {
   public error(message: string): void { for (const s of this.sinks) {s.error(message);} }
 }
 
+/**
+ * Log file permission bits: owner read+write only. The log can contain
+ * workspace paths, so it must never be group/world-readable
+ * (defense-in-depth for js/insecure-temporary-file).
+ */
+const LOG_FILE_MODE = 0o600;
+
 /** Sink that appends to a file on disk via synchronous writes. */
 export class FileLogSink implements LogSink {
   private readonly fd: number;
   constructor(filePath: string) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const fsModule = require("fs") as typeof FsModule;
-    // Open for append+create, truncating any previous run.
-    this.fd = fsModule.openSync(filePath, "w");
+    // Create+truncate with OWNER-ONLY (0o600) permissions so the log — which
+    // can contain workspace paths — is never world-readable, even if a caller
+    // ever points this at a shared directory (defense-in-depth for
+    // js/insecure-temporary-file; callers pass the extension's private logUri).
+    this.fd = fsModule.openSync(filePath, "w", LOG_FILE_MODE);
   }
   public trace(message: string): void { this.write("TRACE", message); }
   public debug(message: string): void { this.write("DEBUG", message); }


### PR DESCRIPTION
## TLDR
Resolve both CodeQL code-scanning findings raised on #164: fix the real **HIGH** insecure-temp-file in the extension logger, and harden + durably suppress the **medium** false-positive on the Dependabot merge bot.

## What Was Added?
- **`.github/codeql/codeql-config.yml`** — a CodeQL config (wired into `codeql.yml`'s `init` via `config-file:`) whose `query-filters` exclude **only** `actions/untrusted-checkout/medium`. The genuinely-dangerous `/high` (`pull_request_target`) variant stays active.

## What Was Changed or Deleted?
**`js/insecure-temporary-file` — HIGH, true positive (the one that mattered):**
- [extension.ts](vscode-extension/src/extension.ts) wrote the debug log to `os.tmpdir()/basilisk-debug-trace.log` — a predictable name in the world-writable shared temp dir, open to symlink redirection and cross-user disclosure. It now writes to the extension's **private** `context.logUri` directory (created with `mkdirSync(recursive)`), which is also where `[VSIX-OUTPUT-CHANNELS]` says logs belong. The now-unused `os` import is dropped; `fs` added.
- [logger.ts](vscode-extension/src/logger.ts) `FileLogSink` now opens the file `0o600` (owner-only) as defense-in-depth, via a named `LOG_FILE_MODE` constant.

**`actions/untrusted-checkout/medium` — verified false positive (the bot runs only git plumbing + `gh pr close`, never executes fork code; plain `pull_request` → fork PRs are read-only):** hardened anyway in [dependabot-automerge.yml](.github/workflows/dependabot-automerge.yml):
- `git config --global core.hooksPath /dev/null` before any git op — merging attacker-influenced tree content cannot execute a hook by construction.
- Job guard tightened to actor **AND** source: `github.actor == 'dependabot[bot]' && startsWith(github.head_ref, 'dependabot/')`.
- Load-bearing comment: the trigger **MUST stay `pull_request`**, never `pull_request_target` (that single change is what would make the finding real).

## How Do The Automated Tests Prove It Works?
- **CodeQL re-scan on this PR** is the direct proof: the `Analyze (javascript-typescript)` job should no longer report `js/insecure-temporary-file` at logger.ts (the `os.tmpdir()` taint source is gone), and `Analyze (actions)` should no longer surface `actions/untrusted-checkout/medium` (excluded by the new config; `/high` still enforced).
- **VS Code Extension** e2e (`make _test_vsix`) exercises activation, which calls `initLogging` — proving the `context.logUri` path is created and the `FileLogSink` opens successfully (logging still works end-to-end).
- Local `tsc -p ./` and `eslint src/` are clean (caught and fixed a `no-magic-numbers` on the mode literal).
- `actionlint` passes on both edited workflows; all three YAML files parse.

## Spec / Doc Changes
No spec text changed. New references: `[GITHUB-CODE-SCANNING]` (codeql-config + workflow comment), `[GITHUB-DEPENDABOT]` (merge-bot guard), `[VSIX-OUTPUT-CHANNELS]` (log location).

## Breaking Changes
- [x] None — debug log path moves from the OS temp dir to the extension's private log dir; no public API or user-facing behavior changes.
