### PR TITLE
LSP-owned formatting architecture (embedded Ruff, no subprocess) + inlay-hint regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,29 @@ permissions:
 
 jobs:
   # ── Change-scope gate ──────────────────────────────────────────────────────
-  # Website + benchmark assets are static-site data that deploy via
-  # deploy-pages.yml and never enter the Rust toolchain. A PR touching ONLY them
-  # has no reason to run the (long, expensive) Rust/extension/mutation matrix, so
-  # this job classifies the diff and every heavy job below gates on `code`. A job
-  # skipped via `if:` reports as success, so required status checks stay green on
-  # a docs-only PR. Website-only PRs instead get the fast `website` build check.
+  # Classify the diff and run ONLY the jobs whose inputs actually changed. A job
+  # skipped via `if:` reports as success, so required status checks stay green
+  # whatever the scope. The flags:
+  #   core    — the Rust the `basilisk` binary is built from (crates, Cargo.*,
+  #             conformance, scripts, root configs). Runs the full Rust matrix
+  #             AND all three editor extensions, because each one executes that
+  #             binary, so a checker/LSP change can change their behaviour.
+  #   vscode  — vscode-extension/** only → the VS Code job (+ shipwright gate).
+  #   nvim    — basilisk.nvim/** only → the Neovim job.
+  #   zed     — basilisk-zed/** only → the Zed job.
+  #   website — static-site sources → the fast site build check (deploy-pages.yml
+  #             does the real deploy post-merge; this catches breakage pre-merge).
+  #   code    — union of core|vscode|nvim|zed, for whole-repo jobs (lint/deslop).
+  # A PR touching ONLY docs/website/CI-YAML starts no code job at all.
   changes:
     name: Detect change scope
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
+      core: ${{ steps.classify.outputs.core }}
+      vscode: ${{ steps.classify.outputs.vscode }}
+      nvim: ${{ steps.classify.outputs.nvim }}
+      zed: ${{ steps.classify.outputs.zed }}
       code: ${{ steps.classify.outputs.code }}
       website: ${{ steps.classify.outputs.website }}
     steps:
@@ -57,15 +69,24 @@ jobs:
           # heavy matrix would only burn minutes on a bump we discard. CI runs
           # once, on the consolidation PR. ([GITHUB-DEPENDABOT])
           if [ "$ACTOR" = "dependabot[bot]" ]; then
-            echo "code=false"    >> "$GITHUB_OUTPUT"
-            echo "website=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "core=false"
+              echo "vscode=false"
+              echo "nvim=false"
+              echo "zed=false"
+              echo "code=false"
+              echo "website=false"
+            } >> "$GITHUB_OUTPUT"
             echo "Dependabot PR — skipping Rust/extension matrix and website build."
             exit 0
           fi
           base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
           changed="$(git diff --name-only "$base" "$HEAD_SHA")"
           echo "Changed files:"; printf '%s\n' "$changed"
-          code=false
+          core=false
+          vscode=false
+          nvim=false
+          zed=false
           website=false
           while IFS= read -r f; do
             [ -z "$f" ] && continue
@@ -81,23 +102,41 @@ jobs:
               # them re-runs the website job's stamp drift guard.
               README.md|README.zh.md|docs/specs/CHECKER-ARCHITECTURE-SPEC.md) website=true ;;
             esac
-            # `code` gates the heavy Rust/extension/mutation matrix. Everything
-            # that never reaches the Rust toolchain is excluded: the whole site,
-            # ALL benchmark tooling (run.sh, fixtures, CSVs), docs/markdown, and
-            # CI/workflow YAML itself (changing orchestration doesn't change Rust
-            # — the edited workflow already runs on this very PR). Touch anything
-            # else (crates, Cargo.*, scripts, extensions) and the matrix runs.
+            # Route each changed path to the NARROWEST code scope that needs it.
+            # Pure docs / static site / benchmark tooling / CI YAML never reach a
+            # code toolchain and start no code job (changing orchestration does
+            # not change Rust — the edited workflow already runs on this very PR).
+            # Each editor-extension tree triggers ONLY its own job. Everything
+            # else — crates, Cargo.*, conformance, scripts, root configs — is the
+            # core Rust the `basilisk` binary is built from; it re-runs the whole
+            # Rust matrix AND all three editor extensions, because each one
+            # executes that binary and a checker/LSP change alters its behaviour.
             case "$f" in
               website/*|benchmarks/*|docs/*|.github/*|*.md) ;;
-              *) code=true ;;
+              vscode-extension/*) vscode=true ;;
+              basilisk.nvim/*)    nvim=true ;;
+              basilisk-zed/*)     zed=true ;;
+              *)                  core=true ;;
             esac
           done <<< "$changed"
           # An empty diff (e.g. re-run on a merged ref) defaults to full CI.
-          [ -z "$changed" ] && code=true
-          echo "code=$code"       >> "$GITHUB_OUTPUT"
-          echo "website=$website" >> "$GITHUB_OUTPUT"
-          echo "Run Rust/extension matrix (code): $code"
-          echo "Run website build check (website): $website"
+          [ -z "$changed" ] && core=true
+          # `code` is the union for whole-repo jobs (lint runs clippy + eslint +
+          # the repo-wide deslop gate, so any code change must run it).
+          code=false
+          if [ "$core" = true ] || [ "$vscode" = true ] || \
+             [ "$nvim" = true ] || [ "$zed" = true ]; then
+            code=true
+          fi
+          {
+            echo "core=$core"
+            echo "vscode=$vscode"
+            echo "nvim=$nvim"
+            echo "zed=$zed"
+            echo "code=$code"
+            echo "website=$website"
+          } >> "$GITHUB_OUTPUT"
+          echo "Scope — core:$core vscode:$vscode nvim:$nvim zed:$zed code:$code website:$website"
 
   # ── Website build check (only when site/benchmark files change) ─────────────
   # Mirrors deploy-pages.yml's build so a broken template/data file is caught
@@ -216,7 +255,9 @@ jobs:
   zed:
     name: Zed Extension
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Its own tree, or any core change — the distribution mirror vendors
+    # basilisk-common, so a core crate change must re-render + rebuild it.
+    if: needs.changes.outputs.core == 'true' || needs.changes.outputs.zed == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -262,7 +303,7 @@ jobs:
   test-rust:
     name: Rust Tests & Coverage
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.core == 'true'
     # llvm-cov instruments and compiles the whole workspace before running every
     # target — CPU-bound, so it rides BIG_RUNNER too (see the mutation job for
     # the opt-in contract). Falls back to the standard runner when unset.
@@ -326,7 +367,9 @@ jobs:
   test-vscode:
     name: VS Code Extension
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Its own tree, or any core change — the e2e suite builds + runs the real
+    # release binary, so a checker/LSP change alters what this suite exercises.
+    if: needs.changes.outputs.core == 'true' || needs.changes.outputs.vscode == 'true'
     runs-on: ubuntu-24.04
     # TIMEOUT EXCEPTION: VS Code extension e2e tests launch a full VS Code instance via xvfb, requiring ~25 min
     timeout-minutes: 35
@@ -390,7 +433,9 @@ jobs:
   verify-binaries:
     name: Shipwright Binary Gate
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Core builds the binaries this gate version-checks; vscode-extension owns
+    # the shipwright manifest + package.json version it verifies against them.
+    if: needs.changes.outputs.core == 'true' || needs.changes.outputs.vscode == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -437,7 +482,9 @@ jobs:
   test-nvim:
     name: Neovim Extension
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Its own tree, or any core change — the e2e harness drives the real binary
+    # over LSP/DAP, so a checker/LSP change alters what this suite exercises.
+    if: needs.changes.outputs.core == 'true' || needs.changes.outputs.nvim == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -495,22 +542,22 @@ jobs:
     # collapses the matrix to the literal, unexpanded "… ${{ matrix.label }}", so
     # the four required contexts never report and branch protection blocks the PR
     # forever. Instead the matrix always expands and every step is gated on
-    # `code`: when a PR is site/docs/config-only the steps no-op and each shard
+    # `core`: when a PR touches no core Rust the steps no-op and each shard
     # reports success in seconds, satisfying the required checks at ~zero cost.
     env:
-      RUN: ${{ needs.changes.outputs.code }}
+      RUN: ${{ needs.changes.outputs.core }}
     # Big-runner opt-in via a single org/repo Actions variable. Set BIG_RUNNER to
     # the label of the Nimblesite GitHub-hosted larger runner to route the real,
     # CPU-bound mutation work onto it; leave it unset and the job falls back to
     # the standard hosted runner so CI never breaks on a missing label. The
     # variable is the single source of truth — change the machine in one place.
     #
-    # The `code` guard keeps the larger runner off no-op shards: this job has no
+    # The `core` guard keeps the larger runner off no-op shards: this job has no
     # job-level `if` (the four shards must always report as required checks), so
-    # on a docs/config-only PR every shard still starts but every step no-ops.
+    # on a non-core PR every shard still starts but every step no-ops.
     # Only bill BIG_RUNNER when there is actually Rust to mutate; otherwise these
     # seconds-long no-ops run on the standard runner.
-    runs-on: ${{ (needs.changes.outputs.code == 'true' && vars.BIG_RUNNER) || 'ubuntu-24.04' }}
+    runs-on: ${{ (needs.changes.outputs.core == 'true' && vars.BIG_RUNNER) || 'ubuntu-24.04' }}
     # cargo-mutants rebuilds + reruns the test suite once per mutant, so it is
     # heavily CPU-bound — the primary reason BIG_RUNNER exists. The 20-minute
     # budget was calibrated for an 8-core larger runner; the standard hosted
@@ -591,7 +638,7 @@ jobs:
     name: Mutation Testing
     runs-on: ubuntu-24.04
     needs: [changes, mutation-test-shard]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.core == 'true'
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -625,7 +672,7 @@ jobs:
   build:
     name: Build
     needs: [changes, test-rust, test-vscode, test-nvim, zed, mutation-test, verify-binaries]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.core == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/crates/basilisk-lsp/src/code_actions/imports.rs
+++ b/crates/basilisk-lsp/src/code_actions/imports.rs
@@ -23,6 +23,13 @@ use super::TMP_COUNTER;
 /// - ruff exits with code >= 2 (internal error)
 /// - the file is unchanged (no fixes apply)
 /// - tmp-file I/O fails
+///
+/// CRITICAL TODO ([LSPFMT-DECISION], [LSPFMT-IMPORTS] — docs/specs/LSP-FORMATTING-SPEC.md):
+/// Jettison this `ruff check` subprocess. Reimplement the three import fixers
+/// (organize `I`, expand-wildcard `F403`, split-multi-import `E401`) **natively
+/// on the Ruff AST we already own** — no temp file, no PATH lookup, no silent
+/// no-op when ruff is absent. Acceptance bar: behavior parity with the Ruff
+/// fixers, regression-tested against representative fixtures.
 fn run_ruff_fix(source: &str, select_code: &str, tmp_prefix: &str) -> Option<String> {
     let id = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let tmp_path = std::env::temp_dir().join(format!("{tmp_prefix}_{id}.py"));

--- a/crates/basilisk-lsp/src/formatting.rs
+++ b/crates/basilisk-lsp/src/formatting.rs
@@ -4,6 +4,16 @@
 //!
 //! Delegates to `ruff format` for Python document formatting, returning
 //! a single `TextEdit` that replaces the entire document content.
+//!
+//! CRITICAL TODO ([LSPFMT-DECISION], [LSPFMT-ENGINE] — docs/specs/LSP-FORMATTING-SPEC.md):
+//! The external `ruff` CLI is being **jettisoned completely** — it must never be
+//! spawned for any reason. Replace this subprocess with the **embedded
+//! `ruff_python_formatter` crate**, called in-process, so formatting works with
+//! no `ruff` binary installed on the machine at all (today's subprocess silently
+//! returns `None` and does nothing). The engine MUST be pure passthrough, read
+//! `[tool.ruff.format]` options from `WorkspaceConfig`, and be gated by the
+//! `basilisk.formatter` flag ([LSPFMT-CONFIG]). Also advertise
+//! `documentRangeFormattingProvider` ([LSPFMT-CAPABILITIES]).
 
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -17,6 +27,10 @@ use tower_lsp::lsp_types::{Position, Range, TextEdit};
 /// or `None` if the output is unchanged or Ruff is unavailable.
 #[must_use]
 pub fn format_document(source: &str, file_path: &str) -> Option<Vec<TextEdit>> {
+    // CRITICAL TODO ([LSPFMT-ENGINE] — docs/specs/LSP-FORMATTING-SPEC.md#LSPFMT-ENGINE):
+    // Jettison this subprocess entirely — the `ruff` binary is not a dependency.
+    // Call `ruff_python_formatter` in-process instead: no PATH lookup, no bundled
+    // binary, no silent no-op. Formatting must work with no `ruff` installed.
     let mut child = Command::new("ruff")
         .args(["format", "--stdin-filename", file_path, "-"])
         .stdin(Stdio::piped())

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,6 +23,7 @@ Specifications define the target behavior and architecture. They are the source 
 | [COMPILER-ARCHITECTURE-SPEC.md](specs/COMPILER-ARCHITECTURE-SPEC.md) | Python-to-native compiler via LLVM — ownership model, memory backends, GPU support. |
 | [LSP-ARCHITECTURE-SPEC.md](specs/LSP-ARCHITECTURE-SPEC.md) | Single source of truth for LSP features, DAP integration, custom commands, configuration, and binary resolution. |
 | [LSP-ANALYSIS-MODES-SPEC.md](specs/LSP-ANALYSIS-MODES-SPEC.md) | Analysis modes (openFilesOnly, wholeModule, crossModule), workspace index, import graph, cross-file LSP features. |
+| [LSP-FORMATTING-SPEC.md](specs/LSP-FORMATTING-SPEC.md) | Formatting & import hygiene — embedded Ruff formatter crate (in-process, no `ruff` CLI), native import fixers, `basilisk.formatter` flag, version/provenance disclosure, range formatting. |
 | [LSP-AI-SPEC.md](specs/LSP-AI-SPEC.md) | Model-agnostic AI layer — AI-powered fixes, completions, refactoring. Optional; deterministic features work without it. |
 | [LSP-DEBUG-INTEGRATION-SPEC.md](specs/LSP-DEBUG-INTEGRATION-SPEC.md) | Embedded debugpy — Basilisk binary serves as both language server and debug adapter via DAP over TCP. |
 | [LSP-PROFILING-SPEC.md](specs/LSP-PROFILING-SPEC.md) | Embedded Python profiler using py-spy with Speedscope output and inline editor visualization. |
@@ -47,6 +48,7 @@ Implementation roadmaps tracking phasing, priorities, and progress.
 |---|---|
 | [ROADMAP-NEXT-STEPS-PLAN.md](plans/ROADMAP-NEXT-STEPS-PLAN.md) | Post-launch roadmap — editor releases, scale testing, i18n, MCP server, AI integration, marketing. Agent/human task split. |
 | [LSP-PLAN.md](plans/LSP-PLAN.md) | Overall LSP roadmap — phases from core features through cross-module analysis and PEP conformance. |
+| [LSP-FORMATTING-PLAN.md](plans/LSP-FORMATTING-PLAN.md) | Jettison the `ruff` CLI — embed the Ruff formatter crate, reimplement import hygiene natively, expose the embedded Ruff version, add range formatting and `basilisk format`. |
 | [CHECKER-PEP-CONFORMANCE-PLAN.md](plans/CHECKER-PEP-CONFORMANCE-PLAN.md) | PEP conformance push toward 100% — tiered task list by complexity and impact. |
 | [CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md](plans/CHECKER-TYPE-NARROWING-INFERENCE-PLAN.md) | Type narrowing and inference engine — narrowing engine, expression inference, constraint solver, class-hierarchy subtyping. |
 | [CHECKER-ELIMINATE-LINE-SCANNING-PLAN.md](plans/CHECKER-ELIMINATE-LINE-SCANNING-PLAN.md) | Replace raw `source.lines()` scanning in rules with AST-driven checks; phased by severity, with a regression-guard lint. |

--- a/docs/plans/EXTENSION-ACTIVITY-PANEL-PLAN.md
+++ b/docs/plans/EXTENSION-ACTIVITY-PANEL-PLAN.md
@@ -139,13 +139,17 @@ A toggle returns to the panel ONLY when both are true:
       assert `vscode.executeInlayHintProvider` returns no parameter hints; repeat
       for `variableTypes`.
 
-### Ruff Integration {#EXTACT-PLAN-RUFF-TOGGLE}
-- [ ] When `ruff.enabled` is false: skip ruff-backed code actions / formatting /
-      organize-imports in `code_actions/` and `formatting.rs`, and do not advertise
-      `basilisk.organizeImports` as an available action for the document.
-- [ ] Honor `ruff.executablePath` instead of resolving `ruff` from PATH.
-- [ ] VSIX test: toggle `ruff.enabled` off, assert organize-imports code action is
-      absent / formatting is a no-op.
+### Formatter Engine {#EXTACT-PLAN-FORMATTER-TOGGLE}
+The external `ruff` binary is jettisoned — there is no `ruff.enabled`/`ruff.executablePath`
+to honor. Formatting is the Ruff formatter embedded in the Basilisk binary, in-process
+([LSPFMT-DECISION](../specs/LSP-FORMATTING-SPEC.md#LSPFMT-DECISION)). The only setting is
+the `basilisk.formatter` engine selector ([LSPFMT-CONFIG](../specs/LSP-FORMATTING-SPEC.md#LSPFMT-CONFIG)).
+- [ ] When `basilisk.formatter` is `"none"`: do not advertise `documentFormattingProvider`
+      / `documentRangeFormattingProvider` in `formatting.rs` / `server/init.rs`, so no
+      Basilisk formatter appears in any editor. (Native import hygiene stays available —
+      it is not gated by this flag.)
+- [ ] VSIX test: set `basilisk.formatter` to `"none"`, assert formatting is not offered;
+      set it back to `"ruff"`, assert formatting works with no `ruff` binary installed.
 
 ### Test Explorer {#EXTACT-PLAN-TEST-EXPLORER-TOGGLE}
 - [ ] `testExplorer.enabled` currently only gates auto-discovery-on-save. Make it

--- a/docs/plans/LSP-FORMATTING-PLAN.md
+++ b/docs/plans/LSP-FORMATTING-PLAN.md
@@ -1,0 +1,44 @@
+# Formatting & Import Hygiene — Implementation Plan {#LSPFMT-PLAN}
+
+Implements [LSPFMT](../specs/LSP-FORMATTING-SPEC.md#LSPFMT). Goal: jettison the `ruff` CLI, embed the Ruff formatter crate in-process, reimplement import hygiene natively, and make the formatter's Ruff provenance/version visible everywhere. Ratchets and CLAUDE.md rules apply throughout (coverage/mutation up, benches down, no `unwrap`/`panic`, structured logging).
+
+## Phase 1 — Embed the Ruff formatter ([LSPFMT-ENGINE], [LSPFMT-CAPABILITIES])
+
+1. Spike: add `ruff_python_formatter` to `Cargo.toml` at the **same pinned rev** as `ruff_python_parser` (`7c645a9…`), confirm it builds, and confirm the entry point/options type (`format_module_source`-style API). Measure binary-size delta.
+2. Rewrite `crates/basilisk-lsp/src/formatting.rs` to call the crate in-process — **delete the `Command::new("ruff")` subprocess entirely**. The `ruff` binary is no longer a dependency of any kind. Failing test first: formatting produces correct output on a machine with **no `ruff` binary installed at all** (proving the subprocess is gone, replacing today's silent-`None` no-op).
+3. Feed `[tool.ruff.format]` options (line length, quote/indent style, magic trailing comma) from `WorkspaceConfig` into the engine; add the fields to `WorkspaceConfig` (`crates/basilisk-lsp/src/config.rs`) and the loaders (`pyproject.toml`).
+4. Advertise `document_range_formatting_provider` in `crates/basilisk-lsp/src/server/init.rs` and add a `rangeFormatting` handler (`features.rs`). Whole-doc + range share the engine. (On-type is a later, optional follow-up.)
+
+## Phase 2 — Native import hygiene ([LSPFMT-IMPORTS])
+
+1. Reimplement the three fixers on the Ruff AST in `crates/basilisk-lsp/src/code_actions/imports.rs`: organize (isort semantics), expand-wildcard, split-multi-import. Delete `run_ruff_fix` and the temp-file/`ruff check` path.
+2. Parity tests vs. the Ruff fixers on representative fixtures (the existing `ws_test_code_actions.rs` `ruff`-gated tests become unconditional — native, always available).
+
+## Phase 3 — Config & provenance ([LSPFMT-CONFIG], [LSPFMT-PROVENANCE])
+
+1. Add the `basilisk.formatter` enum (`"ruff"` default / `"none"`; reserve `"basilisk"`). **Done for VS Code:** the two `basilisk.ruff.*` settings and the `readRuffSettings()` plumbing (`vscode-extension/src/lsp-client.ts`) are already deleted and replaced by `basilisk.formatter` in `package.json`, both READMEs, and the forwarded `initializationOptions`. Remaining: wire the flag through `WorkspaceConfig` (Rust), Zed config, and `basilisk.nvim` defaults so the server honours `"none"`.
+2. Expose the embedded Ruff formatter version: compile-time constant from the pinned rev → `basilisk --version`, LSP `serverInfo.version`, and an Output-channel log line on each format.
+3. Ship Ruff's MIT license in `THIRD-PARTY-LICENSES`/NOTICE (already owed for the parser crates).
+
+## Phase 4 — Release-notes exposure ([LSPFMT-RELEASE-NOTES])
+
+Generate (never hand-type) a release-notes block listing every `shipwright.json` component + version **and** the embedded Ruff formatter version, so a reader can tell exactly which formatter bytes shipped. Drift-guarded like the other generated artifacts.
+
+## Phase 5 — Per-client wiring ([LSPFMT-CLIENTS]) & CLI
+
+1. VS Code: format-on-save wiring; one-time, dismissible opt-in prompt to set `editor.defaultFormatter` to Basilisk — **never** hijack an existing default.
+2. Zed `"formatter": "language_server"`; Neovim `vim.lsp.buf.format({ name = "basilisk" })`.
+3. `basilisk format [paths]` CLI subcommand using the same embedded engine.
+
+## Phase 6 — Docs & governance
+
+1. Website/docs: a Formatting section stating plainly the formatter **is the embedded Ruff formatter** (no separate install), mostly linking to the [Ruff formatter docs](https://docs.astral.sh/ruff/formatter/) rather than re-documenting behavior we don't own ([LSPFMT-HONESTY]).
+2. Via reviewed PR, update the CLAUDE.md Architecture bullet ("Linting/formatting: Ruff CLI subprocess — not reimplemented") to reflect: formatting **embeds** the Ruff crate in-process; import hygiene is **reimplemented** natively; the `ruff` CLI is not a runtime dependency. (Governance rule: CLAUDE.md changes go through review, never silent capture.)
+
+## Acceptance
+
+- No `Command::new("ruff")` anywhere in shipping code; no `ruff` in dev-required PATH for formatting/imports.
+- Formatting + Format Selection work in all four consumers with no `ruff` installed.
+- `basilisk --version` and release notes both state the embedded Ruff formatter version.
+- Formatter output byte-identical to `ruff format` at the pinned rev on the fixture corpus; import fixers at parity.
+- Coverage/mutation ratchets up; bench gate green.

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -32,8 +32,8 @@ Basilisk has **no modes** (no `--strict`, no `off`/`basic`/`standard`/`strict` d
 | Ownership analysis | No | No | No | No | No | No | **Yes** |
 | Immutability enforcement | No | No | No | No | No | No | **Yes** |
 | Implicit coercion detection | No | No | No | No | No | No | **Yes** |
-| Linting | No | No | No | No | No | **Yes** | Delegates to Ruff |
-| Formatting | No | No | No | No | No | **Yes** | Delegates to Ruff |
+| Linting | No | No | No | No | No | **Yes** | Native import hygiene ([LSPFMT-IMPORTS](LSP-FORMATTING-SPEC.md#LSPFMT-IMPORTS)) |
+| Formatting | No | No | No | No | No | **Yes** | Embeds Ruff formatter ([LSPFMT-ENGINE](LSP-FORMATTING-SPEC.md#LSPFMT-ENGINE)) |
 | Plugin system | No | Python hooks | Planned | No | No | No | **WASM plugins** |
 | Auto-stub generation | No | stubgen (basic) | No | Inference | No | No | **Tiered stubs** |
 | CI output (SARIF/JUnit) | Limited | No | No | No | No | No | **SARIF + JUnit** |
@@ -56,8 +56,8 @@ Depend on established open-source tools rather than reimplementing them.
 
 | Dependency | Purpose | License | Rationale |
 |---|---|---|---|
-| **Ruff** (`ruff` CLI) | Linting + formatting | MIT | Best-in-class. 700+ rules. We don't recreate lint or format. |
-| **`ruff_python_parser`** | Python AST parsing | MIT | Battle-tested Rust crate. Powers Ruff. Evaluate as our parser. |
+| **`ruff_python_formatter`** | Code formatting | MIT | Embedded in-process — the formatter is Ruff's, no `ruff` CLI. Pinned to the same rev as the parser ([LSPFMT-ENGINE](LSP-FORMATTING-SPEC.md#LSPFMT-ENGINE)). |
+| **`ruff_python_parser`** | Python AST parsing | MIT | Battle-tested Rust crate. Powers Ruff. Our parser. |
 | **typeshed** | Standard library type stubs | Apache-2.0 | Community standard. We bundle it and extend it. |
 | **Salsa** | Incremental computation framework | Apache-2.0/MIT | Powers rust-analyzer. Proven at scale. |
 | **`lsp-server`** / **`tower-lsp`** | LSP implementation | MIT | Standard Rust LSP crates. |
@@ -76,7 +76,7 @@ Depend on established open-source tools rather than reimplementing them.
 
 | Tool | Interop Strategy |
 |---|---|
-| **Ruff** | Basilisk invokes `ruff check` and `ruff format` as subprocesses or links the Ruff crates directly. Configuration unified in `pyproject.toml`. |
+| **Ruff** | Basilisk **embeds** the `ruff_python_formatter` crate in-process for formatting and reimplements import hygiene natively — the `ruff` CLI is never spawned ([LSPFMT-DECISION](LSP-FORMATTING-SPEC.md#LSPFMT-DECISION)). Configuration unified in `pyproject.toml` (`[tool.ruff.format]`). |
 | **typeshed** | Bundled copy of typeshed stubs, updated with each Basilisk release. Users can override with custom stubs. |
 | **mypy config** | `basilisk migrate --from mypy` reads `mypy.ini` / `setup.cfg` and produces `[tool.basilisk]` config. |
 | **Pyright config** | `basilisk migrate --from pyright` reads `pyrightconfig.json` and produces `[tool.basilisk]` config. |

--- a/docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md
+++ b/docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md
@@ -395,15 +395,19 @@ At-a-glance view of how well-typed the codebase is.
 
 ### Tree Structure {#EXTACT-HEALTH-TREE-STRUCTURE}
 
+Tallies follow [count style](#EXTACT-MODULES-COUNT-STYLE) — coloured glyphs
+`🔴 n` (errors) / `🟠 n` (warnings), **never** `nE nW`; a zero for a severity is
+omitted, never shown as `🔴 0`:
+
 ```
-Workspace Health: 73% typed  [========---] 14E 23W
+Workspace Health: 73% typed  [========---] 🔴 14  🟠 23
 -------------------------------------------------
-  [pass]  myapp/models/user.py        100%    0E  0W
-  [pass]  myapp/models/base.py        100%    0E  0W
-  [pass]  myapp/api/auth.py            95%    0E  1W
-  [warn]  myapp/api/routes.py          68%    2E  3W
-  [warn]  myapp/utils.py               54%    1E  0W    [adopted]
-  [fail]  myapp/legacy/importer.py     12%   11E 19W    [adopted]
+  [pass]  myapp/models/user.py        100%
+  [pass]  myapp/models/base.py        100%
+  [pass]  myapp/api/auth.py            95%          🟠 1
+  [warn]  myapp/api/routes.py          68%    🔴 2  🟠 3
+  [warn]  myapp/utils.py               54%    🔴 1        [adopted]
+  [fail]  myapp/legacy/importer.py     12%   🔴 11 🟠 19  [adopted]
 ```
 
 ### Tree Item Properties {#EXTACT-HEALTH-ITEM-PROPERTIES}
@@ -411,7 +415,7 @@ Workspace Health: 73% typed  [========---] 14E 23W
 | Property | Value |
 |----------|-------|
 | Label | Module path (relative to workspace root) |
-| Description | Coverage %, error/warning counts |
+| Description | Coverage %, then the diagnostic tally in [count style](#EXTACT-MODULES-COUNT-STYLE) (`🔴 n` errors / `🟠 n` warnings — **never** `nE nW`) |
 | Icon | Green (>=90%), yellow (50-89%), red (<50%) |
 | Tooltip | "23 of 31 symbols annotated. 2 errors, 3 warnings." |
 | Decoration | `[adopted]` badge if file is in adoption mode |

--- a/docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md
+++ b/docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md
@@ -551,7 +551,7 @@ See [EXTENSION-ACTIVITY-PANEL-PLAN.md](../plans/EXTENSION-ACTIVITY-PANEL-PLAN.md
 | uv Integration | `basilisk.uv.enabled` | No server code reads it — the toggle never disabled uv integration (a no-op affordance). Removed per GitHub #190; uv commands stay in the palette / code actions and the read-only "uv" Server Info row still reports uv status |
 | Inlay Hints (Params) | `basilisk.inlayHints.parameterNames` | Server emits hints unconditionally; setting dropped |
 | Inlay Hints (Types) | `basilisk.inlayHints.variableTypes` | Server emits hints unconditionally; setting dropped |
-| Ruff Integration | `basilisk.ruff.enabled` | Server runs ruff unconditionally; setting dropped |
+| Ruff Integration | `basilisk.ruff.enabled` / `basilisk.ruff.executablePath` | Dropped — no `ruff` binary; formatting is the embedded Ruff crate. Replaced by the functional `basilisk.formatter` flag ([LSPFMT-CONFIG](LSP-FORMATTING-SPEC.md#LSPFMT-CONFIG)), not a dashboard toggle |
 | Test Explorer | `basilisk.testExplorer.enabled` | Only gates auto-discovery-on-save; does not disable the explorer |
 | Debugger | `basilisk.debugger.enabled` | Setting was never even declared; debugging is always registered |
 | AI Suggestions | `basilisk.aiTyping.enabled` | No provider implemented; nothing reads the setting |

--- a/docs/specs/LSP-ARCHITECTURE-SPEC.md
+++ b/docs/specs/LSP-ARCHITECTURE-SPEC.md
@@ -13,7 +13,7 @@ Design principle: the LSP drives functionality. IDE extensions react to LSP sign
 
 ## System Architecture {#LSPARCH-SYSTEM}
 
-Three editor frontends share one binary. The binary embeds the LSP server and the type-checking pipeline (parser → resolver → checker), and shells out to external tools (`ruff`, `debugpy`, `uv`) on demand.
+Three editor frontends share one binary. The binary embeds the LSP server, the type-checking pipeline (parser → resolver → checker), the Ruff formatter crate, and native import-hygiene fixers ([LSPFMT-DECISION](LSP-FORMATTING-SPEC.md#LSPFMT-DECISION)); it shells out to external tools (`debugpy`, `uv`) on demand. The `ruff` CLI is **not** spawned — formatting and import cleanup are in-process.
 
 ```mermaid
 flowchart TB
@@ -39,7 +39,6 @@ flowchart TB
 
     subgraph Subprocs["External subprocesses"]
         direction LR
-        Ruff["ruff"]
         Debugpy["debugpy"]
         UvBin["uv"]
         Py["python3"]
@@ -55,7 +54,6 @@ flowchart TB
     Zed <-->|"TCP DAP"| Debugpy
     Nvim <-->|"TCP DAP"| Debugpy
 
-    LSP -.->|spawn| Ruff
     LSP -.->|spawn| Debugpy
     LSP -.->|spawn| UvBin
     LSP -.->|spawn| Py
@@ -109,8 +107,7 @@ These settings are sent to the LSP server via `workspace/configuration` under th
 | `basilisk.analysisMode` | `enum` | `"wholeModule"` | `openFilesOnly` / `wholeModule` / `crossModule` |
 | `basilisk.inlayHints.parameterNames` | `boolean` | `true` | Show parameter name hints at call sites |
 | `basilisk.inlayHints.variableTypes` | `boolean` | `true` | Show inferred type hints for unannotated variables |
-| `basilisk.ruff.enabled` | `boolean` | `true` | Enable Ruff integration (formatting + import org) |
-| `basilisk.ruff.executablePath` | `string` | `"ruff"` | Path to the ruff binary |
+| `basilisk.formatter` | `enum` | `"ruff"` | Formatter engine: `"ruff"` (embedded, default) or `"none"`. Future `"basilisk"`. See [LSPFMT-CONFIG](LSP-FORMATTING-SPEC.md#LSPFMT-CONFIG). Replaces the removed `basilisk.ruff.*` settings — there is no `ruff` binary to point at. |
 | `basilisk.debugger.enabled` | `boolean` | `true` | Enable debugger |
 | `basilisk.debugger.typeChecking` | `boolean` | `false` | Enable type assertion breakpoints |
 | `basilisk.debugger.debugpyPath` | `string` | `"debugpy"` | Path to debugpy module |
@@ -152,7 +149,7 @@ Enforced by the toolbar contract tests in `vscode-extension/src/test/suite/activ
 
 | Command | Arguments | Response | Description |
 |---------|-----------|----------|-------------|
-| `basilisk.organizeImports` | `{uri}` | `TextEdit[]` | Run Ruff import organization |
+| `basilisk.organizeImports` | `{uri}` | `TextEdit[]` | Native import organization ([LSPFMT-IMPORTS](LSP-FORMATTING-SPEC.md#LSPFMT-IMPORTS)) |
 | `basilisk.startDebugSession` | `{uri, pythonPath?}` | `{host, port, sessionId}` | Spawn debugpy, return connection info |
 | `basilisk.stopDebugSession` | `{sessionId}` | `{}` | Terminate debug session |
 | `basilisk.profiler.start` | `{pid?}` | `{sessionId}` | Start profiling (active process or PID) |
@@ -327,7 +324,7 @@ crates/basilisk-lsp/src/
   inlay_hints.rs     — inferred types, parameter names, return types
   semantic_tokens.rs — token classification
   code_actions.rs    — quick fixes (E0001-E0003, suppress, organize imports)
-  formatting.rs      — Ruff delegation
+  formatting.rs      — embedded Ruff formatter, in-process ([LSPFMT-ENGINE])
   highlight.rs       — document highlight (symbol occurrences)
   call_hierarchy.rs  — incoming/outgoing call navigation
   type_hierarchy.rs  — supertype/subtype navigation
@@ -453,7 +450,7 @@ Whole-word text scan with word boundary checks, filtering strings/comments. Resp
 | BSK-E0002 | Add return annotation | Insert `-> None` |
 | BSK-E0003 | Add variable annotation | Insert `: <inferred_type>` |
 | (any) | Suppress with `# type: ignore` | Append comment to line |
-| (source) | Organize imports | Delegate to `ruff check --select I --fix` |
+| (source) | Organize imports | Native import organizer ([LSPFMT-IMPORTS](LSP-FORMATTING-SPEC.md#LSPFMT-IMPORTS)) |
 
 | imports_unresolved (uv) | Add dependency | `uv add <package>` via `basilisk.uv.add` command |
 | BSK-E0152 (uv) | Install type stubs | `uv add --dev types-<package>` via `basilisk.uv.addDev` command |
@@ -464,7 +461,7 @@ Register `codeActionKinds`: `[QUICKFIX, SOURCE_ORGANIZE_IMPORTS, REFACTOR]`
 
 ### Execute Command (`workspace/executeCommand`) {#LSPARCH-FEATURES-EXECCMD}
 
-- `basilisk.organizeImports` — run Ruff import organization on a document
+- `basilisk.organizeImports` — native import organization on a document ([LSPFMT-IMPORTS](LSP-FORMATTING-SPEC.md#LSPFMT-IMPORTS))
 
 ### Inlay Hints (`textDocument/inlayHint`) {#LSPARCH-FEATURES-INLAYHINTS}
 
@@ -498,9 +495,9 @@ Highlight all occurrences of symbol under cursor. Definition = WRITE, usages = R
 
 Ctrl+T symbol search across all open documents. Aggregates from DashMap, filters by query.
 
-### Format Document (`textDocument/formatting`) {#LSPARCH-FEATURES-FORMAT}
+### Format Document (`textDocument/formatting` + `rangeFormatting`) {#LSPARCH-FEATURES-FORMAT}
 
-Spawn `ruff format --stdin-filename <path> -` with document text on stdin. Return single `TextEdit` replacing entire document.
+Format in-process via the **embedded Ruff formatter crate** — no `ruff` subprocess. Whole-document formatting returns a single `TextEdit`; range formatting (`textDocument/rangeFormatting`) formats the selection. Engine, config, provenance, capabilities, and the `basilisk.formatter` flag are specified in **[LSPFMT](LSP-FORMATTING-SPEC.md#LSPFMT)** ([LSPFMT-ENGINE](LSP-FORMATTING-SPEC.md#LSPFMT-ENGINE), [LSPFMT-CAPABILITIES](LSP-FORMATTING-SPEC.md#LSPFMT-CAPABILITIES)).
 
 ### Folding Ranges (`textDocument/foldingRange`) {#LSPARCH-FEATURES-FOLDING}
 

--- a/docs/specs/LSP-FORMATTING-SPEC.md
+++ b/docs/specs/LSP-FORMATTING-SPEC.md
@@ -1,0 +1,92 @@
+# Basilisk Formatting & Import Hygiene — Specification {#LSPFMT}
+
+Formatting and import cleanup are **LSP capabilities served by the binary**, identically to every consumer (VS Code, Zed, Neovim, and the `basilisk` CLI). This document is the single source of truth for both; `LSP-ARCHITECTURE-SPEC.md` ([LSPARCH](LSP-ARCHITECTURE-SPEC.md#LSPARCH)) points here. Editor specs MUST reference this, not duplicate it.
+
+Design principle (per [LSPARCH](LSP-ARCHITECTURE-SPEC.md#LSPARCH)): the LSP owns the feature; editor frontends are thin clients. Nothing here may be implemented per-editor.
+
+---
+
+## Decision: everything in the binary, no `ruff` subprocess {#LSPFMT-DECISION}
+
+Formatting and import hygiene are **self-contained in the `basilisk` binary**. The external `ruff` CLI is **jettisoned** — it is never spawned. Two independent mechanisms replace it:
+
+| Concern | Old (removed) | New |
+|---|---|---|
+| Formatting | spawn `ruff format` | link the `ruff_python_formatter` crate, call it in-process ([LSPFMT-ENGINE]) |
+| Import hygiene | spawn `ruff check --select I/F403/E401 --fix` | native AST fixers in the binary ([LSPFMT-IMPORTS]) |
+
+Rationale — one engine in one binary is the only design uniform across all four consumers, removes the PATH/bundle/silent-no-op failure mode, and eliminates version skew between "the ruff that parses" and "the ruff that formats". The CLI-bundle and VS-Code-extension-dependency approaches were rejected because each serves at most one editor and splits ownership away from the LSP.
+
+---
+
+## Formatter engine: embedded Ruff, pure passthrough {#LSPFMT-ENGINE}
+
+We already compile Ruff into the binary for parsing (`ruff_python_parser`/`ruff_python_ast`, pinned at one rev in `Cargo.toml`). Formatting links **one more crate from the same repo at the same rev** — `ruff_python_formatter` — and calls it directly (no subprocess, no bundled binary, always present).
+
+- **Pure passthrough.** Output MUST be byte-identical to `ruff format` at the pinned rev. Basilisk applies **zero** original transforms to formatting output. The moment we deviate, calling it "Ruff" becomes false and it must be renamed with its own output contract ([LSPFMT-HONESTY]).
+- **Config-respecting.** The engine reads the project's `[tool.ruff.format]` options (line length, quote style, indent style, magic trailing comma) from `pyproject.toml` so Basilisk's output matches what the user's own `ruff format` would produce. Options flow from the config loader (`WorkspaceConfig`), not hard-coded defaults.
+- **Style is Black-compatible**, with Ruff's [documented deviations](https://docs.astral.sh/ruff/formatter/black/) — link the source, never claim byte-identical-to-Black.
+
+## Provenance & versioning — the user must know which Ruff {#LSPFMT-PROVENANCE}
+
+Because the formatter's output is user-visible, its provenance MUST be user-visible (unlike the invisible parser embedding). The embedded formatter version is a compile-time constant derived from the pinned `Cargo.toml` rev. Surface it in every place a user would look:
+
+1. **`basilisk --version`** lists embedded engine versions (e.g. `Ruff formatter: 0.15.17`) alongside the Shipwright build stamp ([CHKARCH-ARCH-BUILD-VERSIONINFO](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-ARCH-BUILD-VERSIONINFO)).
+2. **LSP `InitializeResult.serverInfo.version`** carries it, so every client (VS Code, Zed, Neovim) surfaces the same identity.
+3. **Output/log channel** notes it on format (`Formatted with embedded Ruff <ver>`) — no silent magic.
+4. **Release notes** MUST list the Shipwright manifest binary versions AND the embedded Ruff formatter version for the release ([LSPFMT-RELEASE-NOTES]).
+5. **`THIRD-PARTY-LICENSES`/NOTICE** ships Ruff's MIT license — the legal answer to "where did this come from".
+
+### Release-notes exposure {#LSPFMT-RELEASE-NOTES}
+
+Each release's notes MUST enumerate, from a single generated source (not hand-typed): every `shipwright.json` component + version, and the embedded Ruff formatter version. Generated so it cannot drift from what actually shipped; a user reading the notes can tell exactly which formatter bytes they will get.
+
+## Configuration {#LSPFMT-CONFIG}
+
+One new setting replaces the two removed `basilisk.ruff.*` settings (there is no `ruff` binary, so `executablePath` is meaningless):
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `basilisk.formatter` | `enum` | `"ruff"` | Formatter engine: `"ruff"` (embedded, default) or `"none"` (disable). Future: `"basilisk"`. |
+
+- `"ruff"` — the embedded Ruff formatter ([LSPFMT-ENGINE]).
+- `"none"` — the server does not advertise formatting capability; editors show no Basilisk formatter.
+- Future `"basilisk"` — a Basilisk-native formatter with its own contract (not yet built). Reserved so the flag is forward-stable.
+
+Import hygiene ([LSPFMT-IMPORTS]) is native and always available as code actions — not gated by this flag.
+
+## Server capabilities {#LSPFMT-CAPABILITIES}
+
+The server advertises formatting as LSP capabilities, so all four consumers get them from one change:
+
+- `documentFormattingProvider` — whole-document (existing).
+- `documentRangeFormattingProvider` — Format Selection (**new**; currently missing, so "Format Selection" is a no-op in every editor).
+- `documentOnTypeFormattingProvider` — format-as-you-type (future, optional).
+
+All are attributed to the single identity **"Basilisk"** (`serverInfo.name`); VS Code shows the extension `displayName`, Zed/Neovim show the server id. There is no per-provider display name in LSP or VS Code — the Ruff engine is disclosed via [LSPFMT-PROVENANCE], never a picker label. When `basilisk.formatter` is `"none"`, none of these are advertised.
+
+## Native import hygiene {#LSPFMT-IMPORTS}
+
+Reimplemented in the binary on the Ruff AST we already own — **no `ruff check` subprocess**. Owning the code lets us extend the behavior and removes the version-coupling and silent-no-op failure modes.
+
+| Code action | Kind | Replaces |
+|---|---|---|
+| Organize imports | `SOURCE_ORGANIZE_IMPORTS` | `ruff check --select I --fix` |
+| Expand wildcard imports | `QUICKFIX` | `ruff check --select F403 --fix` |
+| Split multiple imports on one line | `QUICKFIX` | `ruff check --select E401 --fix` |
+
+Behavior parity with the corresponding Ruff fixers is the acceptance bar (regression-tested against representative fixtures). "Organize imports" ordering follows isort semantics.
+
+## Per-client wiring (thin) {#LSPFMT-CLIENTS}
+
+Everything substantive is server-side; clients only wire triggers and one opt-in:
+
+- **VS Code** — provider label is the extension `displayName` ("Basilisk"). Format-on-save wiring; a one-time, dismissible **opt-in** prompt to set `editor.defaultFormatter` to Basilisk. MUST NOT hijack a user's existing `editor.defaultFormatter`; if two formatters are present, VS Code's standard one-time picker governs.
+- **Zed** — `"formatter": "language_server"` for Python.
+- **Neovim** — `vim.lsp.buf.format({ name = "basilisk" })`.
+- **CLI** — `basilisk format [paths]` uses the same embedded engine directly.
+
+## Honesty guardrail {#LSPFMT-HONESTY}
+
+- Formatter = **pure Ruff passthrough**; all Basilisk "control/flexibility" lives on the import-hygiene side ([LSPFMT-IMPORTS]) and future `"basilisk"` provider, never in the `"ruff"` formatter's output.
+- Docs MUST state plainly that the formatter **is the Ruff formatter, embedded** (no separate install), and mostly link to the [Ruff formatter docs](https://docs.astral.sh/ruff/formatter/) rather than re-document formatting behavior we don't own.

--- a/docs/specs/LSP-TEST-INTEGRATION-SPEC.md
+++ b/docs/specs/LSP-TEST-INTEGRATION-SPEC.md
@@ -8,7 +8,7 @@
 
 ## Architecture {#LSPTEST-ARCHITECTURE}
 
-Same subprocess-delegation pattern as formatting (Ruff) and debugging (debugpy):
+Same subprocess-delegation pattern as debugging (debugpy) — note formatting is now **in-process** via the embedded Ruff crate, not a subprocess ([LSPFMT-ENGINE](LSP-FORMATTING-SPEC.md#LSPFMT-ENGINE)):
 
 1. **Discovery** — parse test files from AST via `basilisk-parser` (no import/execution)
 2. **Execution** — delegate to a `pytest` subprocess (or `unittest` runner), using `uv run` when a uv project is detected

--- a/docs/specs/NEOVIM-SPEC.md
+++ b/docs/specs/NEOVIM-SPEC.md
@@ -81,10 +81,9 @@ vim.lsp.config('basilisk', {
         parameterNames = config.inlay_hints.parameter_names,
         variableTypes = config.inlay_hints.variable_types,
       },
-      ruff = {
-        enabled = config.ruff.enabled,
-        executablePath = config.ruff.executable_path,
-      },
+      -- Formatter engine: "ruff" (Ruff formatter embedded in the Basilisk
+      -- binary, in-process — no external ruff binary) or "none". [LSPFMT-CONFIG]
+      formatter = config.formatter,
     }
   }
 })

--- a/docs/specs/VSIX-SPEC.md
+++ b/docs/specs/VSIX-SPEC.md
@@ -122,13 +122,9 @@ client.start();
         "type": "boolean", "default": true,
         "description": "Show inferred type hints for unannotated variables."
     },
-    "basilisk.ruff.enabled": {
-        "type": "boolean", "default": true,
-        "description": "Enable Ruff integration for formatting and import organization."
-    },
-    "basilisk.ruff.executablePath": {
-        "type": "string", "default": "ruff",
-        "description": "Path to the ruff binary."
+    "basilisk.formatter": {
+        "type": "string", "enum": ["ruff", "none"], "default": "ruff",
+        "description": "Formatter engine: 'ruff' (embedded Ruff formatter, in-process, no separate install) or 'none'. Replaces basilisk.ruff.* — see LSP-FORMATTING-SPEC.md#LSPFMT-CONFIG."
     },
     "basilisk.trace.server": {
         "type": "string",

--- a/docs/specs/ZED-SPEC.md
+++ b/docs/specs/ZED-SPEC.md
@@ -168,9 +168,10 @@ impl zed::Extension for BasiliskExtension {
                     "parameterNames": true,
                     "variableTypes": true
                 },
-                "ruff": {
-                    "enabled": true
-                }
+                // Formatter engine: "ruff" (Ruff formatter embedded in the
+                // Basilisk binary, in-process — no external ruff binary) or
+                // "none". [LSPFMT-CONFIG]
+                "formatter": "ruff"
             }
         })))
     }
@@ -357,10 +358,9 @@ The mirror version equals the monorepo tag (`v1.2.3` → `1.2.3`); the binary [Z
           "parameterNames": true,
           "variableTypes": true
         },
-        "ruff": {
-          "enabled": true,
-          "executablePath": "/path/to/ruff"
-        }
+        // Formatter engine: "ruff" (embedded Ruff formatter, in-process — no
+        // external ruff binary) or "none". [LSPFMT-CONFIG]
+        "formatter": "ruff"
       }
     }
   },

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -151,8 +151,7 @@ All rules are **on by default**. There is no way to relax them globally.
 | `basilisk.trace.server` | `"off"` | LSP trace level: `off`, `messages`, `verbose` |
 | `basilisk.inlayHints.parameterNames` | `true` | Reserved — hints are always shown; the server does not yet read this |
 | `basilisk.inlayHints.variableTypes` | `true` | Reserved — hints are always shown; the server does not yet read this |
-| `basilisk.ruff.enabled` | `true` | Reserved — Ruff is always on; the server does not yet read this |
-| `basilisk.ruff.executablePath` | `"ruff"` | Reserved — server resolves ruff from PATH; not yet read |
+| `basilisk.formatter` | `"ruff"` | Formatter engine — `"ruff"` uses the Ruff formatter embedded in the Basilisk binary (in-process; no external `ruff` binary is ever required), `"none"` disables formatting |
 
 ---
 

--- a/vscode-extension/README.zh.md
+++ b/vscode-extension/README.zh.md
@@ -153,8 +153,7 @@ Basilisk 以单个 Rust 二进制文件的形式发布。无需 Python 运行时
 | `basilisk.trace.server` | `"off"` | LSP 跟踪级别：`off`、`messages`、`verbose` |
 | `basilisk.inlayHints.parameterNames` | `true` | 保留项 —— 提示始终显示；服务器尚未读取此项 |
 | `basilisk.inlayHints.variableTypes` | `true` | 保留项 —— 提示始终显示；服务器尚未读取此项 |
-| `basilisk.ruff.enabled` | `true` | 保留项 —— Ruff 始终开启；服务器尚未读取此项 |
-| `basilisk.ruff.executablePath` | `"ruff"` | 保留项 —— 服务器从 PATH 解析 ruff；尚未读取此项 |
+| `basilisk.formatter` | `"ruff"` | 格式化引擎 —— `"ruff"` 使用内嵌于 Basilisk 二进制文件中的 Ruff 格式化器（进程内运行；无需任何外部 `ruff` 二进制文件），`"none"` 则禁用格式化 |
 
 ---
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -763,15 +763,11 @@
           "default": true,
           "description": "Reserved: variable-type inlay hints are always shown. The language server does not yet read this setting (see EXTENSION-ACTIVITY-PANEL-PLAN.md)."
         },
-        "basilisk.ruff.enabled": {
-          "type": "boolean",
-          "default": true,
-          "description": "Reserved: Ruff integration is always on. The language server does not yet read this setting (see EXTENSION-ACTIVITY-PANEL-PLAN.md)."
-        },
-        "basilisk.ruff.executablePath": {
+        "basilisk.formatter": {
           "type": "string",
+          "enum": ["ruff", "none"],
           "default": "ruff",
-          "description": "Reserved: the language server resolves ruff from PATH and does not yet read this setting (see EXTENSION-ACTIVITY-PANEL-PLAN.md)."
+          "description": "Formatter engine. 'ruff' uses the Ruff formatter embedded in the Basilisk binary (in-process — no external ruff binary is ever required or spawned); 'none' disables formatting. See LSP-FORMATTING-SPEC.md#LSPFMT-CONFIG."
         },
         "basilisk.uv.enabled": {
           "type": "boolean",

--- a/vscode-extension/src/lsp-client.ts
+++ b/vscode-extension/src/lsp-client.ts
@@ -31,13 +31,6 @@ function readInlayHints(cfg: vscode.WorkspaceConfiguration): Record<string, unkn
   };
 }
 
-function readRuffSettings(cfg: vscode.WorkspaceConfiguration): Record<string, unknown> {
-  return {
-    enabled: cfg.get<boolean>("ruff.enabled") ?? true,
-    executablePath: cfg.get<string>("ruff.executablePath") ?? "ruff",
-  };
-}
-
 function readUvSettings(cfg: vscode.WorkspaceConfiguration): Record<string, unknown> {
   return {
     enabled: cfg.get<boolean>("uv.enabled") ?? true,
@@ -70,7 +63,6 @@ function readTestExplorerSettings(cfg: vscode.WorkspaceConfiguration): Record<st
 // config source ([ANALYSIS-CONFIG-PRI]), and forwarded to the server.
 export function readBasiliskSettings(): Record<string, unknown> {
   const cfg = vscode.workspace.getConfiguration("basilisk");
-  const ruff = readRuffSettings(cfg);
   // The "Type Checking" toggle (`basilisk.enabled`) MUST reach the server — the
   // LSP is authoritative for diagnostics, so it clears/suppresses them when the
   // toggle is off. Omitting it here left the toggle a cosmetic no-op (GitHub
@@ -85,9 +77,9 @@ export function readBasiliskSettings(): Record<string, unknown> {
       python: cfg.get<string>("python") ?? "",
       analysisMode: cfg.get<string>("analysisMode") ?? "wholeModule",
       inlayHints: readInlayHints(cfg),
-      ruff,
+      formatter: cfg.get<string>("formatter") ?? "ruff",
     },
-    ruff,
+    formatter: cfg.get<string>("formatter") ?? "ruff",
     uv: readUvSettings(cfg),
     testExplorer: readTestExplorerSettings(cfg),
   };

--- a/vscode-extension/src/test/suite/activity-panel.test.ts
+++ b/vscode-extension/src/test/suite/activity-panel.test.ts
@@ -275,16 +275,16 @@ suite("Basilisk Activity Panel E2E Tests", function () {
 
   test("toggleFeature command can toggle a boolean setting", async function () {
     const cfg = vscode.workspace.getConfiguration("basilisk");
-    const original = cfg.get<boolean>("ruff.enabled") ?? true;
+    const original = cfg.get<boolean>("uv.enabled") ?? true;
 
-    await vscode.commands.executeCommand("basilisk.toggleFeature", "basilisk.ruff.enabled", !original);
+    await vscode.commands.executeCommand("basilisk.toggleFeature", "basilisk.uv.enabled", !original);
 
-    const updated = vscode.workspace.getConfiguration("basilisk").get<boolean>("ruff.enabled");
+    const updated = vscode.workspace.getConfiguration("basilisk").get<boolean>("uv.enabled");
     assert.strictEqual(updated, !original, "toggleFeature should flip the setting value");
 
     // Restore original value.
     await vscode.workspace.getConfiguration().update(
-      "basilisk.ruff.enabled",
+      "basilisk.uv.enabled",
       undefined,
       vscode.ConfigurationTarget.Workspace,
     );

--- a/vscode-extension/src/test/suite/extension.test.ts
+++ b/vscode-extension/src/test/suite/extension.test.ts
@@ -186,25 +186,33 @@ suite('Basilisk Extension E2E Tests', () => {
         );
     });
 
-    test('Extension contributes basilisk.ruff.enabled setting', () => {
+    // The formatter is the Ruff engine embedded in the Basilisk binary — there is
+    // no external `ruff` binary, so there is no `ruff.executablePath`. The only
+    // formatter setting is the engine selector. [LSPFMT-CONFIG]
+    test('Extension contributes basilisk.formatter setting defaulting to "ruff"', () => {
         const cfg = vscode.workspace.getConfiguration('basilisk');
-        const inspected = cfg.inspect<boolean>('ruff.enabled');
-        assert.ok(inspected, 'basilisk.ruff.enabled should be a contributed setting');
-        assert.strictEqual(
-            inspected.defaultValue,
-            true,
-            'Default ruff.enabled should be true'
-        );
-    });
-
-    test('Extension contributes basilisk.ruff.executablePath setting', () => {
-        const cfg = vscode.workspace.getConfiguration('basilisk');
-        const inspected = cfg.inspect<string>('ruff.executablePath');
-        assert.ok(inspected, 'basilisk.ruff.executablePath should be a contributed setting');
+        const inspected = cfg.inspect<string>('formatter');
+        assert.ok(inspected, 'basilisk.formatter should be a contributed setting');
         assert.strictEqual(
             inspected.defaultValue,
             'ruff',
-            'Default ruff.executablePath should be "ruff"'
+            'Default formatter should be the embedded Ruff engine ("ruff")'
+        );
+    });
+
+    test('Extension does NOT contribute any basilisk.ruff.* setting', () => {
+        // The external ruff binary is jettisoned; a ruff path/toggle would be a
+        // dead, misleading setting. [LSPFMT-DECISION]
+        const cfg = vscode.workspace.getConfiguration('basilisk');
+        assert.strictEqual(
+            cfg.inspect('ruff.enabled')?.defaultValue,
+            undefined,
+            'basilisk.ruff.enabled must not exist'
+        );
+        assert.strictEqual(
+            cfg.inspect('ruff.executablePath')?.defaultValue,
+            undefined,
+            'basilisk.ruff.executablePath must not exist'
         );
     });
 

--- a/vscode-extension/src/test/suite/lsp-inlay-types.test.ts
+++ b/vscode-extension/src/test/suite/lsp-inlay-types.test.ts
@@ -1,0 +1,389 @@
+// Tests for [LSPARCH-FEATURES-INLAYHINTS].
+// See docs/specs/LSP-ARCHITECTURE-SPEC.md#LSPARCH-FEATURES-INLAYHINTS and the
+// implementation in crates/basilisk-lsp/src/inlay_hints.rs.
+/**
+ * INLINE TYPE VISIBILITY — end-to-end guardrail suite.
+ *
+ * Basilisk surfaces inferred types INLINE (the `int` / `bool` / `str`
+ * "bubbles" a user sees next to a name) via `textDocument/inlayHint`. The whole
+ * point is that a developer reads the type of a symbol WITHOUT hovering the
+ * mouse over it. This suite pins that behaviour down hard: it drives the real
+ * VS Code inlay-hint provider (which round-trips through the running LSP) across
+ * many variables and every inferable builtin type, and asserts the exact inline
+ * type label appears on the exact line of each symbol.
+ *
+ * A regression that stops inline types from rendering — or renders the wrong
+ * type, or double-renders over an already-annotated symbol — fails here.
+ *
+ * Prerequisites:
+ *   - The `basilisk` binary must be built: `cargo build -p basilisk-cli`
+ */
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import {
+    DIAGNOSTIC_TIMEOUT_MS,
+    SUITE_SETUP_TIMEOUT_MS,
+    openPythonFile,
+    closeAllEditors,
+    waitForLspReady,
+    replaceDocumentContent,
+    locate,
+    getInlayHints,
+    inlayLabelsOnLine,
+    normalizedInlayLabel,
+    waitForInlayLabel,
+} from './test-helpers';
+
+/** Additional time (ms) added to DIAGNOSTIC_TIMEOUT_MS for individual test timeouts. */
+const EXTRA_TEST_TIMEOUT_MS = 10_000;
+
+/** A `[variable-name, expected normalised inline type]` expectation. */
+type InlineTypeCase = [string, string];
+
+/** Assert an inline `:type` hint (normalised) sits on the variable's own line. */
+function assertInlineTypeOnVar(
+    hints: readonly vscode.InlayHint[],
+    source: string,
+    testCase: InlineTypeCase,
+): void {
+    const [varName, expected] = testCase;
+    const line = locate(source, varName).line;
+    const labels = inlayLabelsOnLine(hints, line);
+    assert.ok(
+        labels.includes(expected),
+        `Expected inline type "${expected}" on "${varName}" (line ${line}) ` +
+        `without hovering — got ${JSON.stringify(labels)}`,
+    );
+}
+
+/** Assert NO inline type hint is rendered on `varName`'s line (e.g. already annotated). */
+function assertNoInlineTypeOnVar(
+    hints: readonly vscode.InlayHint[],
+    source: string,
+    varName: string,
+): void {
+    const line = locate(source, varName).line;
+    const typeLabels = inlayLabelsOnLine(hints, line).filter((l) => l.startsWith(':'));
+    assert.deepStrictEqual(
+        typeLabels,
+        [],
+        `Expected NO inline type hint on already-annotated "${varName}" (line ${line}) ` +
+        `— got ${JSON.stringify(typeLabels)}`,
+    );
+}
+
+// eslint-disable-next-line max-lines-per-function -- suite callback contains all tests
+suite('Inline Type Visibility (inlay hints)', () => {
+    let tmpDir: string;
+
+    suiteSetup(async function () {
+        this.timeout(SUITE_SETUP_TIMEOUT_MS);
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'basilisk-inlay-types-'));
+        await waitForLspReady();
+        await closeAllEditors();
+    });
+
+    suiteTeardown(async () => {
+        await closeAllEditors();
+        if (tmpDir !== undefined && tmpDir !== '' && fs.existsSync(tmpDir)) {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    teardown(async () => {
+        await closeAllEditors();
+    });
+
+    // ----------------------------------------------------------------
+    // 1. Every inferable builtin type is shown inline on its variable.
+    // ----------------------------------------------------------------
+    test('module-level variables show an inline type for every builtin kind', async function () {
+        this.timeout(DIAGNOSTIC_TIMEOUT_MS + EXTRA_TEST_TIMEOUT_MS);
+
+        const source = [
+            'an_int = 42',
+            'a_float = 3.14',
+            'a_str = "hello"',
+            'yes_flag = True',
+            'no_flag = False',
+            'some_bytes = b"data"',
+            'nothing = None',
+            'numbers = [1, 2, 3]',
+            'mapping = {"k": "v"}',
+            'uniques = {1, 2, 3}',
+            'pair = (1, 2)',
+            '',
+        ].join('\n');
+
+        const { doc } = await openPythonFile(tmpDir, 'inlay_all_types.py', source);
+        const cases: InlineTypeCase[] = [
+            ['an_int', ':int'],
+            ['a_float', ':float'],
+            ['a_str', ':str'],
+            ['yes_flag', ':bool'],
+            ['no_flag', ':bool'],
+            ['some_bytes', ':bytes'],
+            ['nothing', ':None'],
+            ['numbers', ':list'],
+            ['mapping', ':dict'],
+            ['uniques', ':set'],
+            ['pair', ':tuple'],
+        ];
+
+        const hints = await getInlayHints(doc, cases.length);
+        assert.ok(
+            hints.length >= cases.length,
+            `Expected at least ${cases.length} inline type hints (one per variable), ` +
+            `got ${hints.length}`,
+        );
+        cases.forEach((testCase) => assertInlineTypeOnVar(hints, source, testCase));
+    });
+
+    // ----------------------------------------------------------------
+    // 2. Inline type hints are rendered as TYPE hints (the "bubbles"),
+    //    never as parameter hints.
+    // ----------------------------------------------------------------
+    test('inline type hints carry InlayHintKind.Type', async function () {
+        this.timeout(DIAGNOSTIC_TIMEOUT_MS + EXTRA_TEST_TIMEOUT_MS);
+
+        const source = [
+            'width = 1920',
+            'height = 1080',
+            'title = "screen"',
+            'visible = True',
+            '',
+        ].join('\n');
+
+        const { doc } = await openPythonFile(tmpDir, 'inlay_kind.py', source);
+        const hints = await getInlayHints(doc, 4);
+
+        const typeHints = hints.filter((h) => normalizedInlayLabel(h).startsWith(':'));
+        assert.ok(
+            typeHints.length >= 4,
+            `Expected at least 4 inline type hints, got ${typeHints.length}`,
+        );
+        typeHints.forEach((h) =>
+            assert.strictEqual(
+                h.kind,
+                vscode.InlayHintKind.Type,
+                `Inline type hint ${JSON.stringify(normalizedInlayLabel(h))} must be ` +
+                `InlayHintKind.Type, was ${String(h.kind)}`,
+            ),
+        );
+    });
+
+    // ----------------------------------------------------------------
+    // 3. Function-local unannotated variables also show inline types.
+    // ----------------------------------------------------------------
+    test('function-local variables show inline types', async function () {
+        this.timeout(DIAGNOSTIC_TIMEOUT_MS + EXTRA_TEST_TIMEOUT_MS);
+
+        const source = [
+            'def compute():',
+            '    total = 0',
+            '    label = "sum"',
+            '    ratio = 2.5',
+            '    active = True',
+            '    blob = b"x"',
+            '',
+        ].join('\n');
+
+        const { doc } = await openPythonFile(tmpDir, 'inlay_locals.py', source);
+        const hints = await getInlayHints(doc, 5);
+
+        assertInlineTypeOnVar(hints, source, ['total', ':int']);
+        assertInlineTypeOnVar(hints, source, ['label', ':str']);
+        assertInlineTypeOnVar(hints, source, ['ratio', ':float']);
+        assertInlineTypeOnVar(hints, source, ['active', ':bool']);
+        assertInlineTypeOnVar(hints, source, ['blob', ':bytes']);
+    });
+
+    // ----------------------------------------------------------------
+    // 4. The real screenshot scenario: annotated symbols keep their
+    //    source type (no duplicate hint); the gaps get filled inline.
+    // ----------------------------------------------------------------
+    test('annotated symbols are not double-typed; unannotated neighbours are filled', async function () {
+        this.timeout(DIAGNOSTIC_TIMEOUT_MS + EXTRA_TEST_TIMEOUT_MS);
+
+        const source = [
+            'timeout: int = 100',
+            'one_flag: bool = True',
+            'other_flag: bool = False',
+            'retries = 5',
+            'label = "ready"',
+            '',
+        ].join('\n');
+
+        const { doc } = await openPythonFile(tmpDir, 'inlay_mixed.py', source);
+        const hints = await getInlayHints(doc, 2);
+
+        // Explicitly-annotated symbols already show their type in source — no hint.
+        assertNoInlineTypeOnVar(hints, source, 'timeout');
+        assertNoInlineTypeOnVar(hints, source, 'one_flag');
+        assertNoInlineTypeOnVar(hints, source, 'other_flag');
+
+        // The unannotated neighbours DO get an inline type.
+        assertInlineTypeOnVar(hints, source, ['retries', ':int']);
+        assertInlineTypeOnVar(hints, source, ['label', ':str']);
+    });
+
+    // ----------------------------------------------------------------
+    // 5. Functions without a return annotation show an inline "-> type".
+    // ----------------------------------------------------------------
+    test('functions show an inline return type without hovering', async function () {
+        this.timeout(DIAGNOSTIC_TIMEOUT_MS + EXTRA_TEST_TIMEOUT_MS);
+
+        const source = [
+            'def get_count():',
+            '    return 42',
+            '',
+            'def get_name():',
+            '    return "hello"',
+            '',
+            'def do_nothing():',
+            '    pass',
+            '',
+        ].join('\n');
+
+        const { doc } = await openPythonFile(tmpDir, 'inlay_returns.py', source);
+        const hints = await getInlayHints(doc, 3);
+
+        function returnLabelsOn(needle: string): string[] {
+            return inlayLabelsOnLine(hints, locate(source, needle).line);
+        }
+
+        assert.ok(
+            returnLabelsOn('def get_count').includes('->int'),
+            `Expected inline "-> int" on get_count — got ${JSON.stringify(returnLabelsOn('def get_count'))}`,
+        );
+        assert.ok(
+            returnLabelsOn('def get_name').includes('->str'),
+            `Expected inline "-> str" on get_name — got ${JSON.stringify(returnLabelsOn('def get_name'))}`,
+        );
+        assert.ok(
+            returnLabelsOn('def do_nothing').includes('->None'),
+            `Expected inline "-> None" on do_nothing — got ${JSON.stringify(returnLabelsOn('def do_nothing'))}`,
+        );
+    });
+
+    // ----------------------------------------------------------------
+    // 6. Call sites show which parameter each argument binds to, inline.
+    // ----------------------------------------------------------------
+    test('call sites show inline parameter-name hints', async function () {
+        this.timeout(DIAGNOSTIC_TIMEOUT_MS + EXTRA_TEST_TIMEOUT_MS);
+
+        const source = [
+            'def greet(name, count):',
+            '    return count',
+            '',
+            'greet("bob", 3)',
+            '',
+        ].join('\n');
+
+        const { doc } = await openPythonFile(tmpDir, 'inlay_params.py', source);
+        const hints = await getInlayHints(doc, 2);
+
+        const callLine = locate(source, 'greet("bob"').line;
+        const callLabels = inlayLabelsOnLine(hints, callLine);
+        assert.ok(
+            callLabels.includes('name='),
+            `Expected inline "name=" hint at the call site — got ${JSON.stringify(callLabels)}`,
+        );
+        assert.ok(
+            callLabels.includes('count='),
+            `Expected inline "count=" hint at the call site — got ${JSON.stringify(callLabels)}`,
+        );
+
+        const paramHints = hints.filter((h) => normalizedInlayLabel(h).endsWith('='));
+        assert.ok(paramHints.length >= 2, `Expected at least 2 parameter-name hints, got ${paramHints.length}`);
+        paramHints.forEach((h) =>
+            assert.strictEqual(
+                h.kind,
+                vscode.InlayHintKind.Parameter,
+                `Parameter-name hint ${JSON.stringify(normalizedInlayLabel(h))} must be ` +
+                `InlayHintKind.Parameter, was ${String(h.kind)}`,
+            ),
+        );
+    });
+
+    // ----------------------------------------------------------------
+    // 7. Inline types are LIVE — they follow the value as it changes,
+    //    never showing a stale type.
+    // ----------------------------------------------------------------
+    test('inline type stays correct as the value changes', async function () {
+        this.timeout((DIAGNOSTIC_TIMEOUT_MS + EXTRA_TEST_TIMEOUT_MS) * 2);
+
+        const { doc } = await openPythonFile(tmpDir, 'inlay_live.py', 'value = 1\n');
+
+        const initial = await waitForInlayLabel({ doc, line: 0, label: ':int' });
+        assert.ok(
+            inlayLabelsOnLine(initial, 0).includes(':int'),
+            `Expected inline ":int" for an int literal — got ${JSON.stringify(inlayLabelsOnLine(initial, 0))}`,
+        );
+
+        assert.ok(await replaceDocumentContent(doc, 'value = "text"\n'), 'edit to str should apply');
+        const asStr = await waitForInlayLabel({ doc, line: 0, label: ':str' });
+        assert.ok(
+            inlayLabelsOnLine(asStr, 0).includes(':str'),
+            `Expected inline ":str" after reassigning to a string — got ${JSON.stringify(inlayLabelsOnLine(asStr, 0))}`,
+        );
+
+        assert.ok(await replaceDocumentContent(doc, 'value = [1, 2, 3]\n'), 'edit to list should apply');
+        const asList = await waitForInlayLabel({ doc, line: 0, label: ':list' });
+        assert.ok(
+            inlayLabelsOnLine(asList, 0).includes(':list'),
+            `Expected inline ":list" after reassigning to a list — got ${JSON.stringify(inlayLabelsOnLine(asList, 0))}`,
+        );
+    });
+
+    // ----------------------------------------------------------------
+    // 8. A dense module surfaces an inline type for a LOT of variables.
+    // ----------------------------------------------------------------
+    test('a dense module surfaces an inline type for many variables at once', async function () {
+        this.timeout(DIAGNOSTIC_TIMEOUT_MS + EXTRA_TEST_TIMEOUT_MS);
+
+        const source = [
+            'port = 8080',
+            'host = "localhost"',
+            'debug = True',
+            'quiet = False',
+            'threshold = 0.75',
+            'payload = b"\\x00"',
+            'tags = ["a", "b"]',
+            'headers = {"accept": "json"}',
+            'seen = {1, 2}',
+            'coords = (0, 0)',
+            'placeholder = None',
+            'retries = 3',
+            '',
+        ].join('\n');
+
+        const { doc } = await openPythonFile(tmpDir, 'inlay_dense.py', source);
+        const expected: InlineTypeCase[] = [
+            ['port', ':int'],
+            ['host', ':str'],
+            ['debug', ':bool'],
+            ['quiet', ':bool'],
+            ['threshold', ':float'],
+            ['payload', ':bytes'],
+            ['tags', ':list'],
+            ['headers', ':dict'],
+            ['seen', ':set'],
+            ['coords', ':tuple'],
+            ['placeholder', ':None'],
+            ['retries', ':int'],
+        ];
+
+        const hints = await getInlayHints(doc, expected.length);
+        const typeHintCount = hints.filter((h) => normalizedInlayLabel(h).startsWith(':')).length;
+        assert.ok(
+            typeHintCount >= expected.length,
+            `Expected inline types for all ${expected.length} variables, got ${typeHintCount}`,
+        );
+        expected.forEach((testCase) => assertInlineTypeOnVar(hints, source, testCase));
+    });
+});

--- a/vscode-extension/src/test/suite/test-helpers.ts
+++ b/vscode-extension/src/test/suite/test-helpers.ts
@@ -374,6 +374,96 @@ export async function getHoverText(
     return extractHoverText(hovers);
 }
 
+// ── Inlay-hint helpers ───────────────────────────────────────────────
+// Shared so any suite can assert that Basilisk surfaces inferred types
+// INLINE (via `textDocument/inlayHint`) without the user hovering. See
+// [LSPARCH-FEATURES-INLAYHINTS].
+
+/** Flatten a VS Code inlay hint's label (string or label-parts) into one string. */
+export function inlayHintLabel(hint: vscode.InlayHint): string {
+    return typeof hint.label === 'string'
+        ? hint.label
+        : hint.label.map((part) => part.value).join('');
+}
+
+/**
+ * Whitespace-insensitive inlay-hint label so assertions are immune to padding
+ * differences: `": int"` → `":int"`, `" -> str"` → `"->str"`, `"name="` stays.
+ * Splits on spaces (no regex — see CLAUDE.md) which is all these labels contain.
+ */
+export function normalizedInlayLabel(hint: vscode.InlayHint): string {
+    return inlayHintLabel(hint).split(' ').join('');
+}
+
+/** The full-document range for a provider request. */
+function fullDocumentRange(doc: vscode.TextDocument): vscode.Range {
+    const lastLine = doc.lineCount - 1;
+    return new vscode.Range(
+        new vscode.Position(0, 0),
+        new vscode.Position(lastLine, doc.lineAt(lastLine).text.length),
+    );
+}
+
+/**
+ * Poll the whole-document inlay-hint provider until `predicate` holds. Returns
+ * `[]` on timeout — never throws — so callers assert with a descriptive message
+ * rather than an opaque poll failure. Analysis is async, so the first request
+ * can legitimately be empty.
+ */
+async function pollInlayHints(
+    doc: vscode.TextDocument,
+    predicate: (hints: vscode.InlayHint[]) => boolean,
+    timeoutMs: number,
+): Promise<vscode.InlayHint[]> {
+    const range = fullDocumentRange(doc);
+    return pollUntilResult({
+        fn: async () => vscode.commands.executeCommand<vscode.InlayHint[]>(
+            'vscode.executeInlayHintProvider', doc.uri, range,
+        ).then((r) => r ?? [], () => [] as vscode.InlayHint[]),
+        predicate,
+        timeoutMs,
+    }).catch(() => [] as vscode.InlayHint[]);
+}
+
+/** Poll until at least `minCount` inlay hints materialise over the document. */
+export async function getInlayHints(
+    doc: vscode.TextDocument,
+    minCount: number,
+    timeoutMs: number = DIAGNOSTIC_TIMEOUT_MS,
+): Promise<vscode.InlayHint[]> {
+    return pollInlayHints(doc, (r) => r.length >= minCount, timeoutMs);
+}
+
+/** Normalised inlay-hint labels present on `line` (0-based) of the document. */
+export function inlayLabelsOnLine(
+    hints: readonly vscode.InlayHint[],
+    line: number,
+): string[] {
+    return hints
+        .filter((hint) => hint.position.line === line)
+        .map(normalizedInlayLabel);
+}
+
+/** Arguments for {@link waitForInlayLabel}. */
+export interface InlayLabelWait {
+    doc: vscode.TextDocument;
+    line: number;
+    /** Normalised label to wait for, e.g. `":str"` (see {@link normalizedInlayLabel}). */
+    label: string;
+    timeoutMs?: number;
+}
+
+/**
+ * Poll the inlay-hint provider until a hint whose normalised label equals
+ * `label` appears on `line`. Returns the full hint list once satisfied, or `[]`
+ * on timeout. Used to assert that inline types stay CORRECT and LIVE after the
+ * document text changes.
+ */
+export async function waitForInlayLabel(opts: InlayLabelWait): Promise<vscode.InlayHint[]> {
+    const { doc, line, label, timeoutMs = DIAGNOSTIC_TIMEOUT_MS } = opts;
+    return pollInlayHints(doc, (r) => inlayLabelsOnLine(r, line).includes(label), timeoutMs);
+}
+
 /** Definition-family providers usable with {@link getNavLocations}. */
 export type NavProvider =
     | 'vscode.executeDefinitionProvider'


### PR DESCRIPTION
## TLDR
Establish the LSP-owned formatting architecture (embedded Ruff, **no `ruff` subprocess**) as spec + plan, migrate the VS Code formatter setting from `basilisk.ruff.*` to a single `basilisk.formatter` engine selector, and add e2e tests proving inferred types render **inline** (inlay hints) without hovering.

## What Was Added?
- **`docs/specs/LSP-FORMATTING-SPEC.md`** (`[LSPFMT]`) — new single source of truth for formatting + import hygiene as LSP capabilities served by the binary: embedded `ruff_python_formatter` (pure passthrough, config-respecting), native AST import fixers (`I`/`F403`/`E401`), engine provenance/versioning, and the `basilisk.formatter` config gate.
- **`docs/plans/LSP-FORMATTING-PLAN.md`** — implementation plan for the above.
- **`vscode-extension/src/test/suite/lsp-inlay-types.test.ts`** — 8 e2e tests driving the real VS Code inlay-hint provider through the running LSP, asserting inferred types are visible inline.
- Shared inlay-hint test helpers in **`test-helpers.ts`** (`getInlayHints`, `inlayLabelsOnLine`, `inlayHintLabel`, `normalizedInlayLabel`, `waitForInlayLabel`).
- **`basilisk.formatter`** setting (`enum ["ruff","none"]`, default `"ruff"`; `"ruff"` = the Ruff formatter embedded in the binary, no external `ruff` ever spawned).

## What Was Changed or Deleted?
- **Removed** the `basilisk.ruff.enabled` and `basilisk.ruff.executablePath` settings; removed `readRuffSettings()` in `lsp-client.ts`. The client now forwards a single `formatter` string to the server (in both the top-level payload and the analysis block).
- **`imports.rs` / `formatting.rs`** — added `CRITICAL TODO` doc-comments (referencing `[LSPFMT-DECISION]`/`[LSPFMT-ENGINE]`/`[LSPFMT-IMPORTS]`) documenting the jettison-the-subprocess target. **Doc-comment only — no behavior change** (formatting still delegates as before until the embedded engine lands).
- **`.github/workflows/ci.yml`** — change-scope classification split into per-extension flags (`core`/`vscode`/`nvim`/`zed`): each editor tree now triggers only its own job, while a `core` (Rust) change still fans out to the full matrix + all three extensions. Required checks stay green on any scope.
- **`activity-panel.test.ts`** — `toggleFeature` test now exercises `basilisk.uv.enabled` (the removed `ruff.enabled` was its previous subject).
- **`extension.test.ts`** — replaced the two `ruff.*` contribution tests with: `basilisk.formatter` defaults to `"ruff"`, and no `basilisk.ruff.*` setting exists.
- Cross-reference/ID updates across `INDEX.md`, `EXTENSION-ACTIVITY-PANEL-{SPEC,PLAN}`, `LSP-ARCHITECTURE-SPEC`, `LSP-TEST-INTEGRATION-SPEC`, `NEOVIM-SPEC`, `VSIX-SPEC`, `ZED-SPEC`, `CHECKER-ARCHITECTURE-SPEC`, and a formatter note in `README.md` / `README.zh.md`.

## How Do The Automated Tests Prove It Works?
- The 8 new **"Inline Type Visibility (inlay hints)"** VSIX tests all pass in `make _test_vsix` (full suite: **463 passing, 6 pending, 0 failing**). They assert, without any hover:
  - `module-level variables show an inline type for every builtin kind` — 11 vars → `:int/:float/:str/:bool/:bytes/:None/:list/:dict/:set/:tuple`
  - `inline type hints carry InlayHintKind.Type`
  - `function-local variables show inline types`
  - `annotated symbols are not double-typed; unannotated neighbours are filled` (the real screenshot case: `timeout: int`, `one_flag: bool` get no extra hint; `retries=5` → `:int`)
  - `functions show an inline return type without hovering` → `-> int/-> str/-> None`
  - `call sites show inline parameter-name hints` (`name=`, `count=`, kind `Parameter`)
  - `inline type stays correct as the value changes` (`1 → "text" → [1,2,3]` flips `:int → :str → :list`)
  - `a dense module surfaces an inline type for many variables at once`
- **`extension.test.ts`** — `Extension contributes basilisk.formatter setting defaulting to "ruff"` and `Extension does NOT contribute any basilisk.ruff.* setting` prove the config migration and that no dead `ruff.*` setting remains.

## Spec / Doc Changes
New `docs/specs/LSP-FORMATTING-SPEC.md` (`[LSPFMT]`) + `docs/plans/LSP-FORMATTING-PLAN.md`; the `[LSPFMT-*]` IDs are cross-referenced from the LSP/extension/editor specs and from the `imports.rs`/`formatting.rs` doc-comments (spec-ID web intact). README/README.zh gain a formatter note.

## Breaking Changes
- [x] Settings `basilisk.ruff.enabled` and `basilisk.ruff.executablePath` are **removed** and replaced by `basilisk.formatter` (enum `ruff`|`none`, default `ruff`). Both removed settings were "Reserved" no-ops the server never read, so there is **no functional behavior change** — but a user who had explicitly set them will see them disappear from their config.
