### PR TITLE
fix(zed): repair Python highlights query for Zed's bundled grammar

### DIFF
--- a/basilisk-zed/languages/python/highlights.scm
+++ b/basilisk-zed/languages/python/highlights.scm
@@ -12,9 +12,6 @@
 "case" @keyword
 "type" @keyword
 
-; Exception keywords
-["except*"] @keyword
-
 ; Builtins
 ((identifier) @function.builtin
   (#any-of? @function.builtin
@@ -85,16 +82,13 @@
 (type (attribute attribute: (identifier) @type))
 (type (subscript value: (identifier) @type))
 
-; Generic type parameters (PEP 695 — Python 3.12+)
-(type_parameter (identifier) @type)
-
 ; Class definitions
 (class_definition name: (identifier) @type)
 (class_definition superclasses: (argument_list (identifier) @type))
 
 ; String literals
 (string) @string
-(string (escape_sequence) @string.escape)
+(escape_sequence) @string.escape
 
 ; F-string interpolations
 (interpolation) @string.special


### PR DESCRIPTION
## TLDR
Fixes the Zed extension doing nothing for Python files: a broken tree-sitter highlights query was preventing the Python language from registering, which also blocked the basilisk LSP from attaching.

## What Was Changed or Deleted?
`basilisk-zed/languages/python/highlights.scm` had three patterns written against a newer `tree-sitter-python` than Zed bundles, so loading the query failed (`failed to load language Python: Error loading highlights query`) and the whole Python language — highlighting **and** language-server attachment — never came up:

- `["except*"]` (PEP 654 exception groups) — invalid node type. Removed; the `except` keyword is already highlighted via the keyword list.
- `(type_parameter (identifier) @type)` (PEP 695 generics) — impossible pattern against Zed's grammar. Removed.
- `(string (escape_sequence) @string.escape)` — impossible pattern (escape sequences aren't direct children of `string` in Zed's grammar). Rewritten to the grammar-agnostic `(escape_sequence) @string.escape`, preserving escape highlighting.

Net: −7/+1 lines, one file.

## How Do The Automated Tests Prove It Works?
Tree-sitter queries are compiled by the editor at runtime, not by any CI job, so this was verified against the **running Zed editor**: after the change, `Zed.log` shows the Python language registering with **zero** query errors (previously `Query error … Invalid node type "except*"`), and the **basilisk language server attaches** — test discovery runs and enumerates the workspace's `pytest` tests. Before the fix, no language server attached at all.

## Breaking Changes
- [x] None