### PR TITLE
Align uv diagnostics, debug errors, and CI pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         with:
           cache-on-failure: true
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -234,7 +234,7 @@ jobs:
         with:
           cache-on-failure: true
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -253,7 +253,7 @@ jobs:
       # the ref edits that file and busts the cache; score.py re-fetches whenever
       # the stamped ref differs, so a stale prefix restore self-heals.
       - name: Cache conformance fixtures
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: conformance/tests
           key: conformance-suite-${{ hashFiles('conformance/score.py') }}
@@ -297,7 +297,7 @@ jobs:
           cache: npm
           cache-dependency-path: vscode-extension/package-lock.json
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -330,7 +330,7 @@ jobs:
       # so the pinned editor version is reused instead of re-downloaded; a
       # version bump (config/manifest change) busts the key and re-fetches.
       - name: Cache VS Code test build
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vscode-extension/.vscode-test
           key: vscode-test-${{ runner.os }}-${{ hashFiles('vscode-extension/.vscode-test.mjs', 'vscode-extension/.vscode-test.js', 'vscode-extension/package.json') }}
@@ -404,7 +404,7 @@ jobs:
       - name: Install lld
         run: sudo apt-get update && sudo apt-get install -y lld
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -424,7 +424,7 @@ jobs:
       # Cache them so the clones become no-ops — test-nvim.sh skips any dir that
       # already exists. Bump the key suffix to force a refresh of the pins.
       - name: Cache Neovim test plugins
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             /tmp/plenary.nvim
@@ -504,7 +504,7 @@ jobs:
           save-if: ${{ env.RUN == 'true' && matrix.shard == '0/4' }}
 
       - if: env.RUN == 'true'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 
@@ -544,7 +544,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,7 +221,7 @@ jobs:
           cache-dependency-path: vscode-extension/package-lock.json
 
       # Needed to vendor debugpy (pip install --target) into the VSIX bundle.
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2604,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
 dependencies = [
  "libc",
  "memchr",

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 <p align="center">
   <a href="https://www.basilisk-python.dev/docs/conformance/"><strong><!--g:score-->100.0%<!--/g:score--> PEP conformance</strong></a> &mdash; <!--g:pass-->141<!--/g:pass--> of <!--g:total-->141<!--/g:total--> tests in the official
-  <a href="https://github.com/python/typing/tree/f6e2e588880a057a939cee76c6c919aebd4db37c/conformance"><code>python/typing</code></a>
-  conformance suite (commit <code><!--g:short-->f6e2e58<!--/g:short--></code>), scored on the real binary in its default config by
+  <a href="https://github.com/python/typing/tree/c94dfceff0af70c6626a1f86bc8f979135ae4652/conformance"><code>python/typing</code></a>
+  conformance suite (commit <code><!--g:short-->c94dfce<!--/g:short--></code>), scored on the real binary in its default config by
   <a href="https://github.com/Nimblesite/Basilisk/blob/main/conformance/score.py"><code>conformance/score.py</code></a>.
   We target <code>python/typing@main</code> and ratchet the score up only.
 </p>

--- a/README.zh.md
+++ b/README.zh.md
@@ -25,8 +25,8 @@
 
 <p align="center">
   <a href="https://www.basilisk-python.dev/zh/docs/conformance/"><strong>PEP 符合性 <!--g:score-->100.0%<!--/g:score--></strong></a> &mdash; 官方
-  <a href="https://github.com/python/typing/tree/f6e2e588880a057a939cee76c6c919aebd4db37c/conformance"><code>python/typing</code></a>
-  符合性套件 <!--g:total-->141<!--/g:total--> 个测试中通过 <!--g:pass-->141<!--/g:pass--> 个（提交 <code><!--g:short-->f6e2e58<!--/g:short--></code>），由
+  <a href="https://github.com/python/typing/tree/c94dfceff0af70c6626a1f86bc8f979135ae4652/conformance"><code>python/typing</code></a>
+  符合性套件 <!--g:total-->141<!--/g:total--> 个测试中通过 <!--g:pass-->141<!--/g:pass--> 个（提交 <code><!--g:short-->c94dfce<!--/g:short--></code>），由
   <a href="https://github.com/Nimblesite/Basilisk/blob/main/conformance/score.py"><code>conformance/score.py</code></a>
   在默认配置下对真实二进制文件评分。我们对标 <code>python/typing@main</code>，得分只升不降。
 </p>

--- a/crates/basilisk-checker/src/rules/missing_type_stubs/mod.rs
+++ b/crates/basilisk-checker/src/rules/missing_type_stubs/mod.rs
@@ -129,6 +129,10 @@ fn make_diagnostic(import: &ImportInfo, path: &str) -> Diagnostic {
 /// official authoring guide so a developer — or an AI assisting in the editor —
 /// has self-contained context to write the stub. No shell command appears here:
 /// per [STUBRES-CODEACTIONS] the quick fix does the work, the help only explains.
+///
+/// Implements [LSPUV-DIAGNOSTICS-MISSING-STUBS]: the typeshed branch is gated
+/// on the bundled typeshed index — stub names are never guessed by
+/// concatenation.
 fn stub_help_text(root_module: &str) -> String {
     match basilisk_stubs::typeshed_stub_distribution(root_module) {
         Some(distribution) => {

--- a/crates/basilisk-lsp/src/code_actions/mod.rs
+++ b/crates/basilisk-lsp/src/code_actions/mod.rs
@@ -366,6 +366,9 @@ fn make_uv_add_dev_pytest_action(diag: &Diagnostic) -> CodeAction {
 /// Returns `None` when no stub distribution is known (the package ships inline
 /// `py.typed` types or no stubs exist), so we never offer a quick-fix that would
 /// fail to resolve on `PyPI` (e.g. the nonexistent `pydantic_ai-stubs`).
+///
+/// Implements [LSPUV-DIAGNOSTICS-MISSING-STUBS] — the `basilisk.uv.addDev`
+/// quick fix, gated on the bundled typeshed index.
 fn make_uv_add_stubs_action(diag: &Diagnostic, module: &str) -> Option<CodeAction> {
     let stubs_package = basilisk_stubs::typeshed_stub_distribution(module)?;
     Some(CodeAction {

--- a/crates/basilisk-lsp/src/code_actions/mod.rs
+++ b/crates/basilisk-lsp/src/code_actions/mod.rs
@@ -708,11 +708,11 @@ mod tests {
     }
 
     #[test]
-    fn test_bsk_w0014_code_action_includes_uv_add_dev_pytest() {
+    fn pytest_not_found_code_action_includes_uv_add_dev_pytest() {
         let diag = make_diagnostic(
             DiagnosticSeverity::WARNING,
             crate::server::test_handlers::PYTEST_NOT_FOUND_CODE,
-            "pytest not found in uv.lock — use quick fix to install",
+            "Test runner \"pytest\" is not installed. Run \"uv add --dev pytest\" to install.",
             range_at((0, 0), (0, 0)),
         );
         let uri = Url::parse("file:///test_example.py").unwrap();

--- a/crates/basilisk-lsp/src/debug.rs
+++ b/crates/basilisk-lsp/src/debug.rs
@@ -26,7 +26,8 @@ const ADAPTER_BIND_TIMEOUT: Duration = Duration::from_secs(30);
 /// Errors that can occur during debug session management.
 // Implements [LSPDEBUG-ERRORS] — error variants and their user-facing messages
 // ("debugpy not found. Install it…", "No Python interpreter found. Checked…").
-// The JSON-RPC error codes (-32001 / -32002) are mapped in server/commands.rs.
+// The JSON-RPC error code for each variant is `DebugError::jsonrpc_code`.
+// typeDiagram model: models/debug_session.td (diagram docs/models/debug_session.svg).
 #[derive(Debug)]
 pub enum DebugError {
     /// Failed to allocate a free TCP port.
@@ -67,6 +68,26 @@ impl fmt::Display for DebugError {
                 "No Python interpreter found. Checked: {searched}. \
                  Set BASILISK_PYTHON or create a virtualenv."
             ),
+        }
+    }
+}
+
+impl DebugError {
+    /// JSON-RPC error code for this failure, per [LSPDEBUG-ERRORS].
+    ///
+    /// `-32001` is reserved for "debugpy not found" and `-32002` for "no Python
+    /// interpreter"; transport failures (port/spawn/timeout/adapter-exit) use
+    /// the generic implementation-defined server code `-32000` so an adapter
+    /// crash is never reported to the client as a missing interpreter.
+    #[must_use]
+    pub const fn jsonrpc_code(&self) -> i64 {
+        match self {
+            Self::DebugpyNotFound(_) => -32001,
+            Self::PythonNotFound(_) => -32002,
+            Self::PortAllocation(_)
+            | Self::SpawnFailed(_)
+            | Self::Timeout(_)
+            | Self::AdapterExited(_) => -32000,
         }
     }
 }
@@ -336,8 +357,9 @@ fn bundled_debugpy_pythonpath() -> Option<std::ffi::OsString> {
 ///
 /// # Errors
 ///
-/// Returns `DebugError::SpawnFailed` if the Python process cannot be started,
-/// or `DebugError::DebugpyNotFound` if the import fails.
+/// Returns `DebugError::PythonNotFound` if the interpreter binary itself is
+/// missing, `DebugError::SpawnFailed` for any other spawn failure, or
+/// `DebugError::DebugpyNotFound` if the import fails.
 // Implements [LSPDEBUG-PYRES] — `check_debugpy` verifies the interpreter can
 // import debugpy before spawning, returning `DebugError::DebugpyNotFound` if not.
 pub async fn check_debugpy(python: &str) -> Result<(), DebugError> {
@@ -350,7 +372,15 @@ pub async fn check_debugpy(python: &str) -> Result<(), DebugError> {
     if let Some(pythonpath) = bundled_debugpy_pythonpath() {
         let _ = command.env("PYTHONPATH", pythonpath);
     }
-    let output = command.output().await.map_err(DebugError::SpawnFailed)?;
+    let output = command.output().await.map_err(|err| {
+        // A missing interpreter binary is a missing-Python condition (-32002),
+        // not a generic spawn failure — see [LSPDEBUG-ERRORS].
+        if err.kind() == std::io::ErrorKind::NotFound {
+            DebugError::PythonNotFound(python.to_owned())
+        } else {
+            DebugError::SpawnFailed(err)
+        }
+    })?;
 
     if output.status.success() {
         info!(python, "debugpy is available");
@@ -518,7 +548,10 @@ mod tests {
         ] {
             let code = err.jsonrpc_code();
             assert_eq!(code, -32000, "{err:?} must use the generic server code");
-            assert!(code != -32001 && code != -32002, "{err:?} must not use a reserved code");
+            assert!(
+                code != -32001 && code != -32002,
+                "{err:?} must not use a reserved code"
+            );
         }
     }
 

--- a/crates/basilisk-lsp/src/debug.rs
+++ b/crates/basilisk-lsp/src/debug.rs
@@ -485,11 +485,41 @@ mod tests {
         }
     }
 
-    // Tests [LSPDEBUG-PYRES]: check_debugpy fails when the interpreter is absent.
+    // Tests [LSPDEBUG-PYRES]: a missing interpreter is a missing-Python
+    // condition, not a debugpy condition.
     #[tokio::test]
     async fn check_debugpy_with_nonexistent_python_returns_err() {
         let result = check_debugpy("/nonexistent/python").await;
-        assert!(result.is_err(), "nonexistent python must fail");
+        assert!(
+            matches!(result, Err(DebugError::PythonNotFound(_))),
+            "a nonexistent interpreter must map to PythonNotFound, got {result:?}"
+        );
+    }
+
+    // Tests [LSPDEBUG-ERRORS]: each error variant maps to the JSON-RPC code the
+    // spec reserves for it — -32001 only for debugpy-missing, -32002 only for
+    // interpreter-missing, and a generic server error for transport failures so
+    // an adapter crash is not reported as "no Python interpreter".
+    #[test]
+    fn jsonrpc_code_matches_spec_reservations() {
+        assert_eq!(
+            DebugError::DebugpyNotFound("python3".to_owned()).jsonrpc_code(),
+            -32001
+        );
+        assert_eq!(
+            DebugError::PythonNotFound("python3".to_owned()).jsonrpc_code(),
+            -32002
+        );
+        for err in [
+            DebugError::PortAllocation(std::io::Error::from(std::io::ErrorKind::AddrInUse)),
+            DebugError::SpawnFailed(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+            DebugError::Timeout(5678),
+            DebugError::AdapterExited("signal 9".to_owned()),
+        ] {
+            let code = err.jsonrpc_code();
+            assert_eq!(code, -32000, "{err:?} must use the generic server code");
+            assert!(code != -32001 && code != -32002, "{err:?} must not use a reserved code");
+        }
     }
 
     /// The user-facing timeout message must name the REAL budget — a stale

--- a/crates/basilisk-lsp/src/server/commands.rs
+++ b/crates/basilisk-lsp/src/server/commands.rs
@@ -283,7 +283,7 @@ pub(super) async fn execute_start_debug_session(
             .log_message(MessageType::ERROR, err.to_string())
             .await;
         return Err(tower_lsp::jsonrpc::Error {
-            code: tower_lsp::jsonrpc::ErrorCode::ServerError(-32001),
+            code: tower_lsp::jsonrpc::ErrorCode::ServerError(err.jsonrpc_code()),
             message: err.to_string().into(),
             data: None,
         });
@@ -333,7 +333,7 @@ pub(super) async fn execute_start_debug_session(
                 .log_message(MessageType::ERROR, err.to_string())
                 .await;
             Err(tower_lsp::jsonrpc::Error {
-                code: tower_lsp::jsonrpc::ErrorCode::ServerError(-32002),
+                code: tower_lsp::jsonrpc::ErrorCode::ServerError(err.jsonrpc_code()),
                 message: err.to_string().into(),
                 data: None,
             })

--- a/crates/basilisk-lsp/src/server/init.rs
+++ b/crates/basilisk-lsp/src/server/init.rs
@@ -907,7 +907,7 @@ async fn check_pytest_from_index(
         client
             .log_message(
                 MessageType::WARNING,
-                "Basilisk: pytest not found in uv.lock — use the quick fix to install it"
+                "Basilisk: test runner \"pytest\" is not installed — use the quick fix (uv add --dev pytest)"
                     .to_owned(),
             )
             .await;

--- a/crates/basilisk-lsp/src/server/test_handlers.rs
+++ b/crates/basilisk-lsp/src/server/test_handlers.rs
@@ -369,15 +369,15 @@ impl tower_lsp::lsp_types::notification::Notification for CoverageResultNotifica
     const METHOD: &'static str = basilisk_common::coverage_notifications::COVERAGE_RESULT;
 }
 
-/// Diagnostic code for pytest not found in uv project.
-pub(crate) const PYTEST_NOT_FOUND_CODE: &str = "BSK-W0014";
+/// Diagnostic code for pytest not found in a uv project.
+///
+/// Dedicated to this diagnostic — `BSK-W0014` is the explicit-`Any` nudge rule
+/// and must not be reused here ([LSPTEST-UV-INTEGRATION-TEST-DEPENDENCY-VERIFICATION]).
+pub(crate) const PYTEST_NOT_FOUND_CODE: &str = "BSK-W0015";
 
-// Implements [LSPTEST-UV-INTEGRATION-TEST-DEPENDENCY-VERIFICATION] — "pytest not in uv.lock" Warning.
-// DEVIATION: the spec's table message is `Test runner "pytest" is not installed. Run "uv add --dev
-// pytest" to install.`; the message emitted below differs. The reused code is `BSK-W0014`, which
-// CLAUDE.md documents as the explicit-`Any` nudge rule — reusing that code for a test-dependency
-// warning is a cross-purpose overlap worth confirming.
-/// Build a `BSK-W0014` diagnostic for a test file missing pytest.
+// Implements [LSPTEST-UV-INTEGRATION-TEST-DEPENDENCY-VERIFICATION] — "pytest not in uv.lock" Warning
+// with the `basilisk.uv.addDev` quick fix (attached in code_actions).
+/// Build the pytest-missing diagnostic (`BSK-W0015`) for a uv test file.
 pub(super) fn make_pytest_not_found_diagnostic() -> Diagnostic {
     Diagnostic {
         range: Range {
@@ -394,7 +394,8 @@ pub(super) fn make_pytest_not_found_diagnostic() -> Diagnostic {
         code: Some(NumberOrString::String(PYTEST_NOT_FOUND_CODE.to_owned())),
         code_description: None,
         source: Some("basilisk".to_owned()),
-        message: "pytest not found in uv.lock — use quick fix to install".to_owned(),
+        message: "Test runner \"pytest\" is not installed. Run \"uv add --dev pytest\" to install."
+            .to_owned(),
         tags: None,
         related_information: None,
         data: None,
@@ -514,12 +515,18 @@ mod tests {
         );
         assert_eq!(diag.severity, Some(DiagnosticSeverity::WARNING));
         assert_eq!(diag.source.as_deref(), Some("basilisk"));
-        assert!(diag.message.contains("pytest"));
+        assert_eq!(
+            diag.message,
+            "Test runner \"pytest\" is not installed. Run \"uv add --dev pytest\" to install."
+        );
     }
 
     #[test]
-    fn pytest_not_found_code_constant() {
-        assert_eq!(PYTEST_NOT_FOUND_CODE, "BSK-W0014");
+    fn pytest_not_found_code_is_dedicated_not_explicit_any() {
+        // BSK-W0014 is the explicit-`Any` nudge rule; the pytest-missing
+        // diagnostic must use its own code, not collide with it.
+        assert_eq!(PYTEST_NOT_FOUND_CODE, "BSK-W0015");
+        assert_ne!(PYTEST_NOT_FOUND_CODE, "BSK-W0014");
     }
 
     #[test]

--- a/crates/basilisk-resolver/src/scope/function_types.rs
+++ b/crates/basilisk-resolver/src/scope/function_types.rs
@@ -190,7 +190,8 @@ pub struct FunctionInfo {
     pub docstring: Option<String>,
     /// Type narrowing guards detected in this function body.
     ///
-    /// Collected during AST resolution for use by the checker's `NarrowingContext`.
-    /// See `CHECKER-TYPE-INFERENCE-SPEC.md` §7.
+    /// Collected during AST resolution for the planned checker narrowing
+    /// engine (NARROWPLAN Phase 1); currently unconsumed. See
+    /// `CHECKER-TYPE-INFERENCE-SPEC.md` §7.
     pub narrowing_guards: Vec<NarrowingGuard>,
 }

--- a/crates/basilisk-resolver/src/scope/narrowing_types.rs
+++ b/crates/basilisk-resolver/src/scope/narrowing_types.rs
@@ -2,8 +2,11 @@
 //! Narrowing guard types collected from function bodies.
 //!
 //! These represent control-flow-sensitive type narrowing facts extracted
-//! during AST resolution. The checker's `NarrowingContext` consumes them
-//! to track narrowed variable types through branches.
+//! during AST resolution. They are collected for the planned checker
+//! narrowing engine (see NARROWPLAN Phase 1 in
+//! docs/plans/CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md) and currently have
+//! no consumer; live narrowing for `assert_type` uses the flow environment
+//! in `visitor/assert_narrow.rs` instead ([TYPEINF-NARROWING-ASSIGN]).
 
 use super::span::Span;
 

--- a/crates/basilisk-stubs/data/typeshed_stub_distributions.tsv
+++ b/crates/basilisk-stubs/data/typeshed_stub_distributions.tsv
@@ -1,7 +1,7 @@
 # typeshed third-party stub distribution map — GENERATED, do not edit by hand.
 # Source: python/typeshed `stubs/<DIST>/` directories (main branch).
 # Each line maps a Python *import root* to the PyPI *distribution* that
-# publishes its stubs (always `types-<DIST>`). Used by BSK-W0010 quick fix
+# publishes its stubs (always `types-<DIST>`). Used by the BSK-E0152 quick fix
 # to offer a real `uv add --dev <dist>` and to suppress the fix when no
 # stub distribution exists. Regenerate from typeshed's git tree.
 # Format: <import_root>\t<distribution>

--- a/crates/basilisk-uv/src/detect.rs
+++ b/crates/basilisk-uv/src/detect.rs
@@ -9,6 +9,9 @@ use std::path::{Path, PathBuf};
 use tracing::debug;
 
 /// Information about a detected uv-managed project.
+///
+/// Implements [LSPUV-DETECTION-RESULT]: raw boolean signals plus the matched
+/// root — consumers derive paths from `root` themselves.
 #[derive(Debug, Clone)]
 pub struct UvProjectInfo {
     /// Absolute path to the project root directory.

--- a/crates/basilisk-uv/src/detect.rs
+++ b/crates/basilisk-uv/src/detect.rs
@@ -12,7 +12,13 @@ use tracing::debug;
 ///
 /// Implements [LSPUV-DETECTION-RESULT]: raw boolean signals plus the matched
 /// root — consumers derive paths from `root` themselves.
+///
+/// typeDiagram model: `models/uv_detection.td` (diagram `docs/models/uv_detection.svg`).
 #[derive(Debug, Clone)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "one independent boolean per uv detection signal ([LSPUV-DETECTION-SIGNALS])"
+)]
 pub struct UvProjectInfo {
     /// Absolute path to the project root directory.
     pub root: PathBuf,

--- a/crates/basilisk-uv/src/detect.rs
+++ b/crates/basilisk-uv/src/detect.rs
@@ -25,6 +25,11 @@ pub struct UvProjectInfo {
 
     /// Whether the virtual environment was created by uv.
     pub uv_managed_venv: bool,
+
+    /// Whether `.python-version` exists with no `poetry.lock`/`Pipfile.lock` —
+    /// the Medium-confidence signal (`uv init` writes `.python-version` before
+    /// the first sync creates `uv.lock`).
+    pub has_python_version: bool,
 }
 
 /// Scan workspace roots and return info for the first directory that looks like
@@ -34,27 +39,29 @@ pub struct UvProjectInfo {
 /// - A `uv.lock` file exists
 /// - `pyproject.toml` contains a `[tool.uv]` section
 /// - `.venv/pyvenv.cfg` contains a `uv = true` marker
+/// - `.python-version` exists with no `poetry.lock`/`Pipfile.lock`
 //
 // Implements [LSPARCH-UV-DETECT] — the startup detection step that gates building
 // the PackageRegistry (registry build/workspace-member discovery live in the LSP
 // server's build_uv_registry and basilisk-uv's registry/workspace modules).
 // Implements [LSPUV-DETECTION-SIGNALS] — filesystem-only signal check (no
 // subprocess), evaluated in spec order: uv.lock, then `[tool.uv]`, then
-// `.venv/pyvenv.cfg` `uv = true`. Note: the spec's fourth Medium-confidence
-// signal (`.python-version` present + no poetry/pipenv lock) is NOT checked
-// here — see the conformance audit (DEVIATION).
+// `.venv/pyvenv.cfg` `uv = true`, then the Medium-confidence `.python-version`
+// signal (guarded against poetry/pipenv projects).
 pub fn detect_uv_project(workspace_roots: &[PathBuf]) -> Option<UvProjectInfo> {
     for root in workspace_roots {
         let has_lockfile = root.join("uv.lock").is_file();
         let has_tool_uv = check_tool_uv_section(root);
         let uv_managed_venv = check_uv_managed_venv(root);
+        let has_python_version = check_python_version_signal(root);
 
-        if has_lockfile || has_tool_uv || uv_managed_venv {
+        if has_lockfile || has_tool_uv || uv_managed_venv || has_python_version {
             debug!(
                 root = %root.display(),
                 has_lockfile,
                 has_tool_uv,
                 uv_managed_venv,
+                has_python_version,
                 "detected uv project"
             );
 
@@ -63,6 +70,7 @@ pub fn detect_uv_project(workspace_roots: &[PathBuf]) -> Option<UvProjectInfo> {
                 has_lockfile,
                 has_tool_uv,
                 uv_managed_venv,
+                has_python_version,
             });
         }
     }
@@ -110,6 +118,17 @@ fn check_uv_managed_venv(root: &Path) -> bool {
                 .strip_prefix("uv")
                 .is_some_and(|rest| rest.trim_start().starts_with("= true"))
     })
+}
+
+/// Check whether `.python-version` exists with no competing lock file.
+//
+// Implements [LSPUV-DETECTION-SIGNALS] — the ".python-version + no other
+// manager" Medium-confidence signal. The poetry/pipenv lock guard keeps a
+// pyenv-managed poetry/pipenv project from being misread as a uv project.
+fn check_python_version_signal(root: &Path) -> bool {
+    root.join(".python-version").is_file()
+        && !root.join("poetry.lock").is_file()
+        && !root.join("Pipfile.lock").is_file()
 }
 
 // Tests for [LSPUV-DETECTION-SIGNALS]: each detection signal in isolation,
@@ -161,6 +180,36 @@ mod tests {
     }
 
     #[test]
+    fn detects_python_version_only() {
+        let dir = setup_dir();
+        std::fs::write(dir.path().join(".python-version"), "3.12\n").unwrap();
+
+        let info = detect_uv_project(&[dir.path().to_path_buf()]).unwrap();
+        assert!(info.has_python_version);
+        assert!(!info.has_lockfile);
+        assert!(!info.has_tool_uv);
+        assert!(!info.uv_managed_venv);
+    }
+
+    #[test]
+    fn python_version_with_poetry_lock_not_detected() {
+        let dir = setup_dir();
+        std::fs::write(dir.path().join(".python-version"), "3.12\n").unwrap();
+        std::fs::write(dir.path().join("poetry.lock"), "").unwrap();
+
+        assert!(detect_uv_project(&[dir.path().to_path_buf()]).is_none());
+    }
+
+    #[test]
+    fn python_version_with_pipfile_lock_not_detected() {
+        let dir = setup_dir();
+        std::fs::write(dir.path().join(".python-version"), "3.12\n").unwrap();
+        std::fs::write(dir.path().join("Pipfile.lock"), "{}").unwrap();
+
+        assert!(detect_uv_project(&[dir.path().to_path_buf()]).is_none());
+    }
+
+    #[test]
     fn returns_none_for_non_uv_project() {
         let dir = setup_dir();
         assert!(detect_uv_project(&[dir.path().to_path_buf()]).is_none());
@@ -196,10 +245,13 @@ mod tests {
         std::fs::create_dir_all(&venv_dir).unwrap();
         std::fs::write(venv_dir.join("pyvenv.cfg"), "uv = true\n").unwrap();
 
+        std::fs::write(dir.path().join(".python-version"), "3.12\n").unwrap();
+
         let info = detect_uv_project(&[dir.path().to_path_buf()]).unwrap();
         assert!(info.has_lockfile);
         assert!(info.has_tool_uv);
         assert!(info.uv_managed_venv);
+        assert!(info.has_python_version);
     }
 
     #[test]

--- a/crates/basilisk-uv/src/python_version.rs
+++ b/crates/basilisk-uv/src/python_version.rs
@@ -33,11 +33,12 @@ pub fn read_python_version(root: &Path) -> Option<String> {
 /// checker's centralized default ([CHKARCH-VERSION-TARGET], issue #93).
 //
 // Implements [LSPUV-PYTHON-VERSION-RESOLUTION-ORDER] steps 2–4 of the spec's
-// 6-step cascade. The spec's step 1 (`basilisk.python` explicit override) and
-// step 6 (default 3.12) are owned by the consumers
+// 5-step cascade. Step 1 (explicit `python-version` in project config) and
+// step 5 (default 3.12) are owned by the consumers
 // (`basilisk_lsp::workspace`, CLI `main.rs`, and the checker's centralized
-// default). The spec's step 5 ("probe `python3 --version` in the venv") is NOT
-// implemented anywhere — see conformance audit (DEVIATION).
+// default). Venv probing (`python3 --version`) is deliberately out of scope
+// per the spec: resolution reads declared project metadata only, so the
+// target stays deterministic across machines and adds no subprocess spawn.
 #[must_use]
 pub fn resolve_target_python_version(root: &Path) -> Option<String> {
     read_python_version(root)

--- a/crates/basilisk-uv/src/registry.rs
+++ b/crates/basilisk-uv/src/registry.rs
@@ -96,15 +96,15 @@ impl PackageRegistry {
         self.packages.contains_key(import_name)
     }
 
-    /// Search for a type-stub package (e.g. `types-requests` for `requests`).
+    /// Look up a `types_{name}` entry in the lock registry (e.g.
+    /// `types_requests` for `requests`).
     ///
-    /// Returns the import name of the stub package if found.
-    //
-    // Implements [LSPUV-DIAGNOSTICS-MISSING-STUBS] — the "a matching stub
-    // package exists in uv.lock" precondition for the BSK-E0152 typeshed
-    // suggestion. NOTE: only the `types_{name}` form is checked here; the
-    // spec also names the `{name}-stubs` form, which this does not detect.
-    // See conformance audit (DEVIATION).
+    /// Returns the import name of the stub package if present. This is a
+    /// plain registry lookup; the BSK-E0152 stub *suggestion* path
+    /// ([LSPUV-DIAGNOSTICS-MISSING-STUBS]) instead uses the bundled typeshed
+    /// index (`basilisk_stubs::typeshed_stub_distribution`), and installed
+    /// `{name}-stubs` packages are honoured at import-resolution time
+    /// ([STUBRES-PEP561] step 3) — never by name guessing here.
     #[must_use]
     pub fn find_stub_package(&self, name: &str) -> Option<String> {
         let stub_import = format!("types_{name}");
@@ -345,8 +345,10 @@ mod tests {
         assert!(registry.has_package("my_editable"));
     }
 
-    // [LSPUV-DIAGNOSTICS-MISSING-STUBS]: a `types-<pkg>` entry in uv.lock is
-    // discoverable as the matching stub package (keyed `types_<pkg>`).
+    // A `types-<pkg>` entry in uv.lock is discoverable as the matching stub
+    // package (keyed `types_<pkg>`). Registry lookup only — the BSK-E0152
+    // suggestion path ([LSPUV-DIAGNOSTICS-MISSING-STUBS]) uses the bundled
+    // typeshed index instead.
     #[test]
     fn find_stub_package_found() {
         let lock = LockFile {

--- a/docs/models/debug_session.svg
+++ b/docs/models/debug_session.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 356 234" width="356" height="234" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="13">
+<defs>
+  <marker id="td-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+    <path d="M0,0 L10,5 L0,10 z" fill="#5b6068"/>
+  </marker>
+</defs>
+<rect x="0" y="0" width="356" height="234" fill="none"/>
+<g data-decl="DebugError" data-kind="union">
+  <rect x="29" y="28" width="298" height="178" rx="6" ry="6" fill="#ffffff" stroke="#3b3f46" stroke-width="1"/>
+  <rect x="29" y="28" width="298" height="50.2" rx="6" ry="6" fill="#f3eefa" stroke="none"/>
+  <rect x="29" y="72.2" width="298" height="6" fill="#f3eefa" stroke="none"/>
+  <line x1="29" y1="78.2" x2="327" y2="78.2" stroke="#3b3f46" stroke-width="1"/>
+  <rect x="29" y="28" width="4" height="178" rx="2" ry="2" fill="#7a4cc7"/>
+  <text x="39" y="49.65" fill="#1a1d22" font-weight="600">union DebugError</text>
+  <text x="178" y="72.8" fill="#7a4cc7" font-size="9" font-weight="700" text-anchor="middle" font-style="italic" letter-spacing="0.08em">ONE OF</text>
+  <line x1="29" y1="78.2" x2="327" y2="78.2" stroke="#dadde2" stroke-width="1"/>
+  <line x1="29" y1="78.2" x2="327" y2="78.2" stroke="#dadde2" stroke-width="1" stroke-dasharray="4 3"/>
+<text x="39" y="93.35" fill="#1a1d22">◇ PortAllocation { io: String }</text>
+<line x1="29" y1="99.4" x2="327" y2="99.4" stroke="#dadde2" stroke-width="1" stroke-dasharray="4 3"/>
+<text x="39" y="114.55" fill="#1a1d22">◇ SpawnFailed { io: String }</text>
+<line x1="29" y1="120.60000000000001" x2="327" y2="120.60000000000001" stroke="#dadde2" stroke-width="1" stroke-dasharray="4 3"/>
+<text x="39" y="135.75000000000003" fill="#1a1d22">◇ Timeout { port: Int }</text>
+<line x1="29" y1="141.8" x2="327" y2="141.8" stroke="#dadde2" stroke-width="1" stroke-dasharray="4 3"/>
+<text x="39" y="156.95000000000002" fill="#1a1d22">◇ AdapterExited { status: String }</text>
+<line x1="29" y1="163" x2="327" y2="163" stroke="#dadde2" stroke-width="1" stroke-dasharray="4 3"/>
+<text x="39" y="178.15" fill="#1a1d22">◇ DebugpyNotFound { python: String }</text>
+<line x1="29" y1="184.2" x2="327" y2="184.2" stroke="#dadde2" stroke-width="1" stroke-dasharray="4 3"/>
+<text x="39" y="199.35" fill="#1a1d22">◇ PythonNotFound { searched: String }</text>
+</g>
+
+</svg>

--- a/docs/models/uv_detection.svg
+++ b/docs/models/uv_detection.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 270 197" width="270" height="197" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="13">
+<defs>
+  <marker id="td-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+    <path d="M0,0 L10,5 L0,10 z" fill="#5b6068"/>
+  </marker>
+</defs>
+<rect x="0" y="0" width="270" height="197" fill="none"/>
+<g data-decl="UvProjectInfo" data-kind="record">
+  <rect x="29" y="28" width="212" height="141" rx="6" ry="6" fill="#ffffff" stroke="#3b3f46" stroke-width="1"/>
+  <rect x="29" y="28" width="212" height="34.2" rx="6" ry="6" fill="#eef1f5" stroke="none"/>
+  <rect x="29" y="56.2" width="212" height="6" fill="#eef1f5" stroke="none"/>
+  <line x1="29" y1="62.2" x2="241" y2="62.2" stroke="#3b3f46" stroke-width="1"/>
+  <rect x="29" y="28" width="4" height="141" rx="2" ry="2" fill="#1f6feb"/>
+  <text x="39" y="49.65" fill="#1a1d22" font-weight="600">UvProjectInfo</text>
+  
+  <line x1="29" y1="62.2" x2="241" y2="62.2" stroke="#dadde2" stroke-width="1"/>
+<text x="39" y="77.35" fill="#1a1d22">root: String</text>
+<line x1="29" y1="83.4" x2="241" y2="83.4" stroke="#dadde2" stroke-width="1"/>
+<text x="39" y="98.55" fill="#1a1d22">has_lockfile: Bool</text>
+<line x1="29" y1="104.60000000000001" x2="241" y2="104.60000000000001" stroke="#dadde2" stroke-width="1"/>
+<text x="39" y="119.75" fill="#1a1d22">has_tool_uv: Bool</text>
+<line x1="29" y1="125.80000000000001" x2="241" y2="125.80000000000001" stroke="#dadde2" stroke-width="1"/>
+<text x="39" y="140.95000000000002" fill="#1a1d22">uv_managed_venv: Bool</text>
+<line x1="29" y1="147" x2="241" y2="147" stroke="#dadde2" stroke-width="1"/>
+<text x="39" y="162.15" fill="#1a1d22">has_python_version: Bool</text>
+</g>
+
+</svg>

--- a/docs/plans/SPEC-CONFORMANCE-AUDIT-PLAN.md
+++ b/docs/plans/SPEC-CONFORMANCE-AUDIT-PLAN.md
@@ -32,7 +32,16 @@ a false claim.
 | `VSIX-PYTHON-DEBUGGER-DAP-LAUNCH-CONFIGURATIONS` | Shows debugger `type: "basilisk"` + `env`/`typeChecking` launch fields | Real type is `basilisk-debug`; launch schema differs | Follow-up |
 | `VSIX-OUTPUT-CHANNELS` | Says file log at `/tmp/basilisk-debug-trace.log` | Code uses `context.logUri` (secure per-extension dir) — intentional | Follow-up (spec should adopt secure path) |
 | `VSIX-STATUS-BAR` | Example uses `$(warning)` for an error count | Code uses `$(error)` for errors, `$(warning)` for warnings (correct) | Follow-up |
-| `ANALYSIS-INDEX-STRUCT`, `LSPUV-DETECTION-RESULT`, `LSPUV-WORKSPACE-MODEL`, `LSPUV-LOCK-REGISTRY` | Spec Rust struct shapes are simplified illustrations | Real structs differ (often more correct, e.g. `version: i32`) | Follow-up (refresh examples) |
+| `ANALYSIS-INDEX-STRUCT`, `LSPUV-WORKSPACE-MODEL`, `LSPUV-LOCK-REGISTRY` | Spec Rust struct shapes are simplified illustrations | Real structs differ (often more correct, e.g. `version: i32`) | Follow-up (refresh examples) |
+| `LSPUV-DETECTION-RESULT` | Spec showed a fictional `EnvironmentManager` enum + path-rich `UvProjectInfo` | `basilisk-uv/src/detect.rs` boolean-signal struct; `Option<UvProjectInfo>` is the whole decision | **Fixed** (spec rewritten, #232) |
+| `LSPUV-DIAGNOSTICS-MISSING-STUBS` | Spec's `types-{name}`/`{name}-stubs` name-guessing precondition was unimplementable; shipped design uses the bundled typeshed index + PEP 561 resolution | `basilisk-stubs::typeshed_stub_distribution`; `import_resolver.rs` `try_resolve_stub_package` | **Fixed** (spec rewritten, #208) |
+| `LSPUV-PYTHON-VERSION-RESOLUTION-ORDER` | Spec's venv `python3 --version` probe (step 5) is deliberately unbuilt (non-deterministic across machines, subprocess on check path); spec's step 1 named the wrong setting | `basilisk-uv/src/python_version.rs` + consumers | **Fixed** (spec rewritten to the 5-step cascade, #209) |
+| `ANALYSIS-INCR-DEBOUNCE` | Spec said 150 ms; code shipped 200 ms from day one (pure tuning constant, no external contract) | `basilisk-lsp/src/server/mod.rs` `FILE_WATCHER_DEBOUNCE_MS` | **Fixed** (spec now documents 200 ms, #210) |
+| `AUTOFIX-CONFLICTS` | Spec's safer-fix-wins + "skipped due to conflict" report + internal re-pass never built; resolution is purely positional and mixed-safety overlaps are unreachable with the shipped fix set | `code_actions/mass_fix.rs` `collect_non_overlapping_edits` | **Fixed** (spec rewritten, #220) |
+| `TYPEINF-EXCEEDS-NOUNKNOWN` | Spec claimed no `Unknown` is ever produced; `Unknown` is a deliberate internal insufficient-information sentinel that (mostly) suppresses diagnostics | `basilisk-checker/src/{types.rs,inference.rs}` | **Fixed** (spec rewritten, #223) |
+| `TYPEINF-SUBTYPING-NOMINAL` | Spec pinned C3-linearization MRO cache + `bytearray <: bytes` (removed from the tracked typing spec); shipped two-tier numeric tower passes conformance | `types_parsing.rs`, `rules/shared.rs::is_numeric_subtype` | **Fixed** (spec rewritten, #224) |
+| `TYPEINF-VARS-AUGMENTED`, `TYPEINF-NARROWING-ASSIGN`, `TYPEINF-NARROWING-DICTKEY` | Aspirational narrowing/inference prose; conservative shipped behavior passes conformance at 100%/0 FP; roadmap lives in NARROWPLAN | resolver/checker | **Fixed** (spec rewritten to document shipped behavior, #225) |
+| `TYPEINF-SUBTYPING-IMPL` / `TYPEINF-IMPL` | Spec described a fictional `is_subtype_of(ctx)` engine, `SubtypeContext`, Salsa-backed named components | `basilisk-checker/src/types.rs` `InferredType::is_assignable_to` + per-rule modules | **Fixed** (spec rewritten, #226) |
 | `WEBSITE-MOBILE-DOCS-NAV` | Names a non-existent `mobile-menu.js` | Toggle ships from `eleventy-plugin-techdoc`; reveal rule in `styles.css` | Follow-up |
 | `STUBRES-PROVENANCE-HOVER` | Tier-2 label wording differs between hover label and diag table | `basilisk-stubs/src/types.rs` `hover_label` | Follow-up (wording) |
 
@@ -68,9 +77,6 @@ deviation is tracked, not hidden.
 | `LSPUV-CONFIG-BINARY-RESOLUTION` | 5-priority `find_uv_binary` cascade has **no caller**; `run_uv` spawns bare `uv`, so `executablePath`/`UV_PATH` are ignored | `basilisk-uv/src/binary.rs` vs `uv_commands.rs` |
 | `LSPUV-DETECTION-SIGNALS` | 4th detection signal (`.python-version` w/o poetry/Pipfile lock) not checked | `basilisk-uv/src/detect.rs` |
 | `LSPUV-LOCK-IMPORT-MAPPING` | site-packages top-level-module scan (mechanism 1) not implemented | `basilisk-uv/src/import_map.rs` |
-| `LSPUV-DIAGNOSTICS-MISSING-STUBS` | `{name}-stubs` stub form not matched (only `types-{name}`) | `basilisk-uv/src/registry.rs` `find_stub_package` |
-| `LSPUV-PYTHON-VERSION-RESOLUTION-ORDER` | venv `python3 --version` probe (step 5) missing | `basilisk-uv/src/python_version.rs` |
-| `ANALYSIS-INCR-DEBOUNCE` | spec mandates 150 ms; code uses 200 ms | `basilisk-lsp/src/server/mod.rs` `FILE_WATCHER_DEBOUNCE_MS` |
 | `LSPTEST-...-ENVIRONMENT-VARIABLES` | `PYTHONDONTWRITEBYTECODE=1` never set | `basilisk-lsp/src/test_discovery/runner.rs` `set_venv_env` |
 | `LSPTEST-UV-INTEGRATION-COVERAGE` | emits bare `--cov` instead of `--cov=<src_root>` | `runner.rs` |
 | `LSPTEST-...-PYTEST-RESOLUTION-CASCADE` | `pytestPath` priority does not pre-empt `uv run`; cascade order differs | `runner.rs` `run_tests` |
@@ -82,13 +88,8 @@ deviation is tracked, not hidden.
 | `REFACTOR-FORMATTER` | strips whitespace only; never runs ruff | `code_actions/refactor/helpers.rs` `format_inserted_text` |
 | `REFACTOR-ABSTRACT-ALGO` | only direct same-module bases; no MRO; body hardcoded (ignores `REFACTOR-CONFIG`) | `code_actions/refactor/abstract_methods.rs` |
 | `REFACTOR-RENAME-VALIDATE` | shadowing/builtin-conflict rejections computed then discarded | `references.rs` |
-| `AUTOFIX-CONFLICTS` | overlap keeps earlier-by-position fix; never compares `FixSafety` (spec rule 2) | `code_actions/mass_fix.rs` `collect_non_overlapping_edits` |
 | `AUTOFIX-ADOPTION-RULES` | `auto_graduate` only called from tests; never runs in production | `basilisk-config/src/adoption.rs` |
 | `AUTOFIX-ADOPTION-FLOW` | Adopt does not run safe autofix first; demotions only applied on the adopt-command path, not normal publish | `basilisk-lsp/src/server/adoption.rs`, `workspace_analysis.rs` |
-| `TYPEINF-EXCEEDS-NOUNKNOWN` | spec claims no `Unknown` ever produced, but `InferredType::Unknown` is produced for calls/lambdas and treated as bidirectionally compatible | `basilisk-checker/src/{types.rs,inference.rs}` |
-| `TYPEINF-SUBTYPING-NOMINAL` | `complex` collapsed into `Float` at parse (loses `float <: complex`); `bytearray <: bytes` not modeled | `basilisk-checker/src/types_parsing.rs` |
-| `TYPEINF-VARS-AUGMENTED`, `TYPEINF-NARROWING-ASSIGN`, `TYPEINF-NARROWING-DICTKEY` | not implemented (augmented-assign re-typing; assignment narrowing extraction; `"k" in typed_dict` narrowing) | resolver/checker |
-| `TYPEINF-SUBTYPING-IMPL` / `TYPEINF-IMPL` | spec describes an `is_subtype_of(ctx)` engine + named components that don't exist; real path is `InferredType::is_assignable_to` (name-comparison fallback) | `basilisk-checker/src/types.rs` |
 | `CHKARCH-CLI-EXITCODES` | exit code `2` (configuration error) never produced; malformed config silently falls back to defaults | `basilisk-cli/src/main.rs`, `basilisk-config/src/lib.rs` |
 | `LSPDEBUG-ERRORS` | all `start_session` failures map to `-32002` (spec reserves it for "no Python interpreter") | `basilisk-lsp/src/server/commands.rs` |
 
@@ -99,4 +100,7 @@ deviation is tracked, not hidden.
 Tracked for added coverage (mutation/coverage ratchets only rise):
 `ANALYSIS-CROSSLSP-RENAME` (cross-file), `ANALYSIS-CAPS`, `NVIM-DEFAULT-KEYMAPS-STANDARD-LSP`,
 LSP adoption command handlers + `apply_adoptions`, `REFACTOR-FORMATTER`, `REFACTOR-INLINE-VAR-SAFETY`,
-`PROFILE-MEMORY-VIS-REFGRAPH`, `PROFILE-PERMISSIONS-WINDOWS` (cfg-gated).
+`PROFILE-MEMORY-VIS-REFGRAPH`, `PROFILE-PERMISSIONS-WINDOWS` (cfg-gated),
+`LSPUV-PYTHON-VERSION-RESOLUTION-ORDER` (the `requires-python`/`uv.lock` fallback steps of
+`resolve_target_python_version` and `constraint_lower_bound` have no direct test — only the
+`.python-version` step is covered).

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -647,6 +647,7 @@ The full set of codes the checker emits — generated from rule source by `scrip
 | `BSK-W0012` | Unused dependency |
 | `BSK-W0013` | Stale uv lock file |
 | `BSK-W0014` | Explicit `Any` annotation — prefer a concrete type (style nudge; split from `returns_compatibility`, see [CHKARCH-CONFORMANCE-MODE](#CHKARCH-CONFORMANCE-MODE)) |
+| `BSK-W0015` | Test runner `pytest` not installed in the uv project ([LSPTEST-UV-INTEGRATION-TEST-DEPENDENCY-VERIFICATION](LSP-TEST-INTEGRATION-SPEC.md#LSPTEST-UV-INTEGRATION-TEST-DEPENDENCY-VERIFICATION)) |
 | `BSK-W0040` | Lambda function missing type annotations |
 | `BSK-W0050` | Redundant type annotation warning |
 

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -260,7 +260,7 @@ The `# type:` prefix keeps compatibility with tools that recognize `# type: igno
 
 ### Python Typing PEP Coverage {#CHKARCH-PEPS}
 
-Basilisk's **target** is 100% conformance with the Python typing specification. We measure against the latest **`python/typing@main`**, recording the exact graded commit by hash in `conformance_report.json` (currently [`<!--g:short-->f6e2e58<!--/g:short-->`](https://github.com/python/typing/tree/f6e2e588880a057a939cee76c6c919aebd4db37c/conformance)). Today the official scorer, run unmodified in CI on the binary in its default configuration (the PEP conformance set; see [CHKARCH-CONFORMANCE-MODE](#CHKARCH-CONFORMANCE-MODE)), reports **<!--g:pass-->141<!--/g:pass--> of <!--g:total-->141<!--/g:total--> files passing (<!--g:score-->100.0%<!--/g:score-->)**, with **<!--g:fp-->0<!--/g:fp--> false positives** and **<!--g:missed-->0<!--/g:missed--> missed required errors** (<!--g:caught-->970<!--/g:caught--> caught). We run that suite in CI on every change; the gate ratchets the pass-percentage **up** and the false-positive ceiling **down** — closed only by fixing the checker, never by disabling a rule.
+Basilisk's **target** is 100% conformance with the Python typing specification. We measure against the latest **`python/typing@main`**, recording the exact graded commit by hash in `conformance_report.json` (currently [`<!--g:short-->c94dfce<!--/g:short-->`](https://github.com/python/typing/tree/c94dfceff0af70c6626a1f86bc8f979135ae4652/conformance)). Today the official scorer, run unmodified in CI on the binary in its default configuration (the PEP conformance set; see [CHKARCH-CONFORMANCE-MODE](#CHKARCH-CONFORMANCE-MODE)), reports **<!--g:pass-->141<!--/g:pass--> of <!--g:total-->141<!--/g:total--> files passing (<!--g:score-->100.0%<!--/g:score-->)**, with **<!--g:fp-->0<!--/g:fp--> false positives** and **<!--g:missed-->0<!--/g:missed--> missed required errors** (<!--g:caught-->970<!--/g:caught--> caught). We run that suite in CI on every change; the gate ratchets the pass-percentage **up** and the false-positive ceiling **down** — closed only by fixing the checker, never by disabling a rule.
 
 #### Foundation PEPs {#CHKARCH-PEPS-FOUNDATION}
 
@@ -1278,7 +1278,7 @@ the reference checkers (pyright, mypy, pyrefly, ty, zuban, pycroscope) are grade
   **down**. Per-file results are written to `conformance/conformance_status.csv`.
 - **Current score** — measured against `python/typing@main` at the exact graded
   commit recorded in `conformance_report.json`, currently
-  [`<!--g:short-->f6e2e58<!--/g:short-->`](https://github.com/python/typing/tree/f6e2e588880a057a939cee76c6c919aebd4db37c/conformance):
+  [`<!--g:short-->c94dfce<!--/g:short-->`](https://github.com/python/typing/tree/c94dfceff0af70c6626a1f86bc8f979135ae4652/conformance):
   **<!--g:pass-->141<!--/g:pass--> / <!--g:total-->141<!--/g:total--> = <!--g:score-->100.0%<!--/g:score-->**, **<!--g:fp-->0<!--/g:fp--> false positives**, **<!--g:missed-->0<!--/g:missed--> missed required errors**, with
   **<!--g:caught-->970<!--/g:caught-->** required errors caught. The binary runs in its default configuration — the
   PEP conformance set — and `score.py` deletes any `basilisk.json` first so nothing

--- a/docs/specs/CHECKER-TYPE-INFERENCE-SPEC.md
+++ b/docs/specs/CHECKER-TYPE-INFERENCE-SPEC.md
@@ -172,10 +172,10 @@ z: str = 42         # imports_unresolved: int is not assignable to str
 
 ```python
 x = 1
-x += 2   # still int — calls __iadd__ or __add__, return type drives x's new type
+x += 2   # still int — the target keeps its existing type
 ```
 
-The type of `x` after `x op= rhs` is the return type of `type(x).__iadd__(rhs)` (or `__add__` if `__iadd__` is absent). If the return type differs from `x`'s current type, the narrowed type applies.
+Augmented assignment (`x op= rhs`) does not re-type the target: `x` keeps its previously declared or inferred type. Basilisk does not resolve `__iadd__`/`__add__` return types to compute a new type; retaining the existing type is conservative and emits no diagnostics on spec-valid code (the conformance gate holds at 100% pass / 0 false positives, self-measured by `conformance/score.py`). Operator return-type inference is roadmap work — see [NARROWPLAN-EXPR-INFERENCE-OPERATORS](../plans/CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md#NARROWPLAN-EXPR-INFERENCE-OPERATORS). Augmented assignment IS analyzed for `Final`/`ReadOnly` reassignment violations and literal-semantics checks.
 
 ### Walrus Operator {#TYPEINF-VARS-WALRUS}
 
@@ -535,11 +535,10 @@ Truthiness narrowing removes falsy types from the union (`None`, `Literal[0]`, `
 
 ```python
 x: int | str = get_value()
-x = 42
-reveal_type(x)  # int — narrowed by assignment
+x = 42   # x keeps its declared type int | str
 ```
 
-After assignment, the variable's type is that of the assigned value (possibly narrower than the declared type).
+Basilisk does not narrow a variable's type on assignment: the variable retains its declared type. The flow-narrowing environment used for `assert_type` checking (`crates/basilisk-resolver/src/visitor/assert_narrow.rs`) narrows only on single-class `isinstance` guards, enum `is` comparisons, and `TypeGuard`/`TypeIs` calls; assignment statements do not update it. Assignment narrowing is roadmap work — see [NARROWPLAN-ENGINE-PATTERNS](../plans/CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md#NARROWPLAN-ENGINE-PATTERNS) item 4.
 
 ### Pattern Matching Narrowing {#TYPEINF-NARROWING-MATCH}
 
@@ -609,8 +608,6 @@ Assertions narrow the type for all code after the `assert` statement (within the
 
 ### Dict Key Existence Narrowing {#TYPEINF-NARROWING-DICTKEY}
 
-`TypedDict` types narrow via key existence checks:
-
 ```python
 class Movie(TypedDict, total=False):
     title: str
@@ -618,8 +615,10 @@ class Movie(TypedDict, total=False):
 
 def f(m: Movie) -> None:
     if "title" in m:
-        reveal_type(m["title"])  # str — not str | undefined
+        m["title"]   # the TypedDict type is NOT narrowed by the `in` check
 ```
+
+Basilisk does not narrow `TypedDict` types via `"key" in td` checks; no `in`-comparison narrowing exists. Access checking for non-required keys is conservative, so no diagnostic depends on this narrowing — every `typeddicts_*` conformance file passes with zero false positives (self-measured, `conformance/conformance_status.csv`). Key-existence (`in`-guard) narrowing is roadmap work — see [NARROWPLAN](../plans/CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md).
 
 ### Narrowing Scope Limitations {#TYPEINF-NARROWING-SCOPE}
 
@@ -712,13 +711,17 @@ class Dog(Animal): ...
 x: Animal = Dog()  # OK — Dog is a nominal subtype of Animal
 ```
 
-**MRO resolution** uses [C3 linearization](https://www.python.org/download/releases/2.3/mro/) (same as CPython). The MRO is computed per class and cached in `ResolvedModule`.
+**MRO resolution** is simplified: rules walk `ClassInfo.bases` transitively per class (no C3 linearization engine and no MRO cache in `ResolvedModule`); full C3 linearization remains future work ([NARROWPLAN-SUBTYPING-NOMINAL](../plans/CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md#NARROWPLAN-SUBTYPING-NOMINAL)).
 
-**Builtin type hierarchy** (hardcoded):
-- `bool` <: `int` <: `float` <: `complex`
-- `bytearray` <: `bytes` (for read contexts)
-- All classes <: `object`
-- `Never` <: everything (bottom type)
+**Builtin numeric tower.** The typing-spec promotions ([Special cases for float and complex](https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex)) hold: `bool`/`int` are accepted where `float` is expected, and `bool`/`int`/`float` where `complex` is expected. Two layers implement this:
+
+- Annotation-text level (the conformance rules): `rules/shared.rs::is_numeric_subtype` encodes the full `bool <: int <: float <: complex` chain, mirrored by rule-local helpers (`narrowing_typeis`, `narrowing_typeis_2`, `overloads_evaluation`, `generics_typevartuple_callable`, `aliases_implicit`, `generics_syntax_scoping`).
+- `InferredType` level: the annotation parser folds `complex` into `Float` (`types_parsing.rs`: `"float" | "complex" => Float`), so the `int → float` and `int`/`float → complex` promotions hold by construction (`bool` acceptance lives at the text level). Accepted trade-off: a `complex`-typed value is not rejected where `float` is expected — the conformance suite does not exercise that direction.
+
+**Other builtin relations:**
+- All classes <: `object` (`object` parses to the `Any` escape hatch for assignment purposes).
+- `Never` <: everything (bottom type).
+- There is **no** `bytearray <: bytes` promotion: the [current typing spec](https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex) defines promotions only for `float`/`complex` (the historical `bytes` shorthand was removed), and no conformance test requires it. `bytearray` parses to `Named("bytearray")` and is assignable essentially only to itself, `object`, and `Any`.
 
 ### Protocol Structural Subtyping {#TYPEINF-SUBTYPING-PROTOCOL}
 
@@ -832,30 +835,19 @@ g: Callable[[Dog], Animal]  # accepts Dog, returns Animal
 
 > **Authority**: [PEP 484 §Callable](https://peps.python.org/pep-0484/#callable), [Typing spec — Callables](https://typing.readthedocs.io/en/latest/spec/callables.html)
 
-### Implementation: `is_subtype_of()` {#TYPEINF-SUBTYPING-IMPL}
+### Implementation: `InferredType::is_assignable_to()` {#TYPEINF-SUBTYPING-IMPL}
 
-The current `is_assignable_to()` in `types.rs` handles primitives, containers, unions, optionals, and callables but falls back to name comparison for `Named` types. The full subtyping engine:
+Subtyping is decided by `InferredType::is_assignable_to(&self, other)` in `crates/basilisk-checker/src/types.rs` — a pure structural match over the `InferredType` enum, called on production paths by the compatibility rules (e.g. `rules/assignment_compatibility`, `rules/returns_compatibility`). It implements:
 
-```rust
-fn is_subtype_of(source: &ResolvedType, target: &ResolvedType, ctx: &SubtypeContext) -> bool {
-    match (source, target) {
-        // Nominal: check MRO
-        (Class(src), Class(tgt)) => ctx.mro_contains(src, tgt),
-        // Protocol: structural check
-        (_, Protocol(proto)) => ctx.satisfies_protocol(source, proto),
-        // Generic: variance-aware
-        (Generic(src_base, src_args), Generic(tgt_base, tgt_args)) =>
-            ctx.check_generic_subtype(src_base, src_args, tgt_base, tgt_args),
-        // TypedDict: field-by-field
-        (TypedDict(src), TypedDict(tgt)) => ctx.check_typeddict_compat(src, tgt),
-        // Callable: contravariant params, covariant return
-        (Callable(src), Callable(tgt)) => ctx.check_callable_subtype(src, tgt),
-        // ... other cases
-    }
-}
-```
+- `Any` / `Unknown` bidirectional compatibility and `Never` as bottom ([TYPEINF-SPECIAL-ANY](#TYPEINF-SPECIAL-ANY), [TYPEINF-SPECIAL-NEVER](#TYPEINF-SPECIAL-NEVER)).
+- Partial, literal-level numeric relations: `int` (and `Literal` ints/floats) <: `float`, `Literal[True/False]` <: `bool`/`int`, plus `Literal`/`LiteralString`/`str` relations ([TYPEINF-SUBTYPING-NOMINAL](#TYPEINF-SUBTYPING-NOMINAL), [TYPEINF-SPECIAL-LITERALSTRING](#TYPEINF-SPECIAL-LITERALSTRING)). The full `bool <: int <: float <: complex` tower lives in the annotation-text-level helpers used by the conformance rules.
+- `Optional`/`Union` decomposition: `A | B <: C` iff both sides do; `A <: A | B` ([TYPEINF-SUBTYPING-UNION](#TYPEINF-SUBTYPING-UNION)).
+- Element-assignability (covariant) checks for `list`/`set`/`dict`; fixed-length, homogeneous `tuple[X, ...]`, and PEP 646 unpacked (`*tuple[...]`/`*Ts`) tuple matching ([TYPEINF-SUBTYPING-GENERIC](#TYPEINF-SUBTYPING-GENERIC), [TYPEINF-COLLECTIONS-TUPLES](#TYPEINF-COLLECTIONS-TUPLES)).
+- Callable contravariant parameters / covariant return, with `...` params gradual ([TYPEINF-SUBTYPING-CALLABLE](#TYPEINF-SUBTYPING-CALLABLE)); `TypeForm` covariance.
 
-`SubtypeContext` holds the MRO cache, protocol member tables, and generic variance info needed for recursive subtype checks.
+`Named` types (user classes and unparameterised imports) compare by base name before `[`: `Foo[int]` and `Foo[float]` are treated as compatible. This is deliberate — without whole-program generic variance analysis, stricter matching would emit false positives, and the conformance gate holds `max_false_positives` at zero.
+
+Nominal MRO walking and structural Protocol/TypedDict compatibility are NOT centralized here: they live in the per-conformance-area rule modules (`rules/protocols_*`, `rules/typeddicts_*`, and the class-bases-walking `is_subtype_of` helper in `rules/generics_basic_3/helpers.rs`). There is no shared `SubtypeContext` or MRO cache.
 
 ---
 
@@ -950,9 +942,9 @@ Inference-relevant conformance tests:
 
 Deliberate, distinctive behaviors of Basilisk's inference engine:
 
-### No Unresolved-Type Fallback {#TYPEINF-EXCEEDS-NOUNKNOWN}
+### Conservative `Unknown` Sentinel {#TYPEINF-EXCEEDS-NOUNKNOWN}
 
-Basilisk **never produces an unresolved/`Unknown` type** — every inferred type is either concrete or an error.
+When syntactic RHS inference cannot determine a type (call expressions, `type(...)` calls, arbitrary expressions, lambda return types — `infer_rhs` in `crates/basilisk-checker/src/inference.rs`), it produces the internal sentinel `InferredType::Unknown` (`crates/basilisk-checker/src/types.rs`). `Unknown` is deliberately conservative: `is_assignable_to` treats it as bidirectionally compatible, and rules that encounter it generally suppress their diagnostic rather than guess — an unprovable mismatch is not reported (precision over recall, per [CHKARCH-CONFORMANCE-MODE]). Two deliberate positive-match exceptions exist where an `Unknown`-typed value still fires E0014 (and the word `Unknown` appears in the message): recursive value-alias matching and `TypeForm` RHS validation in `rules/assignment_compatibility` — there, treating `Unknown` as a non-match keeps genuinely incompatible assignments firing. `Unknown` never substitutes for a *required* annotation: missing annotations remain errors (E0001/E0002, see [TYPEINF-REQUIRED](#TYPEINF-REQUIRED)) and `Any` is never inferred as a fallback ([TYPEINF-SPECIAL-ANY](#TYPEINF-SPECIAL-ANY)).
 
 ### Strict Container Inference Always On {#TYPEINF-EXCEEDS-CONTAINERS}
 
@@ -974,15 +966,15 @@ Every missing annotation is an error; silent inference of public-API types is no
 
 ## Implementation Notes {#TYPEINF-IMPL}
 
-The inference engine lives in the `basilisk-checker` crate, using [Salsa](https://github.com/salsa-rs/salsa) for incremental computation. Results are stored as Salsa query results, enabling **sub-10ms incremental re-inference** on single-file changes.
+The inference engine lives in the `basilisk-checker` crate as free functions and per-rule visitors, not named engine structs:
 
-Key components:
+- `src/inference.rs` — RHS expression inference (`infer_rhs`, [TYPEINF-ALGO])
+- `src/collection_inference.rs` — union-of-element-types container inference ([TYPEINF-COLLECTIONS])
+- `src/types.rs` — the `InferredType` model and `is_assignable_to` ([TYPEINF-SUBTYPING-IMPL](#TYPEINF-SUBTYPING-IMPL))
+- `src/types_parsing.rs` — annotation text → `InferredType`
+- Narrowing, overload resolution, and Literal handling are implemented inside the corresponding conformance rule modules (`rules/narrowing_typeguard.rs`, `rules/narrowing_typeis*.rs`, `rules/overloads_*.rs`, `rules/literals_*`).
 
-- **`InferenceEngine`** — top-level bidirectional inference driver
-- **`ConstraintSolver`** — TypeVar constraint collection and solving
-- **`NarrowingEngine`** — flow-sensitive narrowing via control-flow graph
-- **`OverloadResolver`** — 5-step overload resolution per conformance spec
-- **`LiteralFolder`** — Literal type widening/narrowing rules
+Incremental computation is currently a content-hash result cache in `basilisk-db` (`crates/basilisk-db`); the Salsa-backed database is planned Phase 2 work — see [CHKARCH-INCREMENTAL-SALSA](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-INCREMENTAL-SALSA).
 
 ---
 

--- a/docs/specs/LSP-ANALYSIS-MODES-SPEC.md
+++ b/docs/specs/LSP-ANALYSIS-MODES-SPEC.md
@@ -76,10 +76,11 @@ Default: `"wholeModule"`. The user must explicitly opt down to `openFilesOnly`.
 
 Resolution order (highest wins):
 
-1. Editor workspace setting (`basilisk.analysisMode`)
-2. `analysisMode` in `basilisk.json`
-3. `analysisMode` in `[tool.basilisk]` section of `pyproject.toml`
-4. Hard default: `wholeModule`
+1. Editor workspace setting (`basilisk.analysisMode`) — delivered as `initializationOptions.analysisMode` at startup and re-applied at runtime via `workspace/didChangeConfiguration` (top-level `analysisMode` or nested `basilisk.analysisMode`). Editors that always forward a value (the VS Code extension and basilisk.nvim both send their `wholeModule` default) pin the mode from the editor side; clients that send no value (e.g. the Zed extension) fall through to the file tier.
+2. The first parseable config file in the first workspace root, checked in this order: `basilisk.json`, then `pyrightconfig.json` (pyright compatibility), then `pyproject.toml` — `[tool.basilisk]` or, failing that, `[tool.pyright]`. The winning file supplies the entire workspace config: precedence is first-file-wins, NOT per-field merging, so a `basilisk.json` that omits `analysisMode` resolves to the default even if `pyproject.toml` sets one (mirroring [pyright's own whole-file precedence](https://microsoft.github.io/pyright/#/configuration) of `pyrightconfig.json` over `pyproject.toml`).
+3. Hard default: `wholeModule`.
+
+Tier 1 and the fallback are resolved by `resolve_analysis_mode` (`crates/basilisk-lsp/src/workspace_analysis.rs`); the file tier is `load_config` (`crates/basilisk-lsp/src/config.rs`), which the CLI shares.
 
 ---
 
@@ -246,7 +247,7 @@ If the file is open, the event is ignored. Otherwise read from disk; if `source_
 
 ### Debouncing {#ANALYSIS-INCR-DEBOUNCE}
 
-File-watcher events MUST be debounced 150 ms to avoid thrashing during bulk saves. `didChange` events are NOT debounced — latency matters.
+File-watcher events are trailing-debounced 200 ms (`FILE_WATCHER_DEBOUNCE_MS`, `crates/basilisk-lsp/src/server/mod.rs`) to avoid thrashing during bulk saves: each `workspace/didChangeWatchedFiles` batch cancels any pending re-analysis task and schedules a fresh one, so a burst of events triggers work only once it settles. `didChange` events are NOT debounced — latency matters.
 
 ---
 

--- a/docs/specs/LSP-ARCHITECTURE-SPEC.md
+++ b/docs/specs/LSP-ARCHITECTURE-SPEC.md
@@ -175,27 +175,45 @@ Enforced by the toolbar contract tests in `vscode-extension/src/test/suite/activ
 
 | Notification | Direction | Params | Description |
 |-------------|-----------|--------|-------------|
-| `basilisk/moduleChanged` | Server → Client | `{module: ModuleNode}` | Sent when a module's symbol table changes after re-analysis. Debounced at 300ms. |
+| `basilisk/moduleChanged` | Server → Client | `{module: {name, path, kind, symbols}}` | Sent when a module's symbol table changes after re-analysis. Debounced at 300ms. Carries a partial `ModuleNode` — no folded health fields; clients refetch via `basilisk.workspaceModules` for rollups. |
 
 ### Data Model Types {#LSPARCH-DATAMODEL}
 
+The wire shapes below are the shipped contract, consumed field-for-field by the
+VS Code extension (`module-explorer.ts`), basilisk.nvim (`type_health.lua`), and
+the Zed slash commands. Source of truth: `crates/basilisk-lsp/src/server/activity_panel/`
+(`module_tree.rs`, `type_health.rs`, `helpers.rs`). Panel-rendering semantics live in
+[EXTACT-DATA-MODEL](EXTENSION-ACTIVITY-PANEL-SPEC.md#EXTACT-DATA-MODEL).
+
 ```typescript
-/** A node in the workspace module tree. */
+/**
+ * A module entry. `basilisk.workspaceModules` returns a FLAT list sorted by
+ * name; clients rebuild the package hierarchy from dotted names
+ * ([EXTACT-MODULES-TREE-STRUCTURE]).
+ */
 interface ModuleNode {
     name: string;              // Fully qualified module name (e.g. "mypackage.utils")
     path: string;              // Absolute filesystem path to the module file or __init__.py
-    kind: "package" | "module";
-    children: ModuleNode[];    // Sub-modules (non-empty only for packages)
-    symbols: SymbolNode[];     // Top-level symbols exported by this module
+    kind: "package" | "module";  // "package" iff the file is __init__.py/__init__.pyi
+    symbols: SymbolNode[];     // Top-level symbols in this module
+    // Folded per-module health rollup (single source: compute_file_health):
+    coveragePercent: number;   // annotated/total * 100, rounded; 100 when the module has no symbols
+    errors: number;            // 0 when type checking is disabled ([ANALYSIS-ENABLED], #119)
+    warnings: number;          // ditto
+    adopted: boolean;          // file is in adopted (errors-as-warnings) mode
 }
 
-/** A symbol within a module (function, class, or variable). */
+/** A symbol within a module. */
 interface SymbolNode {
     name: string;
-    kind: "function" | "class" | "variable";
-    type: string | null;       // Inferred or annotated type signature, null if unresolved
+    kind: "function" | "class" | "variable" | "constant";
+                               // "constant" = module var whose name chars are all
+                               //   uppercase/underscore (digit-bearing names emit "variable")
     line: number;              // 0-based line number of the definition
-    children: SymbolNode[];    // Nested symbols (e.g. methods inside a class)
+    annotated: boolean;        // functions: all params + return annotated (methods exclude
+                               //   self/cls); vars/attrs: annotation present; classes: always true
+    exported: boolean;         // reserved for __all__ tracking; currently always false
+    children?: SymbolNode[];   // present on class nodes only (methods + attributes, sorted by line)
 }
 
 /**
@@ -211,16 +229,30 @@ interface WorkspaceModulesResponse {
 /** Aggregate health statistics for a scope (workspace or single module). */
 interface HealthStats {
     totalSymbols: number;      // Total symbols in scope
-    typedSymbols: number;      // Symbols with a resolved type annotation
-    coveragePercent: number;   // (typedSymbols / totalSymbols) * 100, 0 when totalSymbols == 0
-    errorCount: number;        // Number of BSK-E* diagnostics
-    warningCount: number;      // Number of BSK-W* diagnostics
+    annotatedSymbols: number;  // Symbols counted as annotated (see SymbolNode.annotated)
+    coveragePercent: number;   // (annotatedSymbols / totalSymbols) * 100; 100 when
+                               //   totalSymbols == 0 (clients branch on totalFiles == 0
+                               //   for the empty state, #57)
+    errors: number;            // Number of BSK-E* diagnostics
+    warnings: number;          // Number of BSK-W* diagnostics
+    adoptedFiles: number;      // Files with >= 1 demoted diagnostic
+    totalFiles: number;        // In workspaceModules this counts ALL indexed files,
+                               //   regardless of the scope filter
 }
 
-/** Per-module health breakdown. */
+/**
+ * Per-module health breakdown (`TypeHealthResponse.modules` entry), sorted
+ * ascending by coveragePercent — worst first. Unlike `basilisk.workspaceModules`,
+ * typeHealth errors/warnings are NOT gated on type checking being enabled.
+ */
 interface ModuleHealth {
-    module: string;            // Fully qualified module name
-    stats: HealthStats;
+    name: string;              // Fully qualified module name
+    path: string;              // Absolute filesystem path
+    coveragePercent: number;
+    errors: number;
+    warnings: number;
+    adopted: boolean;
+    unannotated: string[];     // Names of unannotated symbols (quick-fix suggestions)
 }
 
 /** Response from `basilisk.typeHealth`. */
@@ -403,7 +435,7 @@ Whole-word text scan with word boundary checks, filtering strings/comments. Resp
 
 ### Rename Symbol (`textDocument/prepareRename` + `textDocument/rename`) {#LSPARCH-FEATURES-RENAME}
 
-Validates symbol is renameable, returns `WorkspaceEdit` with `TextEdit` for each occurrence. Single-file scope.
+`prepareRename` returns the identifier range + placeholder when the cursor is on a renameable symbol, `null` otherwise; the new name itself is validated in `rename` (`scope_tree::validate_rename`). `rename` returns a workspace-wide `WorkspaceEdit` built in two halves: (1) a scope-aware single-file core (`references::rename_symbol`) that renames every occurrence in the current file respecting lexical scoping (shadowed bindings untouched) and also updates keyword-argument call sites and docstring references when renaming a parameter, `self.attr` references when renaming a class attribute, and `__all__` entries when renaming a module-level symbol; (2) a cross-file half ([ANALYSIS-CROSSLSP-RENAME](LSP-ANALYSIS-MODES-SPEC.md#ANALYSIS-CROSSLSP-RENAME), [REFACTOR-RENAME](LSP-REFACTORING-SPEC.md#REFACTOR-RENAME)) that walks the import graph to also rename the symbol in every importer of the current file and — when the cursor symbol is itself imported — at its source-definition file. The cross-file half is gated on `crossModule` analysis; without it rename degrades gracefully to single-file.
 
 ### Completion (`textDocument/completion`) {#LSPARCH-FEATURES-COMPLETION}
 

--- a/docs/specs/LSP-MASS-AUTOFIX-SPEC.md
+++ b/docs/specs/LSP-MASS-AUTOFIX-SPEC.md
@@ -78,12 +78,14 @@ Exposed through:
 
 ### Conflict Resolution {#AUTOFIX-CONFLICTS}
 
-When multiple fixes target overlapping text ranges in the same file:
+When multiple fixes produce overlapping text edits in the same file (`collect_non_overlapping_edits`, `crates/basilisk-lsp/src/code_actions/mass_fix.rs`):
 
-1. Fixes are sorted by start position (ascending).
-2. If two fixes overlap, the **safer** fix wins. If same safety, the **earlier-registered** fix wins.
-3. The losing fix is skipped and reported as "skipped due to conflict".
-4. After applying all non-conflicting fixes, diagnostics are re-evaluated. Skipped fixes may become applicable on the next pass.
+1. Candidate edits are sorted by start position (line, then character), ascending.
+2. Edits are accepted greedily in that order; an edit whose range overlaps the previously accepted edit is skipped. Resolution is purely positional — safety is never compared at this stage. With the shipped fix set, Safe and Unsafe fixes cannot produce overlapping edits: all fixes except BSK-W0050's annotation removal are zero-width inserts targeting mutually exclusive constructs.
+3. Skipped edits are silently dropped from the batch — they are not applied and not itemised in the result.
+4. Re-evaluation happens through the normal check loop rather than an internal second pass: in the editor, applying the `WorkspaceEdit` triggers a re-check that re-publishes remaining diagnostics (and their fixes); on the CLI, `basilisk fix` is idempotent and a re-run applies any fix that became applicable.
+
+Safety scoping is the caller's concern, upstream of conflict resolution: the CLI filters to safe-only by default (`--unsafe` / `--rules` / `all` widen it), while the LSP fix-all commands currently operate on all fixable rules.
 
 ### Undo {#AUTOFIX-UNDO}
 

--- a/docs/specs/LSP-TEST-INTEGRATION-SPEC.md
+++ b/docs/specs/LSP-TEST-INTEGRATION-SPEC.md
@@ -159,11 +159,11 @@ pub fn build_test_command(
 
 The `PackageRegistry` (built from `uv.lock`) enables test dependency diagnostics:
 
-| Condition | Diagnostic | Severity | Code Action |
-|-----------|-----------|----------|-------------|
-| pytest not in `uv.lock` | `Test runner \"pytest\" is not installed. Run \"uv add --dev pytest\" to install.` | Warning | `basilisk.uv.addDev` with `pytest` |
-| `pytest-cov` not in `uv.lock` (coverage requested) | `Coverage plugin \"pytest-cov\" is not installed.` | Info | `basilisk.uv.addDev` with `pytest-cov` |
-| Test imports unresolved package | Standard imports_unresolved with uv context (see [LSP-UV-INTEGRATION-SPEC.md §5](LSP-UV-INTEGRATION-SPEC.md)) | Error | `basilisk.uv.add` |
+| Condition | Diagnostic | Severity | Code | Code Action |
+|-----------|-----------|----------|------|-------------|
+| pytest not in `uv.lock` | `Test runner \"pytest\" is not installed. Run \"uv add --dev pytest\" to install.` | Warning | `BSK-W0015` | `basilisk.uv.addDev` with `pytest` |
+| `pytest-cov` not in `uv.lock` (coverage requested) | `Coverage plugin \"pytest-cov\" is not installed.` | Info | — | `basilisk.uv.addDev` with `pytest-cov` |
+| Test imports unresolved package | Standard imports_unresolved with uv context (see [LSP-UV-INTEGRATION-SPEC.md §5](LSP-UV-INTEGRATION-SPEC.md)) | Error | — | `basilisk.uv.add` |
 
 These diagnostics are only emitted in uv projects and respect the existing `basilisk.uv.enabled` setting.
 

--- a/docs/specs/LSP-UV-INTEGRATION-SPEC.md
+++ b/docs/specs/LSP-UV-INTEGRATION-SPEC.md
@@ -28,22 +28,18 @@ A workspace is a uv project if **any** of these are true (checked in order):
 
 ### 2.2 Detection Result {#LSPUV-DETECTION-RESULT}
 
-```rust
-pub enum EnvironmentManager {
-    Uv(UvProjectInfo),
-    TraditionalVenv,
-    NoEnvironment,
-}
+`basilisk_uv::detect_uv_project(workspace_roots: &[PathBuf]) -> Option<UvProjectInfo>` scans the roots in order and returns info for the first directory matching a [detection signal](#LSPUV-DETECTION-SIGNALS); `None` means "not a uv project".
 
+```rust
 pub struct UvProjectInfo {
-    pub project_root: PathBuf,
-    pub lock_file: Option<PathBuf>,          // uv.lock
-    pub pyproject: PathBuf,                  // pyproject.toml
-    pub python_version_file: Option<PathBuf>, // .python-version
-    pub venv_dir: Option<PathBuf>,           // .venv
-    pub workspace: Option<UvWorkspaceInfo>,  // if [tool.uv.workspace] present
+    pub root: PathBuf,          // matched workspace root
+    pub has_lockfile: bool,     // uv.lock exists at root
+    pub has_tool_uv: bool,      // pyproject.toml contains [tool.uv]
+    pub uv_managed_venv: bool,  // .venv/pyvenv.cfg contains `uv = true`
 }
 ```
+
+The result carries the raw boolean signals, not resolved paths — consumers derive paths from `root` (e.g. `root.join("uv.lock")` in the `build_uv_registry` functions in `crates/basilisk-lsp/src/server/init.rs` and `crates/basilisk-cli/src/main.rs`). Workspace members ([LSPUV-WORKSPACE-MODEL](#LSPUV-WORKSPACE-MODEL)), `.python-version` resolution ([LSPUV-PYTHON-VERSION](#LSPUV-PYTHON-VERSION)), and venv discovery ([LSPUV-DETECTION-FALLBACK](#LSPUV-DETECTION-FALLBACK)) are separate call paths, not fields on the detection result. There is no `EnvironmentManager` enum: `Option<UvProjectInfo>` is the whole environment-manager decision — `Some` enables the additive uv features (lock-file registry, uv-run test execution, uv status); `None` only skips them, and venv discovery via `find_venv_dir()` runs either way.
 
 ### 2.3 Fallback {#LSPUV-DETECTION-FALLBACK}
 
@@ -119,12 +115,13 @@ When `uv.lock` changes (LSP file watcher or `workspace/didChangeWatchedFiles`): 
 
 Highest wins:
 
-1. `basilisk.python` setting (explicit user override — always wins)
-2. `.python-version` file in workspace root (uv standard)
-3. `[project].requires-python` in `pyproject.toml` (lower bound)
-4. `uv.lock` top-level `requires-python` field
-5. Probe `python3 --version` in the detected venv
-6. Default: `3.12`
+1. Explicit `python-version` in project config (`[tool.basilisk] python-version` in `pyproject.toml`, or `pythonVersion`/`python-version` in `basilisk.json`) — always wins
+2. `.python-version` file in the project root (uv standard; first non-empty, non-comment line)
+3. `[project].requires-python` in `pyproject.toml` — lower bound of the first `>=`/`==`/`~=` clause
+4. `uv.lock` top-level `requires-python` — same lower-bound extraction
+5. Default: `3.12` (the checker's centralized `DEFAULT_TARGET_VERSION`, [`[CHKARCH-VERSION-TARGET]`](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-VERSION-TARGET))
+
+Steps 2–4 are `basilisk_uv::python_version::resolve_target_python_version`; step 1 and the default belong to the consumers (`WorkspaceIndex::load_root_configs`, CLI `main.rs`, `CheckContext::from_config`). Resolution reads declared project metadata only — Basilisk deliberately never probes the venv interpreter (`python3 --version`): the resolved target stays deterministic across machines (a venv built with a different interpreter does not silently shift checker semantics) and version resolution adds no subprocess spawn. The `basilisk.python` VS Code setting is the interpreter *path* for the debugger/profiler and plays no role in version resolution.
 
 ### 4.2 Impact on Type Checking {#LSPUV-PYTHON-VERSION-IMPACT}
 
@@ -189,7 +186,7 @@ error[BSK-E0152]: Package `acme_internal` is installed but has no type stubs ava
 
 Per [STUBRES-CODEACTIONS](CHECKER-STUB-RESOLUTION-SPEC.md#STUBRES-CODEACTIONS) the help describes the fix and never embeds a shell command — the code action does the work. `help`/`note` lines are folded onto the LSP diagnostic message so editors (no `help`/`note` fields) still surface the guidance.
 
-The typeshed stub suggestion (and its `basilisk.uv.addDev` quick fix) is emitted only when: the package IS in `uv.lock`; a matching stub package exists (`types-{name}` or `{name}-stubs`); and the stub is NOT already in `uv.lock`.
+The typeshed stub suggestion (and its `basilisk.uv.addDev` quick fix) is emitted only when the bundled typeshed index (`basilisk_stubs::typeshed_stub_distribution` — a committed TSV regenerated from python/typeshed's `stubs/<DIST>` tree, `crates/basilisk-stubs/data/typeshed_stub_distributions.tsv`, compiled into a phf map by `build.rs`) maps the import root to a real published `types-<DIST>` distribution (e.g. `yaml` → `types-PyYAML`). Stub names are never guessed by string concatenation — neither `types-{name}` nor `{name}-stubs` — so the quick fix never offers a package that does not exist on PyPI. The "stub already installed" case needs no lockfile check: an installed stub-only package (a `{name}-stubs` directory in site-packages — the install form of both typeshed `types-*` distributions and third-party stub packages such as `pandas-stubs`) resolves first in the PEP 561 order ([STUBRES-PEP561](CHECKER-STUB-RESOLUTION-SPEC.md#STUBRES-PEP561) step 3), so the import no longer resolves to an untyped `.py` and BSK-E0152 does not fire at all.
 
 The **create-local-stub** quick fix (`basilisk.stubs.createLocal`, [STUBRES-CREATE-LOCAL](CHECKER-STUB-RESOLUTION-SPEC.md#STUBRES-CREATE-LOCAL)) is offered for **every** BSK-E0152 — the only fix when no typeshed stub exists, a fallback when one does.
 

--- a/models/debug_session.td
+++ b/models/debug_session.td
@@ -1,0 +1,16 @@
+# typeDiagram model - https://typediagram.dev
+# Source-of-truth model for LSP debug-session failures (LSPDEBUG-ERRORS).
+# Implemented by DebugError in crates/basilisk-lsp/src/debug.rs, whose
+# jsonrpc_code() maps each variant to a JSON-RPC error code:
+#   DebugpyNotFound -> -32001, PythonNotFound -> -32002, all others -> -32000.
+# io payloads are std::io::Error in Rust; modelled as String (opaque) here.
+# Regenerate the diagram: typediagram models/debug_session.td > docs/models/debug_session.svg
+
+union DebugError {
+  PortAllocation { io: String }
+  SpawnFailed { io: String }
+  Timeout { port: Int }
+  AdapterExited { status: String }
+  DebugpyNotFound { python: String }
+  PythonNotFound { searched: String }
+}

--- a/models/uv_detection.td
+++ b/models/uv_detection.td
@@ -1,0 +1,13 @@
+# typeDiagram model - https://typediagram.dev
+# Source-of-truth model for uv-project detection (LSPUV-DETECTION-RESULT).
+# Implemented by UvProjectInfo in crates/basilisk-uv/src/detect.rs
+# (root is a PathBuf there; modelled as String here since paths are language-neutral).
+# Regenerate the diagram: typediagram models/uv_detection.td > docs/models/uv_detection.svg
+
+type UvProjectInfo {
+  root: String
+  has_lockfile: Bool
+  has_tool_uv: Bool
+  uv_managed_venv: Bool
+  has_python_version: Bool
+}

--- a/scripts/test-nvim.sh
+++ b/scripts/test-nvim.sh
@@ -13,12 +13,19 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$REPO_ROOT/scripts/common.sh"
 cd "$REPO_ROOT"
 
-# Find or build the basilisk binary.
-BASILISK_BIN=$(find_basilisk_bin) || {
+# Find or build the basilisk binary. When no explicit binary is provided, build
+# a fresh non-coverage CLI so local `make ci` does not reuse test-rust's
+# coverage-instrumented target/ci artifact.
+if [[ -z "${BASILISK_BIN:-}" ]]; then
     header "Building basilisk binary"
-    cargo build --profile ci
+    cargo build --profile ci --bin basilisk
     BASILISK_BIN="$REPO_ROOT/target/ci/basilisk"
-}
+else
+    BASILISK_BIN=$(find_basilisk_bin) || {
+        echo -e "${RED}${BOLD}FATAL: configured basilisk binary not found.${RESET}"
+        exit 1
+    }
+fi
 if [[ ! -x "$BASILISK_BIN" ]]; then
     echo -e "${RED}${BOLD}FATAL: basilisk binary not found.${RESET}"
     exit 1

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -11,24 +11,24 @@
       "dependencies": {
         "@nimblesite/shipwright-vscode": "^0.10.0",
         "@preact/signals-core": "^1.14.3",
-        "vscode-languageclient": "^10.0.0"
+        "vscode-languageclient": "^10.0.1"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
-        "@types/node": "^26.0.0",
+        "@types/node": "^26.0.1",
         "@types/vscode": "^1.99.0",
-        "@typescript-eslint/eslint-plugin": "^8.61.1",
-        "@typescript-eslint/parser": "^8.61.1",
-        "@vscode/test-cli": "^0.0.12",
+        "@typescript-eslint/eslint-plugin": "^8.62.0",
+        "@typescript-eslint/parser": "^8.62.0",
+        "@vscode/test-cli": "^0.0.15",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
-        "eslint": "^10.5.0",
+        "eslint": "^10.6.0",
         "glob": "^13.0.6",
         "mocha": "^11.7.6",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.61.1"
+        "typescript-eslint": "^8.62.0"
       },
       "engines": {
         "vscode": "^1.99.0"
@@ -401,9 +401,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -827,9 +827,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -858,17 +858,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
-      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/type-utils": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -881,22 +881,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.1",
+        "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
-      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -912,14 +912,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
-      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.1",
-        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -934,14 +934,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
-      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
-      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -969,15 +969,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
-      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -994,9 +994,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
-      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1008,16 +1008,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
-      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.1",
-        "@typescript-eslint/tsconfig-utils": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1036,16 +1036,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
-      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1060,13 +1060,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
-      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/types": "8.62.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1106,45 +1106,27 @@
       }
     },
     "node_modules/@vscode/test-cli": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@vscode/test-cli/-/test-cli-0.0.12.tgz",
-      "integrity": "sha512-iYN0fDg29+a2Xelle/Y56Xvv7Nc8Thzq4VwpzAF/SIE6918rDicqfsQxV6w1ttr2+SOm+10laGuY9FG2ptEKsQ==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@vscode/test-cli/-/test-cli-0.0.15.tgz",
+      "integrity": "sha512-nAxk2X79wuXS7aOhyFFhFcCqd7EBUoMesu7ZgsYE/4eFjyBMuyIweVE94BxdKH1RieN8eOz2SIrljrZt6Lk9fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^10.0.10",
-        "c8": "^10.1.3",
-        "chokidar": "^3.6.0",
-        "enhanced-resolve": "^5.18.3",
-        "glob": "^10.3.10",
-        "minimatch": "^9.0.3",
-        "mocha": "^11.7.4",
+        "c8": "^11.0.0",
+        "chokidar": "^5.0.0",
+        "enhanced-resolve": "^5.24.0",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.5",
+        "mocha": "^11.7.6",
         "supports-color": "^10.2.2",
-        "yargs": "^17.7.2"
+        "yargs": "^18.0.0"
       },
       "bin": {
         "vscode-test": "out/bin.mjs"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vscode/test-cli/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/test-cli/node_modules/ansi-styles": {
@@ -1160,152 +1142,71 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@vscode/test-cli/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/@vscode/test-cli/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@vscode/test-cli/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@vscode/test-cli/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vscode/test-cli/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/@vscode/test-cli/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@vscode/test-cli/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vscode/test-cli/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@vscode/test-cli/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@vscode/test-cli/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1325,21 +1226,49 @@
       }
     },
     "node_modules/@vscode/test-cli/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@vscode/test-cli/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/@vscode/test-electron": {
@@ -1664,20 +1593,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1741,19 +1656,6 @@
       ],
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/binaryextensions": {
       "version": "6.11.0",
@@ -1899,9 +1801,9 @@
       }
     },
     "node_modules/c8": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-10.1.3.tgz",
-      "integrity": "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
+      "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1912,7 +1814,7 @@
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.1.6",
-        "test-exclude": "^7.0.1",
+        "test-exclude": "^8.0.0",
         "v8-to-istanbul": "^9.0.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1"
@@ -1921,7 +1823,7 @@
         "c8": "bin/c8.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": "20 || >=22"
       },
       "peerDependencies": {
         "monocart-coverage-reports": "^2"
@@ -2521,14 +2423,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
+      "integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -2633,9 +2535,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -3067,21 +2969,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3466,19 +3353,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -4572,16 +4446,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -5881,9 +5745,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5964,180 +5828,18 @@
       }
     },
     "node_modules/test-exclude": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
-      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
-        "glob": "^10.4.1",
+        "glob": "^13.0.6",
         "minimatch": "^10.2.2"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/test-exclude/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/test-exclude/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
-    "node_modules/test-exclude/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/test-exclude/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/test-exclude/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": "20 || >=22"
       }
     },
     "node_modules/text-table": {
@@ -6331,16 +6033,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
-      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.1",
-        "@typescript-eslint/parser": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1"
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6481,14 +6183,14 @@
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0.tgz",
-      "integrity": "sha512-3yRHFkktZQCCg8ehHnD2Z4DZ4mZ17FNo8bxM4OFt8wtpxNBAOZGHmpbIflZSkicvCxi+ozuWntbdeWiY0gP77w==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.1.tgz",
+      "integrity": "sha512-kXitJTQVKfv69/TY0LnQdsSMaqzRaeoJMMic+B6ad7HLtFPO46MLxpNjnFh1KF1nOhZUoLX+6e+JoIl+Jp3ycQ==",
       "license": "MIT",
       "dependencies": {
         "minimatch": "^10.2.5",
         "semver": "^7.8.1",
-        "vscode-languageserver-protocol": "3.18.0",
+        "vscode-languageserver-protocol": "3.18.1",
         "vscode-languageserver-textdocument": "1.0.13"
       },
       "engines": {
@@ -6496,9 +6198,9 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
-      "integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.1.tgz",
+      "integrity": "sha512-RTiiVHdpxpYcJVI5sq6S5TLjQ4WDR/rBrIWru+kPXe6sGQ9PFQ3GamrTKLvPqbR4ylr1SoodhmcqbFII0WXVuw==",
       "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "9.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -985,24 +985,24 @@
   "dependencies": {
     "@nimblesite/shipwright-vscode": "^0.10.0",
     "@preact/signals-core": "^1.14.3",
-    "vscode-languageclient": "^10.0.0"
+    "vscode-languageclient": "^10.0.1"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.0.1",
     "@types/vscode": "^1.99.0",
-    "@typescript-eslint/eslint-plugin": "^8.61.1",
-    "@typescript-eslint/parser": "^8.61.1",
-    "@vscode/test-cli": "^0.0.12",
+    "@typescript-eslint/eslint-plugin": "^8.62.0",
+    "@typescript-eslint/parser": "^8.62.0",
+    "@vscode/test-cli": "^0.0.15",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "glob": "^13.0.6",
     "mocha": "^11.7.6",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.61.1"
+    "typescript-eslint": "^8.62.0"
   },
   "overrides": {
     "serialize-javascript": "^7.0.6"

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@11ty/eleventy": "^3.1.6",
         "@playwright/test": "^1.61.1",
-        "@types/node": "^26.0.0",
+        "@types/node": "^26.0.1",
         "eleventy-plugin-techdoc": "^0.2.0",
         "markdown-it": "^14.2.0"
       }
@@ -667,9 +667,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@11ty/eleventy": "^3.1.6",
     "@playwright/test": "^1.61.1",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.0.1",
     "eleventy-plugin-techdoc": "^0.2.0",
     "markdown-it": "^14.2.0"
   }

--- a/website/src/_data/conformance_report.json
+++ b/website/src/_data/conformance_report.json
@@ -3,9 +3,9 @@
   "upstream": {
     "repo": "python/typing",
     "ref": "main",
-    "sha": "f6e2e588880a057a939cee76c6c919aebd4db37c",
-    "shortSha": "f6e2e58",
-    "commitDate": "2026-06-23",
+    "sha": "c94dfceff0af70c6626a1f86bc8f979135ae4652",
+    "shortSha": "c94dfce",
+    "commitDate": "2026-07-01",
     "stale": false
   },
   "calculator": {


### PR DESCRIPTION
## TLDR
Aligns uv diagnostics, debug-session error handling, CI pins, and specs/docs with the shipped behavior while keeping the conformance gate at 100%.

## What Was Added?
- Adds the `.python-version` uv-project detection signal on `UvProjectInfo`, guarded against Poetry/Pipenv lockfiles.
- Adds dedicated pytest-missing diagnostic code `BSK-W0015` with the existing `basilisk.uv.addDev pytest` quick fix path.
- Adds `DebugError::jsonrpc_code()` plus source typeDiagram models and generated SVGs for debug errors and uv detection.
- Adds CI caching for downloaded conformance fixtures.

## What Was Changed or Deleted?
- Maps debug startup failures through the concrete `DebugError` variant so missing debugpy, missing Python, and transport failures use distinct JSON-RPC codes.
- Documents and enforces the typeshed-index based stub quick fix path instead of guessing stub package names.
- Updates CI/release action pins, package locks, and Rust/npm dependency versions.
- Makes `scripts/test-nvim.sh` build a fresh non-coverage CLI when `BASILISK_BIN` is not provided, so local `make ci` does not reuse the coverage-instrumented `target/ci` binary.
- Refreshes the conformance stamp to `python/typing@c94dfce` with 141/141 files passing and 0 false positives.

## How Do The Automated Tests Prove It Works?
- Full local `make ci` completed green after the Neovim script change, including lint, dependency audit, Rust coverage, VSIX/E2E, Neovim E2E, release build, and VS Code compile stages.
- `scripts/test-rust.sh` scored the official conformance suite at 141/141 files passing, 100.0%, 970 required errors caught, 0 missed, and 0 false positives.
- VS Code E2E reported 455 passing / 6 pending with extension coverage at 93% against the 87% threshold.
- Neovim E2E reported 16/16 spec files, 16 summaries, 0 failed, 0 errored; screenshot regressions passed; Neovim coverage was 44% against the 39% threshold.
- Mutation shards merged at 124 total mutants, 117 caught, 7 unviable, 0 missed/timeouts, for a 100.0% kill rate matching the baseline.

## Spec / Doc Changes
- Updates README, website conformance data, checker/LSP specs, and the conformance audit plan to the current conformance commit and shipped behavior.
- Documents uv detection, Python-version resolution, pytest diagnostic code `BSK-W0015`, mass autofix conflict behavior, analysis mode precedence/debounce, module/rename wire contracts, and type-inference limitations.
- Adds source and rendered model diagrams for debug-session failures and uv detection.

## Breaking Changes
- [x] None
