### PR TITLE
Fix LSP crash loop on self-named external bases and dead external-member hover (#278, #287)

### DIFF
--- a/benchmarks/status/darwin-arm64-apple-m4.csv
+++ b/benchmarks/status/darwin-arm64-apple-m4.csv
@@ -1,0 +1,53 @@
+# machine: Apple M4
+# cpu: Apple M4
+# arch: arm64
+# os: Darwin 25.5.0
+# cores: 10
+# tools: basilisk=basilisk 0.0.0-dev+g249cdee-dirty
+# runs: 10 (hyperfine mean wall-clock, milliseconds)
+# generated: 2026-07-09T11:03:59+0500
+# note: <tool>_ms = COLD full-file CLI check from scratch (whole process: startup + stubs + analysis). <tool>_diags = error diagnostics the tool reported on that fixture in the measured configuration (error severity only; warnings/notes are not counted) — read every time next to its diags; a tool that reports 0 analyzed the file but flagged no errors there. A blank _ms cell means the tool either was not installed on this machine or failed to analyze that fixture (exit >= 2, e.g. parse abort) and was excluded rather than timed as a crash. Only basilisk and mypy have a -warm column (they keep a real cross-run cache): basilisk-warm = --cache result-cache hit; mypy-warm = incremental .mypy_cache hit (cold mypy = --no-incremental). pyright/ty/pyrefly keep NO cross-run result cache (a repeat run = cold), so they are measured cold-only. zuban is also cold-only but its mypy mode DOES reuse a ./.mypy_cache when present (no flag disables it), so we wipe ./.mypy_cache before every timed run to keep the measurement cold. mypy runs with --strict so it performs the strict-mode analysis the fixtures stress (plain mypy reports 'no issues' on the strictness fixtures); zuban runs as `zuban mypy --strict` for the same reason (its default `zuban check` mode skips these strictness rules).
+fixture,basilisk_ms,basilisk-warm_ms,pyright_ms,mypy_ms,mypy-warm_ms,ty_ms,pyrefly_ms,zuban_ms,basilisk_diags,pyright_diags,mypy_diags,ty_diags,pyrefly_diags,zuban_diags
+aliases_type_statement,22.0,16.9,,,,,,,600,,,,,
+assignment_compatibility,24.5,23.0,,,,,,,2000,,,,,
+call_argument_types,27.9,18.2,,,,,,,998,,,,,
+callables_subtyping,27.3,16.3,,,,,,,600,,,,,
+classvar_scoping,30.0,19.8,,,,,,,2000,,,,,
+constructors_call_init,22.4,16.7,,,,,,,444,,,,,
+dataclasses_usage,22.9,16.8,,,,,,,500,,,,,
+dict_key_hashability,27.7,19.7,,,,,,,2000,,,,,
+e0001_missing_param,25.4,16.7,,,,,,,,,,,,
+e0002_missing_return,29.8,16.7,,,,,,,,,,,,
+e0010_unresolved_import,85.8,22.3,,,,,,,,,,,,
+e0011_explicit_any,29.6,18.2,,,,,,,,,,,,
+e0012_argument_type_mismatch,29.7,20.3,,,,,,,,,,,,
+e0014_assignment_incompatibility,27.2,21.4,,,,,,,,,,,,
+e0016_incompatible_override,64.5,17.1,,,,,,,,,,,,
+e0018_undefined_name,34.2,22.8,,,,,,,,,,,,
+e0022_unhashable_dict_key,30.0,22.0,,,,,,,,,,,,
+e0023_nonexhaustive_match,25.4,18.9,,,,,,,,,,,,
+e0026_typevar_single_constraint,35.6,22.7,,,,,,,,,,,,
+e0036_classvar_misuse,34.2,21.8,,,,,,,,,,,,
+e0038_typeddict_readonly_inheritance,104.1,18.5,,,,,,,,,,,,
+e0050_newtype_name_mismatch,29.1,22.6,,,,,,,,,,,,
+e0054_final_reassignment,22.6,17.8,,,,,,,,,,,,
+e0056_readonly_typeddict_mutation,52.5,18.0,,,,,,,,,,,,
+e0093_typeddict_invalid_key,50.2,18.3,,,,,,,,,,,,
+enums_member_values,22.5,18.2,,,,,,,480,,,,,
+final_reassignment,21.8,16.6,,,,,,,500,,,,,
+generics_defaults_specialization,23.4,16.7,,,,,,,560,,,,,
+literals_semantics,24.6,17.7,,,,,,,576,,,,,
+match_exhaustiveness,24.1,16.8,,,,,,,500,,,,,
+narrowing_typeis,20.5,14.5,,,,,,,520,,,,,
+newtype_definition,25.5,19.9,,,,,,,2000,,,,,
+overloads_evaluation,26.7,17.0,,,,,,,600,,,,,
+override_compatibility,26.8,16.3,,,,,,,200,,,,,
+protocols_definition,22.4,17.0,,,,,,,536,,,,,
+returns_compatibility,21.3,19.5,,,,,,,1080,,,,,
+tuples_index,23.9,17.4,,,,,,,600,,,,,
+typeddict_key_access,22.5,16.6,,,,,,,500,,,,,
+typeddict_readonly_inheritance,27.4,16.8,,,,,,,500,,,,,
+typeddict_readonly_mutation,23.2,17.1,,,,,,,500,,,,,
+typevar_constraints,33.1,19.8,,,,,,,2000,,,,,
+undefined_names,30.6,20.6,,,,,,,2000,,,,,
+unresolved_imports,33.5,20.6,,,,,,,2000,,,,,

--- a/crates/basilisk-checker/src/exports.rs
+++ b/crates/basilisk-checker/src/exports.rs
@@ -9,7 +9,7 @@
 //! a single implementation of "what does a module export" and "which of those
 //! exports does an import bind".
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use basilisk_resolver::scope::{ExternalMethod, ExternalSymbol, ExternalSymbolKind, ImportKind};
@@ -214,6 +214,76 @@ pub fn extract_py_typed_exports(py_path: &Path) -> Vec<(String, ExternalSymbol)>
     extract_exports(&resolved, py_path)
 }
 
+/// Resolve `name` through the re-export chain of a `py.typed` module.
+///
+/// A package `__init__.py` often defines nothing itself and re-exports its
+/// public names from submodules — pydantic v2 exposes `BaseModel` only via
+/// `if TYPE_CHECKING: from .main import *` (runtime uses a lazy module
+/// `__getattr__`). When the resolved file's own definitions miss `name`,
+/// follow its module-level `from … import name` and `from … import *`
+/// statements into the sibling module file and take the symbol — with its
+/// methods — from there (GitHub #287). `visited` breaks import cycles.
+fn chase_py_typed_reexport(
+    py_path: &Path,
+    name: &str,
+    external_cache: &mut HashMap<PathBuf, Vec<(String, ExternalSymbol)>>,
+    visited: &mut HashSet<PathBuf>,
+) -> Option<ExternalSymbol> {
+    if !visited.insert(py_path.to_path_buf()) {
+        return None;
+    }
+    let text = std::fs::read_to_string(py_path).ok()?;
+    let parsed =
+        basilisk_parser::parse_source(text, py_path.to_string_lossy().into_owned()).ok()?;
+    let resolved = basilisk_resolver::resolve(&parsed).ok()?;
+    let dir = py_path.parent()?;
+    resolved
+        .imports
+        .iter()
+        .filter(|import| match import.kind {
+            ImportKind::From => import.names.iter().any(|n| n == name),
+            ImportKind::Star => true,
+            ImportKind::Plain => false,
+        })
+        .filter_map(|import| sibling_module_file(dir, &import.module))
+        .find_map(|target| {
+            let direct = external_cache
+                .entry(target.clone())
+                .or_insert_with(|| extract_py_typed_exports(&target))
+                .iter()
+                .find(|(export_name, _)| export_name == name)
+                .map(|(_, symbol)| symbol.clone());
+            direct.or_else(|| chase_py_typed_reexport(&target, name, external_cache, visited))
+        })
+}
+
+/// Map a `from X import …` module inside a package to a sibling file.
+///
+/// Relative dots are dropped during import collection, so `.main` arrives as
+/// `main` and resolves against the importing file's directory; an absolute
+/// self-import (`pydantic.main`) resolves by stripping the package's own name.
+fn sibling_module_file(dir: &Path, module: &str) -> Option<PathBuf> {
+    let package_prefix = dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| format!("{n}."));
+    let in_package = package_prefix
+        .as_deref()
+        .and_then(|prefix| module.strip_prefix(prefix));
+    [Some(module), in_package]
+        .into_iter()
+        .flatten()
+        .find_map(|candidate| {
+            let base = dir.join(candidate.split('.').collect::<PathBuf>());
+            let file = base.with_extension("py");
+            if file.is_file() {
+                return Some(file);
+            }
+            let init = base.join("__init__.py");
+            init.is_file().then_some(init)
+        })
+}
+
 /// Build a function signature string from a parsed stub function.
 fn build_stub_signature(func: &StubFunction) -> String {
     let mut sig = format!("def {}(", func.name);
@@ -316,6 +386,7 @@ pub fn populate_imported_symbols<'a, F>(
 
         // Prefer workspace exports; otherwise parse an external `.pyi` stub
         // or an inline-typed `py.typed` package (PEP 561 opt-in only).
+        let mut py_typed_source = false;
         let target_exports: &[(String, ExternalSymbol)] = if let Some(exports) =
             workspace_exports(resolved_path)
         {
@@ -331,6 +402,7 @@ pub fn populate_imported_symbols<'a, F>(
         } else if resolved_path.extension().is_some_and(|ext| ext == "py")
             && basilisk_stubs::has_py_typed_marker(resolved_path)
         {
+            py_typed_source = true;
             external_cache
                 .entry(resolved_path.clone())
                 .or_insert_with(|| extract_py_typed_exports(resolved_path))
@@ -343,11 +415,34 @@ pub fn populate_imported_symbols<'a, F>(
         // object — it is not a member to look up in `foo`'s exports.
         if import.kind == ImportKind::From {
             // `from foo import bar, baz` — only import the named symbols.
-            for import_name in &import.names {
-                if let Some((_, symbol)) =
-                    target_exports.iter().find(|(name, _)| name == import_name)
-                {
-                    let _ = imported_symbols.insert(import_name.clone(), symbol.clone());
+            let direct: Vec<(String, Option<ExternalSymbol>)> = import
+                .names
+                .iter()
+                .map(|import_name| {
+                    let symbol = target_exports
+                        .iter()
+                        .find(|(name, _)| name == import_name)
+                        .map(|(_, symbol)| symbol.clone());
+                    (import_name.clone(), symbol)
+                })
+                .collect();
+            for (import_name, symbol) in direct {
+                // A `py.typed` package `__init__.py` may only *re-export* the
+                // name from a submodule (pydantic v2) — chase it (GitHub #287).
+                let symbol = symbol.or_else(|| {
+                    py_typed_source
+                        .then(|| {
+                            chase_py_typed_reexport(
+                                resolved_path,
+                                &import_name,
+                                &mut external_cache,
+                                &mut HashSet::new(),
+                            )
+                        })
+                        .flatten()
+                });
+                if let Some(symbol) = symbol {
+                    let _ = imported_symbols.insert(import_name, symbol);
                 }
             }
         } else {

--- a/crates/basilisk-checker/src/rules/constructors_call_init/helpers.rs
+++ b/crates/basilisk-checker/src/rules/constructors_call_init/helpers.rs
@@ -83,6 +83,19 @@ pub(super) fn has_custom_init_in_bases(
     class_map: &HashMap<&str, &ClassInfo>,
     method_map: &HashMap<(&str, &str), Vec<&basilisk_resolver::FunctionInfo>>,
 ) -> bool {
+    let mut visited = std::collections::HashSet::new();
+    let _ = visited.insert(class_info.name.as_str());
+    custom_init_walk(class_info, class_map, method_map, &mut visited)
+}
+
+/// Recursive body of [`has_custom_init_in_bases`]; `visited` breaks base-name
+/// cycles (GitHub #278).
+fn custom_init_walk<'a>(
+    class_info: &'a ClassInfo,
+    class_map: &HashMap<&str, &'a ClassInfo>,
+    method_map: &HashMap<(&str, &str), Vec<&basilisk_resolver::FunctionInfo>>,
+    visited: &mut std::collections::HashSet<&'a str>,
+) -> bool {
     for base_name in all_base_names(class_info) {
         if base_name == "object" || base_name == "Generic" || base_name == "Protocol" {
             continue;
@@ -101,9 +114,11 @@ pub(super) fn has_custom_init_in_bases(
         }
 
         // Recurse into the base's bases.
-        if let Some(base_class) = class_map.get(base_name) {
-            if has_custom_init_in_bases(base_class, class_map, method_map) {
-                return true;
+        if visited.insert(base_name) {
+            if let Some(base_class) = class_map.get(base_name) {
+                if custom_init_walk(base_class, class_map, method_map, visited) {
+                    return true;
+                }
             }
         }
     }
@@ -137,6 +152,20 @@ pub(super) fn find_init_in_hierarchy<'a>(
     class_map: &HashMap<&str, &ClassInfo>,
     method_map: &'a HashMap<(&str, &str), Vec<&'a basilisk_resolver::FunctionInfo>>,
 ) -> Option<Vec<&'a basilisk_resolver::FunctionInfo>> {
+    let mut visited = std::collections::HashSet::new();
+    let _ = visited.insert(class_info.name.as_str());
+    find_init_walk(class_name, class_info, class_map, method_map, &mut visited)
+}
+
+/// Recursive body of [`find_init_in_hierarchy`]; `visited` breaks base-name
+/// cycles (GitHub #278).
+fn find_init_walk<'a, 'b>(
+    class_name: &str,
+    class_info: &'b ClassInfo,
+    class_map: &HashMap<&str, &'b ClassInfo>,
+    method_map: &'a HashMap<(&str, &str), Vec<&'a basilisk_resolver::FunctionInfo>>,
+    visited: &mut std::collections::HashSet<&'b str>,
+) -> Option<Vec<&'a basilisk_resolver::FunctionInfo>> {
     // Check the class itself first.
     if let Some(funcs) = method_map.get(&(class_name, "__init__")) {
         return Some(funcs.clone());
@@ -152,9 +181,12 @@ pub(super) fn find_init_in_hierarchy<'a>(
             return Some(funcs.clone());
         }
 
+        if !visited.insert(base_name) {
+            continue;
+        }
         if let Some(base_class) = class_map.get(base_name) {
             if let Some(funcs) =
-                find_init_in_hierarchy(base_name, base_class, class_map, method_map)
+                find_init_walk(base_name, base_class, class_map, method_map, visited)
             {
                 return Some(funcs);
             }
@@ -170,6 +202,19 @@ pub(super) fn is_subclass(
     base_name: &str,
     class_map: &HashMap<&str, &ClassInfo>,
 ) -> bool {
+    let mut visited = std::collections::HashSet::new();
+    let _ = visited.insert(class_name);
+    subclass_walk(class_name, base_name, class_map, &mut visited)
+}
+
+/// Recursive body of [`is_subclass`]; `visited` breaks base-name cycles
+/// (GitHub #278).
+fn subclass_walk<'a>(
+    class_name: &str,
+    base_name: &str,
+    class_map: &HashMap<&str, &'a ClassInfo>,
+    visited: &mut std::collections::HashSet<&'a str>,
+) -> bool {
     let Some(class_info) = class_map.get(class_name) else {
         return false;
     };
@@ -178,7 +223,7 @@ pub(super) fn is_subclass(
         if base == base_name {
             return true;
         }
-        if is_subclass(base, base_name, class_map) {
+        if visited.insert(base) && subclass_walk(base, base_name, class_map, visited) {
             return true;
         }
     }

--- a/crates/basilisk-checker/tests/checker/constructors_call_init_tests.rs
+++ b/crates/basilisk-checker/tests/checker/constructors_call_init_tests.rs
@@ -162,3 +162,34 @@ BundleUploadResponse(bundle_id=1, sha256="abc")
     );
     Ok(())
 }
+
+// Issue #278: `class Client(httpx.Client)` records the base under its
+// attribute name `Client`, which collides with the class's own name — the
+// class map then resolves the "base" back to the class itself. Constructing
+// the class walks the `__init__` hierarchy; that walk must not recurse
+// forever on the self-referential chain (stack overflow, SIGABRT crash loop
+// in the LSP), and the call must not fire a false positive.
+#[test]
+fn self_named_external_base_constructor_call_does_not_overflow(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+import httpx
+
+
+class Client(httpx.Client):
+    def wrapped(self) -> str:
+        return "ok"
+
+
+c = Client()
+value = c.wrapped()
+"#;
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"constructors_call_init"),
+        "constructing a class whose name collides with its unresolved external \
+         base must not fire E0111; got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}

--- a/crates/basilisk-lsp/src/hover/tests.rs
+++ b/crates/basilisk-lsp/src/hover/tests.rs
@@ -137,6 +137,61 @@ fn test_hover_on_method_inherited_from_external_stub_base_shows_signature() {
     );
 }
 
+/// Regression for #287, real-package shape: `pydantic/__init__.py` defines no
+/// classes — it re-exports everything from `.main` via a **star import**
+/// inside an `if TYPE_CHECKING:` block (`from .main import *`; runtime uses a
+/// lazy module `__getattr__`). Export extraction must follow that re-export
+/// into `main.py`, so hovering an inherited `model_validate` shows its
+/// signature. Before this, extraction only kept symbols *defined* in the
+/// resolved `__init__.py`, and the hover returned nothing against the real
+/// pydantic package.
+#[test]
+fn test_hover_on_method_reexported_through_py_typed_package_init() {
+    let source = "from pydantic import BaseModel\n\nclass ComposerSavePayload(BaseModel):\n    name: str\n\np = ComposerSavePayload.model_validate({})\n";
+    let mut resolved = parse_and_resolve(source);
+
+    // A real py.typed package on disk, shaped like pydantic v2.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let pkg = dir.path().join("pydantic");
+    std::fs::create_dir(&pkg).expect("create package dir");
+    std::fs::write(pkg.join("py.typed"), "").expect("write py.typed marker");
+    std::fs::write(
+        pkg.join("__init__.py"),
+        "from typing import TYPE_CHECKING\n\nif TYPE_CHECKING:\n    from .main import *\n\n__all__ = ['BaseModel']\n",
+    )
+    .expect("write __init__.py");
+    std::fs::write(
+        pkg.join("main.py"),
+        "class BaseModel:\n    @classmethod\n    def model_validate(cls, obj: object) -> 'BaseModel': ...\n",
+    )
+    .expect("write main.py");
+    if let Some(import) = resolved.imports.first_mut() {
+        import.resolution = ImportResolution::SourcePy;
+        import.resolved_path = Some(pkg.join("__init__.py"));
+    }
+    basilisk_checker::exports::populate_imported_symbols(&mut resolved, |_| None, None);
+    assert!(
+        resolved.imported_symbols.contains_key("BaseModel"),
+        "the TYPE_CHECKING re-export in the package __init__ must surface \
+         `BaseModel` as an imported symbol"
+    );
+
+    // Hover on the `model_validate` call site.
+    let offset = source.rfind("model_validate").expect("usage present") + 1;
+    let hover = hover_at(&resolved, source, offset, &[]);
+    let hover =
+        hover.expect("hover should be Some for a method inherited through a re-exported base");
+    let HoverContents::Markup(markup) = hover.contents else {
+        panic!("expected Markup hover contents");
+    };
+
+    assert!(
+        markup.value.contains("BaseModel.model_validate"),
+        "hover should show the re-exported method's signature: {}",
+        markup.value
+    );
+}
+
 /// Regression for #289: hovering a class name must include the
 /// constructor's signature (the `__init__` hint) — `(class) Point` alone
 /// doesn't tell the user how to instantiate it.

--- a/crates/basilisk-lsp/src/salsa_engine.rs
+++ b/crates/basilisk-lsp/src/salsa_engine.rs
@@ -6,7 +6,7 @@
 //! **input** handles (one [`SourceFile`] per file, one [`ConfigInput`] per root,
 //! one [`SearchPathsInput`] for the workspace). On each analysis it syncs those
 //! inputs to the current values and reads the memoized queries
-//! ([`resolved_module`] for navigation, [`file_diagnostics_resolved`] for
+//! ([`cross_resolved_module`] for navigation, [`file_diagnostics_resolved`] for
 //! diagnostics), so re-analysing an unchanged file is served from the memo and a
 //! config-only edit re-runs only the cheap `check` step. Input handles are
 //! reused across calls (salsa memoization is identity-based), and every write
@@ -21,9 +21,9 @@ use std::sync::{Arc, Mutex};
 
 use basilisk_checker::imports::ImportSearchPaths;
 use basilisk_checker::{
-    cross_resolved_module, file_diagnostics_cross, file_diagnostics_resolved, resolved_module,
-    BasiliskDatabase, ConfigInput, ConfigValue, Diagnostic, FileRegistry, ResolvedFile,
-    SearchPathsInput, SourceFile, WorkspaceFiles,
+    cross_resolved_module, file_diagnostics_cross, file_diagnostics_resolved, BasiliskDatabase,
+    ConfigInput, ConfigValue, Diagnostic, FileRegistry, ResolvedFile, SearchPathsInput, SourceFile,
+    WorkspaceFiles,
 };
 use basilisk_config::BasiliskConfig;
 use dashmap::DashMap;
@@ -86,12 +86,14 @@ impl SalsaAnalysisEngine {
     /// against `search_paths`.
     ///
     /// `root_key` is the file's owning workspace root (the config-input key).
-    /// With `cross_module` set, analysis runs through the cross-module queries
-    /// ([`cross_resolved_module`] / [`file_diagnostics_cross`]): the resolved
-    /// module carries `imported_symbols` populated from the other tracked
-    /// files' **current** content, and editing an imported file's exports
-    /// invalidates exactly its importers. Without it, the plain queries keep
-    /// byte-for-byte CLI parity. [CHKARCH-INCREMENTAL-SALSA]
+    /// The resolved module always comes from [`cross_resolved_module`] and so
+    /// always carries `imported_symbols` — external stub/py.typed enrichment
+    /// drives hover, completion, and navigation in every mode (GitHub #287).
+    /// `cross_module` gates only the **diagnostics** query: with it set,
+    /// [`file_diagnostics_cross`] sees other tracked files' current content
+    /// and editing an imported file's exports invalidates exactly its
+    /// importers; without it, the plain diagnostics query keeps byte-for-byte
+    /// CLI parity. [CHKARCH-INCREMENTAL-SALSA]
     pub(crate) fn analyse(
         &self,
         path: &Path,
@@ -115,11 +117,12 @@ impl SalsaAnalysisEngine {
 
         // One memoized parse+resolve, whose outcome distinguishes a parse error
         // (→ BSK-PARSE) from a resolve error (→ nothing) from a resolved module.
-        let outcome = if cross_module {
-            cross_resolved_module(&*db, source, search_paths_input, workspace)
-        } else {
-            resolved_module(&*db, source, search_paths_input, workspace)
-        };
+        // The resolved view is always the cross-module one: its
+        // `imported_symbols` enrichment from stubs / py.typed packages drives
+        // hover, completion, and navigation for external symbols in every mode
+        // (GitHub #287). Diagnostics stay mode-gated below, so non-cross modes
+        // keep byte-for-byte CLI parity on what they report.
+        let outcome = cross_resolved_module(&*db, source, search_paths_input, workspace);
         match outcome {
             ResolvedFile::ParseError(message) => EngineAnalysis {
                 resolved: None,
@@ -313,6 +316,10 @@ impl SalsaAnalysisEngine {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test-only code: expect acceptable in unit tests"
+)]
 mod tests {
     use super::*;
 
@@ -326,6 +333,54 @@ mod tests {
             registry: None,
             typeshed_path: None,
         }
+    }
+
+    /// Regression for #287, wiring layer: the default (non-cross-module)
+    /// analysis must still populate `imported_symbols` from external
+    /// stub/py.typed packages. Hover, completion, and navigation read the
+    /// engine's resolved view; gating the enrichment on the reserved
+    /// `crossModule` mode left dot-access hover on inherited external methods
+    /// dead in every real editor session.
+    #[test]
+    fn default_mode_analysis_populates_external_imported_symbols() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let site = dir.path().join("site-packages");
+        let pkg = site.join("pydantic");
+        std::fs::create_dir_all(&pkg).expect("create package dir");
+        std::fs::write(pkg.join("py.typed"), "").expect("write py.typed marker");
+        std::fs::write(
+            pkg.join("__init__.py"),
+            "from typing import TYPE_CHECKING\n\nif TYPE_CHECKING:\n    from .main import *\n",
+        )
+        .expect("write __init__.py");
+        std::fs::write(
+            pkg.join("main.py"),
+            "class BaseModel:\n    @classmethod\n    def model_validate(cls, obj: object) -> 'BaseModel': ...\n",
+        )
+        .expect("write main.py");
+
+        let workspace = dir.path().join("ws");
+        std::fs::create_dir_all(&workspace).expect("create workspace dir");
+        let file = workspace.join("app.py");
+        let text = "from pydantic import BaseModel\n\nclass C(BaseModel):\n    name: str\n";
+        std::fs::write(&file, text).expect("write app.py");
+
+        let engine = SalsaAnalysisEngine::default();
+        let config = BasiliskConfig::default();
+        let mut search_paths = empty_search_paths();
+        search_paths.site_packages = Some(site);
+        search_paths.roots = vec![workspace.clone()];
+
+        let analysis = engine.analyse(&file, text, &config, &workspace, &search_paths, false);
+        let resolved = analysis.resolved.expect("module should resolve");
+        let base = resolved
+            .imported_symbols
+            .get("BaseModel")
+            .expect("default-mode analysis must populate external imported symbols (GitHub #287)");
+        assert!(
+            base.methods.iter().any(|m| m.name == "model_validate"),
+            "the re-exported class must carry its methods for dot-access hover"
+        );
     }
 
     /// A deleted file's `SourceFile` is dropped from the engine's map so its

--- a/mutation_testing/mutants_report.html
+++ b/mutation_testing/mutants_report.html
@@ -61,8 +61,8 @@
 </head>
 <body>
 <header>
-  <h1>Basilisk Mutation Report <span>cargo-mutants v27.0.0</span></h1>
-  <div class="meta">2026-06-28T15:38:05.697167Z → 2026-06-28T15:50:14.59564Z</div>
+  <h1>Basilisk Mutation Report <span>cargo-mutants v27.1.0</span></h1>
+  <div class="meta">2026-07-09T06:46:15.467451Z → 2026-07-09T07:00:15.877174Z</div>
 </header>
 
 <div class="stats">
@@ -71,7 +71,7 @@
     <div class="lbl">Mutation Score</div>
   </div>
   <div class="stat">
-    <div class="val">124</div>
+    <div class="val">125</div>
     <div class="lbl">Total Mutants</div>
   </div>
   <div class="stat">
@@ -79,7 +79,7 @@
     <div class="lbl">Missed</div>
   </div>
   <div class="stat">
-    <div class="val caught">117</div>
+    <div class="val caught">118</div>
     <div class="lbl">Caught</div>
   </div>
   <div class="stat">
@@ -94,7 +94,7 @@
 
 <div class="tabs">
   <div class="tab active" onclick="switchTab('missed')">Missed (0)</div>
-  <div class="tab" onclick="switchTab('caught')">Caught (117)</div>
+  <div class="tab" onclick="switchTab('caught')">Caught (118)</div>
   <div class="tab" onclick="switchTab('other')">Other (7)</div>
 </div>
 
@@ -113,15 +113,46 @@
           <tbody>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:80:53</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>131.4s</td>
+      <td class='loc'>crates/basilisk-checker/src/context.rs:82:13</td>
+      <td><code>CheckContext::from_config_with_source</code> -> Self <span class='badge genre'>StructField</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>109.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-0')">▶ show diff</div>
-        <pre id='diff-0' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace || with &amp;&amp; in collect_type_alias_names
+        <pre id='diff-0' class='diff hidden'>--- crates/basilisk-checker/src/context.rs
++++ delete field line_index from struct Self expression in CheckContext::from_config_with_source
+@@ -74,17 +74,17 @@
+         }
+     }
+ 
+     /// Build a context from configuration plus the module `source`, precomputing
+     /// the shared [`line_index`](Self::line_index) once for every rule to reuse.
+     #[must_use]
+     pub fn from_config_with_source(config: &amp;basilisk_config::BasiliskConfig, source: &amp;str) -&gt; Self {
+         Self {
+-            line_index: basilisk_common::text::LineIndex::new(source),
++             /* ~ changed by cargo-mutants ~ */
+             ..Self::from_config(config)
+         }
+     }
+ }
+ 
+ /// Parse `&quot;3.9&quot;` / `&quot;3.12.1&quot;` into `(major, minor)`.
+ fn parse_target_version(raw: &amp;str) -&gt; Option&lt;(u32, u32)&gt; {
+     let mut parts = raw.trim().split('.');
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:80:59</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>!=</code></td>
+      <td class='dur'>25.7s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-1')">▶ show diff</div>
+        <pre id='diff-1' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace == with != in collect_type_alias_names
 @@ -72,17 +72,17 @@
          };
          // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
@@ -132,7 +163,7 @@
              let alias: String = after
                  .chars()
 -                .take_while(|c| c.is_alphanumeric() || *c == '_')
-+                .take_while(|c| c.is_alphanumeric() &amp;&amp; /* ~ changed by cargo-mutants ~ */ *c == '_')
++                .take_while(|c| c.is_alphanumeric() || *c != /* ~ changed by cargo-mutants ~ */ '_')
                  .collect();
              if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
                  names.push(alias);
@@ -141,260 +172,17 @@
      }
      names
  }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:77:42</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>-</code></td>
-      <td class='dur'>135.5s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-1')">▶ show diff</div>
-        <pre id='diff-1' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace + with - in collect_type_alias_names
-@@ -69,17 +69,17 @@
-         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
-         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
-             continue;
-         };
-         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
-         // advances structurally past each match, so the loop cannot be turned
-         // into an infinite loop by mutating an arithmetic advance step.
-         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
--            let after = &amp;import_text[pos + marker.len()..];
-+            let after = &amp;import_text[pos - /* ~ changed by cargo-mutants ~ */ marker.len()..];
-             let alias: String = after
-                 .chars()
-                 .take_while(|c| c.is_alphanumeric() || *c == '_')
-                 .collect();
-             if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
-                 names.push(alias);
-             }
-         }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:63:24</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>136.8s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-2')">▶ show diff</div>
-        <pre id='diff-2' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace != with == in collect_type_alias_names
-@@ -55,17 +55,17 @@
- ///
- /// Handles:
- /// - `from typing import TypeAlias`
- /// - `from typing import TypeAlias as TA`
- /// - `import typing` (used as `typing.TypeAlias`)
- fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
-     let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
-     for import in &amp;module.imports {
--        if import.kind != ImportKind::From {
-+        if import.kind == /* ~ changed by cargo-mutants ~ */ ImportKind::From {
-             continue;
-         }
-         if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
-             continue;
-         }
-         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
-         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
-             continue;
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:61:5</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>vec![]</code></td>
-      <td class='dur'>143.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-3')">▶ show diff</div>
-        <pre id='diff-3' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace collect_type_alias_names -&gt; Vec&lt;String&gt; with vec![]
-@@ -53,43 +53,17 @@
- 
- /// Collect all local names that refer to `typing.TypeAlias` in this module.
- ///
- /// Handles:
- /// - `from typing import TypeAlias`
- /// - `from typing import TypeAlias as TA`
- /// - `import typing` (used as `typing.TypeAlias`)
- fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
--    let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
--    for import in &amp;module.imports {
--        if import.kind != ImportKind::From {
--            continue;
--        }
--        if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
--            continue;
--        }
--        // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
--        let Some(import_text) = slice_span(&amp;module.source, import.span) else {
--            continue;
--        };
--        // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
--        // advances structurally past each match, so the loop cannot be turned
--        // into an infinite loop by mutating an arithmetic advance step.
--        for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
--            let after = &amp;import_text[pos + marker.len()..];
--            let alias: String = after
--                .chars()
--                .take_while(|c| c.is_alphanumeric() || *c == '_')
--                .collect();
--            if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
--                names.push(alias);
--            }
--        }
--    }
--    names
-+    vec![] /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Returns `true` when the annotation text matches one of the known `TypeAlias` names.
- fn is_type_alias_annotation(ann: &amp;str, type_alias_names: &amp;[String]) -&gt; bool {
-     let ann = ann.trim();
-     type_alias_names.iter().any(|n| ann == n) || ann.ends_with(&quot;.TypeAlias&quot;)
- }
- 
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:77:42</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>*</code></td>
-      <td class='dur'>151.0s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-4')">▶ show diff</div>
-        <pre id='diff-4' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace + with * in collect_type_alias_names
-@@ -69,17 +69,17 @@
-         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
-         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
-             continue;
-         };
-         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
-         // advances structurally past each match, so the loop cannot be turned
-         // into an infinite loop by mutating an arithmetic advance step.
-         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
--            let after = &amp;import_text[pos + marker.len()..];
-+            let after = &amp;import_text[pos * /* ~ changed by cargo-mutants ~ */ marker.len()..];
-             let alias: String = after
-                 .chars()
-                 .take_while(|c| c.is_alphanumeric() || *c == '_')
-                 .collect();
-             if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
-                 names.push(alias);
-             }
-         }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:66:26</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>151.4s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-5')">▶ show diff</div>
-        <pre id='diff-5' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace != with == in collect_type_alias_names
-@@ -58,17 +58,17 @@
- /// - `from typing import TypeAlias as TA`
- /// - `import typing` (used as `typing.TypeAlias`)
- fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
-     let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
-     for import in &amp;module.imports {
-         if import.kind != ImportKind::From {
-             continue;
-         }
--        if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
-+        if import.module == /* ~ changed by cargo-mutants ~ */ &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
-             continue;
-         }
-         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
-         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
-             continue;
-         };
-         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
-         // advances structurally past each match, so the loop cannot be turned
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:82:16</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>22.3s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-6')">▶ show diff</div>
-        <pre id='diff-6' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ delete ! in collect_type_alias_names
-@@ -74,17 +74,17 @@
-         // advances structurally past each match, so the loop cannot be turned
-         // into an infinite loop by mutating an arithmetic advance step.
-         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
-             let after = &amp;import_text[pos + marker.len()..];
-             let alias: String = after
-                 .chars()
-                 .take_while(|c| c.is_alphanumeric() || *c == '_')
-                 .collect();
--            if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
-+            if  /* ~ changed by cargo-mutants ~ */alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
-                 names.push(alias);
-             }
-         }
-     }
-     names
- }
- 
- /// Returns `true` when the annotation text matches one of the known `TypeAlias` names.
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:82:43</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>23.9s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-7')">▶ show diff</div>
-        <pre id='diff-7' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace != with == in collect_type_alias_names
-@@ -74,17 +74,17 @@
-         // advances structurally past each match, so the loop cannot be turned
-         // into an infinite loop by mutating an arithmetic advance step.
-         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
-             let after = &amp;import_text[pos + marker.len()..];
-             let alias: String = after
-                 .chars()
-                 .take_while(|c| c.is_alphanumeric() || *c == '_')
-                 .collect();
--            if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
-+            if !alias.is_empty() &amp;&amp; alias == /* ~ changed by cargo-mutants ~ */ &quot;TypeAlias&quot; {
-                 names.push(alias);
-             }
-         }
-     }
-     names
- }
- 
- /// Returns `true` when the annotation text matches one of the known `TypeAlias` names.
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:61:5</td>
       <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>vec![String::new()]</code></td>
-      <td class='dur'>161.8s</td>
+      <td class='dur'>165.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-8')">▶ show diff</div>
-        <pre id='diff-8' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
+        <div class='diff-toggle' onclick="toggle('diff-2')">▶ show diff</div>
+        <pre id='diff-2' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
 +++ replace collect_type_alias_names -&gt; Vec&lt;String&gt; with vec![String::new()]
 @@ -53,43 +53,17 @@
  
@@ -444,14 +232,107 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:82:16</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>36.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-3')">▶ show diff</div>
+        <pre id='diff-3' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ delete ! in collect_type_alias_names
+@@ -74,17 +74,17 @@
+         // advances structurally past each match, so the loop cannot be turned
+         // into an infinite loop by mutating an arithmetic advance step.
+         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
+             let after = &amp;import_text[pos + marker.len()..];
+             let alias: String = after
+                 .chars()
+                 .take_while(|c| c.is_alphanumeric() || *c == '_')
+                 .collect();
+-            if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
++            if  /* ~ changed by cargo-mutants ~ */alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
+                 names.push(alias);
+             }
+         }
+     }
+     names
+ }
+ 
+ /// Returns `true` when the annotation text matches one of the known `TypeAlias` names.
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:66:55</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>177.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-4')">▶ show diff</div>
+        <pre id='diff-4' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace != with == in collect_type_alias_names
+@@ -58,17 +58,17 @@
+ /// - `from typing import TypeAlias as TA`
+ /// - `import typing` (used as `typing.TypeAlias`)
+ fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
+     let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
+     for import in &amp;module.imports {
+         if import.kind != ImportKind::From {
+             continue;
+         }
+-        if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
++        if import.module != &quot;typing&quot; &amp;&amp; import.module == /* ~ changed by cargo-mutants ~ */ &quot;typing_extensions&quot; {
+             continue;
+         }
+         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
+         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
+             continue;
+         };
+         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
+         // advances structurally past each match, so the loop cannot be turned
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:63:24</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>181.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-5')">▶ show diff</div>
+        <pre id='diff-5' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace != with == in collect_type_alias_names
+@@ -55,17 +55,17 @@
+ ///
+ /// Handles:
+ /// - `from typing import TypeAlias`
+ /// - `from typing import TypeAlias as TA`
+ /// - `import typing` (used as `typing.TypeAlias`)
+ fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
+     let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
+     for import in &amp;module.imports {
+-        if import.kind != ImportKind::From {
++        if import.kind == /* ~ changed by cargo-mutants ~ */ ImportKind::From {
+             continue;
+         }
+         if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
+             continue;
+         }
+         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
+         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
+             continue;
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:166:5</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>true</code></td>
-      <td class='dur'>27.7s</td>
+      <td class='dur'>29.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-9')">▶ show diff</div>
-        <pre id='diff-9' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
+        <div class='diff-toggle' onclick="toggle('diff-6')">▶ show diff</div>
+        <pre id='diff-6' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
 +++ replace has_top_level_token -&gt; bool with true
 @@ -158,33 +158,17 @@
          return true;
@@ -491,14 +372,185 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:61:5</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>vec![&quot;xyzzy&quot;.into()]</code></td>
-      <td class='dur'>168.1s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:82:43</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>34.6s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-7')">▶ show diff</div>
+        <pre id='diff-7' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace != with == in collect_type_alias_names
+@@ -74,17 +74,17 @@
+         // advances structurally past each match, so the loop cannot be turned
+         // into an infinite loop by mutating an arithmetic advance step.
+         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
+             let after = &amp;import_text[pos + marker.len()..];
+             let alias: String = after
+                 .chars()
+                 .take_while(|c| c.is_alphanumeric() || *c == '_')
+                 .collect();
+-            if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
++            if !alias.is_empty() &amp;&amp; alias == /* ~ changed by cargo-mutants ~ */ &quot;TypeAlias&quot; {
+                 names.push(alias);
+             }
+         }
+     }
+     names
+ }
+ 
+ /// Returns `true` when the annotation text matches one of the known `TypeAlias` names.
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:166:5</td>
+      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>false</code></td>
+      <td class='dur'>30.0s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-8')">▶ show diff</div>
+        <pre id='diff-8' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace has_top_level_token -&gt; bool with false
+@@ -158,33 +158,17 @@
+         return true;
+     }
+ 
+     false
+ }
+ 
+ /// Returns `true` when the text contains `token` at bracket depth 0.
+ fn has_top_level_token(s: &amp;str, token: &amp;str) -&gt; bool {
+-    let mut depth = 0i32;
+-    let bytes = s.as_bytes();
+-    let tok = token.as_bytes();
+-    let tok_len = tok.len();
+-    // `enumerate` yields each index exactly once — forward progress is
+-    // structural, so mutating the loop counter is impossible.
+-    for (i, &amp;byte) in bytes.iter().enumerate() {
+-        match byte {
+-            b'[' | b'(' | b'{' =&gt; depth += 1,
+-            b']' | b')' | b'}' =&gt; depth -= 1,
+-            _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
+-                return true;
+-            }
+-            _ =&gt; {}
+-        }
+-    }
+-    false
++    false /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Returns `true` when `(...)` contains a comma at depth 0 inside the parens.
+ fn paren_has_top_level_comma(s: &amp;str) -&gt; bool {
+     if s.len() &lt; 2 {
+         return false;
+     }
+     crate::rules::shared::contains_top_level_comma(&amp;s[1..s.len() - 1])
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:174:13</td>
+      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArm</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>37.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-9')">▶ show diff</div>
+        <pre id='diff-9' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ delete match arm b'[' | b'(' | b'{' in has_top_level_token
+@@ -166,17 +166,17 @@
+     let mut depth = 0i32;
+     let bytes = s.as_bytes();
+     let tok = token.as_bytes();
+     let tok_len = tok.len();
+     // `enumerate` yields each index exactly once — forward progress is
+     // structural, so mutating the loop counter is impossible.
+     for (i, &amp;byte) in bytes.iter().enumerate() {
+         match byte {
+-            b'[' | b'(' | b'{' =&gt; depth += 1,
++             /* ~ changed by cargo-mutants ~ */
+             b']' | b')' | b'}' =&gt; depth -= 1,
+             _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
+                 return true;
+             }
+             _ =&gt; {}
+         }
+     }
+     false
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:18</td>
+      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArmGuard</span></td>
+      <td><code class='replacement'>true</code></td>
+      <td class='dur'>37.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-10')">▶ show diff</div>
         <pre id='diff-10' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace match guard depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) with true in has_top_level_token
+@@ -168,17 +168,17 @@
+     let tok = token.as_bytes();
+     let tok_len = tok.len();
+     // `enumerate` yields each index exactly once — forward progress is
+     // structural, so mutating the loop counter is impossible.
+     for (i, &amp;byte) in bytes.iter().enumerate() {
+         match byte {
+             b'[' | b'(' | b'{' =&gt; depth += 1,
+             b']' | b')' | b'}' =&gt; depth -= 1,
+-            _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
++            _ if true /* ~ changed by cargo-mutants ~ */ =&gt; {
+                 return true;
+             }
+             _ =&gt; {}
+         }
+     }
+     false
+ }
+ 
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:174:41</td>
+      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>-=</code></td>
+      <td class='dur'>26.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-11')">▶ show diff</div>
+        <pre id='diff-11' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace += with -= in has_top_level_token
+@@ -166,17 +166,17 @@
+     let mut depth = 0i32;
+     let bytes = s.as_bytes();
+     let tok = token.as_bytes();
+     let tok_len = tok.len();
+     // `enumerate` yields each index exactly once — forward progress is
+     // structural, so mutating the loop counter is impossible.
+     for (i, &amp;byte) in bytes.iter().enumerate() {
+         match byte {
+-            b'[' | b'(' | b'{' =&gt; depth += 1,
++            b'[' | b'(' | b'{' =&gt; depth -= /* ~ changed by cargo-mutants ~ */ 1,
+             b']' | b')' | b'}' =&gt; depth -= 1,
+             _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
+                 return true;
+             }
+             _ =&gt; {}
+         }
+     }
+     false
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:61:5</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>vec![&quot;xyzzy&quot;.into()]</code></td>
+      <td class='dur'>246.9s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-12')">▶ show diff</div>
+        <pre id='diff-12' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
 +++ replace collect_type_alias_names -&gt; Vec&lt;String&gt; with vec![&quot;xyzzy&quot;.into()]
 @@ -53,43 +53,17 @@
  
@@ -548,72 +600,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:66:55</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>173.7s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-11')">▶ show diff</div>
-        <pre id='diff-11' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace != with == in collect_type_alias_names
-@@ -58,17 +58,17 @@
- /// - `from typing import TypeAlias as TA`
- /// - `import typing` (used as `typing.TypeAlias`)
- fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
-     let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
-     for import in &amp;module.imports {
-         if import.kind != ImportKind::From {
-             continue;
-         }
--        if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
-+        if import.module != &quot;typing&quot; &amp;&amp; import.module == /* ~ changed by cargo-mutants ~ */ &quot;typing_extensions&quot; {
-             continue;
-         }
-         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
-         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
-             continue;
-         };
-         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
-         // advances structurally past each match, so the loop cannot be turned
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:174:13</td>
-      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArm</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>23.6s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-12')">▶ show diff</div>
-        <pre id='diff-12' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ delete match arm b'[' | b'(' | b'{' in has_top_level_token
-@@ -166,17 +166,17 @@
-     let mut depth = 0i32;
-     let bytes = s.as_bytes();
-     let tok = token.as_bytes();
-     let tok_len = tok.len();
-     // `enumerate` yields each index exactly once — forward progress is
-     // structural, so mutating the loop counter is impossible.
-     for (i, &amp;byte) in bytes.iter().enumerate() {
-         match byte {
--            b'[' | b'(' | b'{' =&gt; depth += 1,
-+             /* ~ changed by cargo-mutants ~ */
-             b']' | b')' | b'}' =&gt; depth -= 1,
-             _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
-                 return true;
-             }
-             _ =&gt; {}
-         }
-     }
-     false
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:175:13</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArm</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>30.8s</td>
+      <td class='dur'>50.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-13')">▶ show diff</div>
@@ -641,92 +631,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:166:5</td>
-      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:18</td>
+      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArmGuard</span></td>
       <td><code class='replacement'>false</code></td>
-      <td class='dur'>42.5s</td>
+      <td class='dur'>44.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-14')">▶ show diff</div>
         <pre id='diff-14' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace has_top_level_token -&gt; bool with false
-@@ -158,33 +158,17 @@
-         return true;
-     }
- 
-     false
- }
- 
- /// Returns `true` when the text contains `token` at bracket depth 0.
- fn has_top_level_token(s: &amp;str, token: &amp;str) -&gt; bool {
--    let mut depth = 0i32;
--    let bytes = s.as_bytes();
--    let tok = token.as_bytes();
--    let tok_len = tok.len();
--    // `enumerate` yields each index exactly once — forward progress is
--    // structural, so mutating the loop counter is impossible.
--    for (i, &amp;byte) in bytes.iter().enumerate() {
--        match byte {
--            b'[' | b'(' | b'{' =&gt; depth += 1,
--            b']' | b')' | b'}' =&gt; depth -= 1,
--            _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
--                return true;
--            }
--            _ =&gt; {}
--        }
--    }
--    false
-+    false /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Returns `true` when `(...)` contains a comma at depth 0 inside the parens.
- fn paren_has_top_level_comma(s: &amp;str) -&gt; bool {
-     if s.len() &lt; 2 {
-         return false;
-     }
-     crate::rules::shared::contains_top_level_comma(&amp;s[1..s.len() - 1])
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:80:59</td>
-      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>!=</code></td>
-      <td class='dur'>184.8s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-15')">▶ show diff</div>
-        <pre id='diff-15' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace == with != in collect_type_alias_names
-@@ -72,17 +72,17 @@
-         };
-         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
-         // advances structurally past each match, so the loop cannot be turned
-         // into an infinite loop by mutating an arithmetic advance step.
-         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
-             let after = &amp;import_text[pos + marker.len()..];
-             let alias: String = after
-                 .chars()
--                .take_while(|c| c.is_alphanumeric() || *c == '_')
-+                .take_while(|c| c.is_alphanumeric() || *c != /* ~ changed by cargo-mutants ~ */ '_')
-                 .collect();
-             if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
-                 names.push(alias);
-             }
-         }
-     }
-     names
- }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:18</td>
-      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArmGuard</span></td>
-      <td><code class='replacement'>false</code></td>
-      <td class='dur'>26.8s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-16')">▶ show diff</div>
-        <pre id='diff-16' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
 +++ replace match guard depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) with false in has_top_level_token
 @@ -168,17 +168,17 @@
      let tok = token.as_bytes();
@@ -750,32 +662,58 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:18</td>
-      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>MatchArmGuard</span></td>
-      <td><code class='replacement'>true</code></td>
-      <td class='dur'>45.9s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:61:5</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>vec![]</code></td>
+      <td class='dur'>255.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-17')">▶ show diff</div>
-        <pre id='diff-17' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace match guard depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) with true in has_top_level_token
-@@ -168,17 +168,17 @@
-     let tok = token.as_bytes();
-     let tok_len = tok.len();
-     // `enumerate` yields each index exactly once — forward progress is
-     // structural, so mutating the loop counter is impossible.
-     for (i, &amp;byte) in bytes.iter().enumerate() {
-         match byte {
-             b'[' | b'(' | b'{' =&gt; depth += 1,
-             b']' | b')' | b'}' =&gt; depth -= 1,
--            _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
-+            _ if true /* ~ changed by cargo-mutants ~ */ =&gt; {
-                 return true;
-             }
-             _ =&gt; {}
-         }
-     }
-     false
+        <div class='diff-toggle' onclick="toggle('diff-15')">▶ show diff</div>
+        <pre id='diff-15' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace collect_type_alias_names -&gt; Vec&lt;String&gt; with vec![]
+@@ -53,43 +53,17 @@
+ 
+ /// Collect all local names that refer to `typing.TypeAlias` in this module.
+ ///
+ /// Handles:
+ /// - `from typing import TypeAlias`
+ /// - `from typing import TypeAlias as TA`
+ /// - `import typing` (used as `typing.TypeAlias`)
+ fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
+-    let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
+-    for import in &amp;module.imports {
+-        if import.kind != ImportKind::From {
+-            continue;
+-        }
+-        if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
+-            continue;
+-        }
+-        // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
+-        let Some(import_text) = slice_span(&amp;module.source, import.span) else {
+-            continue;
+-        };
+-        // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
+-        // advances structurally past each match, so the loop cannot be turned
+-        // into an infinite loop by mutating an arithmetic advance step.
+-        for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
+-            let after = &amp;import_text[pos + marker.len()..];
+-            let alias: String = after
+-                .chars()
+-                .take_while(|c| c.is_alphanumeric() || *c == '_')
+-                .collect();
+-            if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
+-                names.push(alias);
+-            }
+-        }
+-    }
+-    names
++    vec![] /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Returns `true` when the annotation text matches one of the known `TypeAlias` names.
+ fn is_type_alias_annotation(ann: &amp;str, type_alias_names: &amp;[String]) -&gt; bool {
+     let ann = ann.trim();
+     type_alias_names.iter().any(|n| ann == n) || ann.ends_with(&quot;.TypeAlias&quot;)
  }
  
 </pre></td></tr>
@@ -784,11 +722,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:174:41</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>*=</code></td>
-      <td class='dur'>37.4s</td>
+      <td class='dur'>40.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-18')">▶ show diff</div>
-        <pre id='diff-18' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
+        <div class='diff-toggle' onclick="toggle('diff-16')">▶ show diff</div>
+        <pre id='diff-16' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
 +++ replace += with *= in has_top_level_token
 @@ -166,17 +166,17 @@
      let mut depth = 0i32;
@@ -812,17 +750,16 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:174:41</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:175:41</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>-=</code></td>
-      <td class='dur'>46.7s</td>
+      <td><code class='replacement'>+=</code></td>
+      <td class='dur'>33.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-19')">▶ show diff</div>
-        <pre id='diff-19' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace += with -= in has_top_level_token
-@@ -166,17 +166,17 @@
-     let mut depth = 0i32;
+        <div class='diff-toggle' onclick="toggle('diff-17')">▶ show diff</div>
+        <pre id='diff-17' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace -= with += in has_top_level_token
+@@ -167,17 +167,17 @@
      let bytes = s.as_bytes();
      let tok = token.as_bytes();
      let tok_len = tok.len();
@@ -830,9 +767,9 @@
      // structural, so mutating the loop counter is impossible.
      for (i, &amp;byte) in bytes.iter().enumerate() {
          match byte {
--            b'[' | b'(' | b'{' =&gt; depth += 1,
-+            b'[' | b'(' | b'{' =&gt; depth -= /* ~ changed by cargo-mutants ~ */ 1,
-             b']' | b')' | b'}' =&gt; depth -= 1,
+             b'[' | b'(' | b'{' =&gt; depth += 1,
+-            b']' | b')' | b'}' =&gt; depth -= 1,
++            b']' | b')' | b'}' =&gt; depth += /* ~ changed by cargo-mutants ~ */ 1,
              _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
                  return true;
              }
@@ -840,17 +777,49 @@
          }
      }
      false
+ }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:77:42</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>-</code></td>
+      <td class='dur'>280.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-18')">▶ show diff</div>
+        <pre id='diff-18' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace + with - in collect_type_alias_names
+@@ -69,17 +69,17 @@
+         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
+         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
+             continue;
+         };
+         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
+         // advances structurally past each match, so the loop cannot be turned
+         // into an infinite loop by mutating an arithmetic advance step.
+         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
+-            let after = &amp;import_text[pos + marker.len()..];
++            let after = &amp;import_text[pos - /* ~ changed by cargo-mutants ~ */ marker.len()..];
+             let alias: String = after
+                 .chars()
+                 .take_while(|c| c.is_alphanumeric() || *c == '_')
+                 .collect();
+             if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
+                 names.push(alias);
+             }
+         }
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:24</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>28.6s</td>
+      <td class='dur'>34.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-20')">▶ show diff</div>
-        <pre id='diff-20' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
+        <div class='diff-toggle' onclick="toggle('diff-19')">▶ show diff</div>
+        <pre id='diff-19' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
 +++ replace == with != in has_top_level_token
 @@ -168,17 +168,17 @@
      let tok = token.as_bytes();
@@ -877,11 +846,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:175:41</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>/=</code></td>
-      <td class='dur'>38.1s</td>
+      <td class='dur'>42.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-21')">▶ show diff</div>
-        <pre id='diff-21' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
+        <div class='diff-toggle' onclick="toggle('diff-20')">▶ show diff</div>
+        <pre id='diff-20' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
 +++ replace -= with /= in has_top_level_token
 @@ -167,17 +167,17 @@
      let bytes = s.as_bytes();
@@ -908,11 +877,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:29</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>38.7s</td>
+      <td class='dur'>44.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-22')">▶ show diff</div>
-        <pre id='diff-22' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
+        <div class='diff-toggle' onclick="toggle('diff-21')">▶ show diff</div>
+        <pre id='diff-21' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
 +++ replace &amp;&amp; with || in has_top_level_token
 @@ -168,17 +168,17 @@
      let tok = token.as_bytes();
@@ -936,41 +905,72 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:175:41</td>
-      <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>+=</code></td>
-      <td class='dur'>55.9s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:77:42</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>*</code></td>
+      <td class='dur'>296.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-22')">▶ show diff</div>
+        <pre id='diff-22' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace + with * in collect_type_alias_names
+@@ -69,17 +69,17 @@
+         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
+         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
+             continue;
+         };
+         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
+         // advances structurally past each match, so the loop cannot be turned
+         // into an infinite loop by mutating an arithmetic advance step.
+         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
+-            let after = &amp;import_text[pos + marker.len()..];
++            let after = &amp;import_text[pos * /* ~ changed by cargo-mutants ~ */ marker.len()..];
+             let alias: String = after
+                 .chars()
+                 .take_while(|c| c.is_alphanumeric() || *c == '_')
+                 .collect();
+             if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
+                 names.push(alias);
+             }
+         }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:66:26</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>297.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-23')">▶ show diff</div>
         <pre id='diff-23' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
-+++ replace -= with += in has_top_level_token
-@@ -167,17 +167,17 @@
-     let bytes = s.as_bytes();
-     let tok = token.as_bytes();
-     let tok_len = tok.len();
-     // `enumerate` yields each index exactly once — forward progress is
-     // structural, so mutating the loop counter is impossible.
-     for (i, &amp;byte) in bytes.iter().enumerate() {
-         match byte {
-             b'[' | b'(' | b'{' =&gt; depth += 1,
--            b']' | b')' | b'}' =&gt; depth -= 1,
-+            b']' | b')' | b'}' =&gt; depth += /* ~ changed by cargo-mutants ~ */ 1,
-             _ if depth == 0 &amp;&amp; bytes.get(i..i + tok_len) == Some(tok) =&gt; {
-                 return true;
-             }
-             _ =&gt; {}
++++ replace != with == in collect_type_alias_names
+@@ -58,17 +58,17 @@
+ /// - `from typing import TypeAlias as TA`
+ /// - `import typing` (used as `typing.TypeAlias`)
+ fn collect_type_alias_names(module: &amp;ResolvedModule) -&gt; Vec&lt;String&gt; {
+     let mut names = vec![&quot;TypeAlias&quot;.to_owned()];
+     for import in &amp;module.imports {
+         if import.kind != ImportKind::From {
+             continue;
          }
-     }
-     false
- }
+-        if import.module != &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
++        if import.module == /* ~ changed by cargo-mutants ~ */ &quot;typing&quot; &amp;&amp; import.module != &quot;typing_extensions&quot; {
+             continue;
+         }
+         // Scan the raw import source text for `TypeAlias as &lt;alias&gt;` patterns.
+         let Some(import_text) = slice_span(&amp;module.source, import.span) else {
+             continue;
+         };
+         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
+         // advances structurally past each match, so the loop cannot be turned
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:58</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>39.3s</td>
+      <td class='dur'>52.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-24')">▶ show diff</div>
@@ -1001,7 +1001,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:47</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>42.9s</td>
+      <td class='dur'>31.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-25')">▶ show diff</div>
@@ -1032,7 +1032,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:176:47</td>
       <td><code>has_top_level_token</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>*</code></td>
-      <td class='dur'>45.9s</td>
+      <td class='dur'>33.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-26')">▶ show diff</div>
@@ -1060,78 +1060,47 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:245:42</td>
-      <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>30.5s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/aliases_implicit.rs:80:53</td>
+      <td><code>collect_type_alias_names</code> -> Vec<String> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>&amp;&amp;</code></td>
+      <td class='dur'>328.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-27')">▶ show diff</div>
-        <pre id='diff-27' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
-+++ replace &amp;&amp; with || in check_vars
-@@ -237,17 +237,17 @@
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     params: &amp;ParamMaps,
-     skip: &amp;SkipNames,
-     functions: &amp;[basilisk_resolver::FunctionInfo],
-     call_index: &amp;callable_check::CallIndex,
- ) {
-     vars.iter()
--        .filter(|var| var.has_annotation &amp;&amp; var.rhs_span.is_some())
-+        .filter(|var| var.has_annotation || /* ~ changed by cargo-mutants ~ */ var.rhs_span.is_some())
-         .filter_map(|var| {
-             let annotation_text = extract_annotation(source, var.name_span)?;
- 
-             // Quoted forward-reference annotations (e.g. `&quot;Literal[Color.RED]&quot;`)
-             // are not evaluated as value types here; skip to avoid false positives.
-             if annotation_text.starts_with('&quot;') || annotation_text.starts_with('\'') {
-                 return None;
+        <pre id='diff-27' class='diff hidden'>--- crates/basilisk-checker/src/rules/aliases_implicit.rs
++++ replace || with &amp;&amp; in collect_type_alias_names
+@@ -72,17 +72,17 @@
+         };
+         // Find all occurrences of `TypeAlias as &lt;identifier&gt;`. `match_indices`
+         // advances structurally past each match, so the loop cannot be turned
+         // into an infinite loop by mutating an arithmetic advance step.
+         for (pos, marker) in import_text.match_indices(&quot;TypeAlias as &quot;) {
+             let after = &amp;import_text[pos + marker.len()..];
+             let alias: String = after
+                 .chars()
+-                .take_while(|c| c.is_alphanumeric() || *c == '_')
++                .take_while(|c| c.is_alphanumeric() &amp;&amp; /* ~ changed by cargo-mutants ~ */ *c == '_')
+                 .collect();
+             if !alias.is_empty() &amp;&amp; alias != &quot;TypeAlias&quot; {
+                 names.push(alias);
              }
+         }
+     }
+     names
+ }
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:276:30</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:282:21</td>
       <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>!=</code></td>
-      <td class='dur'>33.7s</td>
+      <td><code class='replacement'>&amp;&amp;</code></td>
+      <td class='dur'>35.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-28')">▶ show diff</div>
         <pre id='diff-28' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
-+++ replace == with != in check_vars
-@@ -268,17 +268,17 @@
-                     declared_type,
-                 ));
-             }
- 
-             // Skip TypeAlias-annotated variables — E0048 handles validation.
-             // The annotation may be `TypeAlias`, `TA`, or any local alias.
-             {
-                 let ann_lower = annotation_text.trim().to_ascii_lowercase();
--                if ann_lower == &quot;typealias&quot;
-+                if ann_lower != /* ~ changed by cargo-mutants ~ */ &quot;typealias&quot;
-                     || ann_lower.ends_with(&quot;.typealias&quot;)
-                     || matches!(declared_type, InferredType::Named(ref n) if n == &quot;ta&quot;)
-                 {
-                     return None;
-                 }
-             }
- 
-             // Skip annotations that reference a PEP 695 type alias or a
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:278:21</td>
-      <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>36.3s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-29')">▶ show diff</div>
-        <pre id='diff-29' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
 +++ replace || with &amp;&amp; in check_vars
-@@ -270,17 +270,17 @@
+@@ -274,17 +274,17 @@
              }
  
              // Skip TypeAlias-annotated variables — E0048 handles validation.
@@ -1153,16 +1122,109 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:277:21</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:249:42</td>
+      <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>45.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-29')">▶ show diff</div>
+        <pre id='diff-29' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
++++ replace &amp;&amp; with || in check_vars
+@@ -241,17 +241,17 @@
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     params: &amp;ParamMaps,
+     skip: &amp;SkipNames,
+     functions: &amp;[basilisk_resolver::FunctionInfo],
+     call_index: &amp;callable_check::CallIndex,
+ ) {
+     vars.iter()
+-        .filter(|var| var.has_annotation &amp;&amp; var.rhs_span.is_some())
++        .filter(|var| var.has_annotation || /* ~ changed by cargo-mutants ~ */ var.rhs_span.is_some())
+         .filter_map(|var| {
+             let annotation_text = extract_annotation(source, var.name_span)?;
+ 
+             // Quoted forward-reference annotations (e.g. `&quot;Literal[Color.RED]&quot;`)
+             // are not evaluated as value types here; skip to avoid false positives.
+             if annotation_text.starts_with('&quot;') || annotation_text.starts_with('\'') {
+                 return None;
+             }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:255:49</td>
       <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>44.6s</td>
+      <td class='dur'>44.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-30')">▶ show diff</div>
         <pre id='diff-30' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
 +++ replace || with &amp;&amp; in check_vars
-@@ -269,17 +269,17 @@
+@@ -247,17 +247,17 @@
+ ) {
+     vars.iter()
+         .filter(|var| var.has_annotation &amp;&amp; var.rhs_span.is_some())
+         .filter_map(|var| {
+             let annotation_text = extract_annotation(source, var.name_span)?;
+ 
+             // Quoted forward-reference annotations (e.g. `&quot;Literal[Color.RED]&quot;`)
+             // are not evaluated as value types here; skip to avoid false positives.
+-            if annotation_text.starts_with('&quot;') || annotation_text.starts_with('\'') {
++            if annotation_text.starts_with('&quot;') &amp;&amp; /* ~ changed by cargo-mutants ~ */ annotation_text.starts_with('\'') {
+                 return None;
+             }
+ 
+             let declared_type = InferredType::from_annotation(annotation_text);
+ 
+             // TypeForm assignments require type-expression validation, not
+             // value-type inference.  Delegate to the dedicated module.
+             if let InferredType::TypeForm(ref inner) = declared_type {
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:280:30</td>
+      <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>!=</code></td>
+      <td class='dur'>37.2s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-31')">▶ show diff</div>
+        <pre id='diff-31' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
++++ replace == with != in check_vars
+@@ -272,17 +272,17 @@
+                     declared_type,
+                 ));
+             }
+ 
+             // Skip TypeAlias-annotated variables — E0048 handles validation.
+             // The annotation may be `TypeAlias`, `TA`, or any local alias.
+             {
+                 let ann_lower = annotation_text.trim().to_ascii_lowercase();
+-                if ann_lower == &quot;typealias&quot;
++                if ann_lower != /* ~ changed by cargo-mutants ~ */ &quot;typealias&quot;
+                     || ann_lower.ends_with(&quot;.typealias&quot;)
+                     || matches!(declared_type, InferredType::Named(ref n) if n == &quot;ta&quot;)
+                 {
+                     return None;
+                 }
+             }
+ 
+             // Skip annotations that reference a PEP 695 type alias or a
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:281:21</td>
+      <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>&amp;&amp;</code></td>
+      <td class='dur'>40.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-32')">▶ show diff</div>
+        <pre id='diff-32' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
++++ replace || with &amp;&amp; in check_vars
+@@ -273,17 +273,17 @@
                  ));
              }
  
@@ -1184,16 +1246,47 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:244:5</td>
-      <td><code>check_vars</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>57.4s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:294:21</td>
+      <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>&amp;&amp;</code></td>
+      <td class='dur'>31.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-31')">▶ show diff</div>
-        <pre id='diff-31' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
+        <div class='diff-toggle' onclick="toggle('diff-33')">▶ show diff</div>
+        <pre id='diff-33' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
++++ replace || with &amp;&amp; in check_vars
+@@ -286,17 +286,17 @@
+             }
+ 
+             // Skip annotations that reference a PEP 695 type alias or a
+             // `TypeAliasType(...)` alias. E0014 cannot evaluate the expanded alias
+             // type, so any assignment check would be unreliable (false positives).
+             if let InferredType::Named(ref name) = declared_type {
+                 let base = name.split('[').next().unwrap_or(name);
+                 if skip.type_alias.contains(base)
+-                    || skip.type_alias_type.contains(&amp;base.to_ascii_lowercase())
++                    &amp;&amp; /* ~ changed by cargo-mutants ~ */ skip.type_alias_type.contains(&amp;base.to_ascii_lowercase())
+                 {
+                     return None;
+                 }
+             }
+ 
+             // Skip dict literal assignments to TypedDict annotations. E0014 compares
+             // the top-level type (e.g. `dict[str, str|int]` vs `Movie`) which always
+             // mismatches. Field-level checking is done by E0093 instead.
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:248:5</td>
+      <td><code>check_vars</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>69.6s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-34')">▶ show diff</div>
+        <pre id='diff-34' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
 +++ replace check_vars with ()
-@@ -236,174 +236,17 @@
+@@ -240,174 +240,17 @@
      source: &amp;str,
      path: &amp;str,
      diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
@@ -1372,161 +1465,16 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:251:49</td>
-      <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>51.9s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-32')">▶ show diff</div>
-        <pre id='diff-32' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
-+++ replace || with &amp;&amp; in check_vars
-@@ -243,17 +243,17 @@
- ) {
-     vars.iter()
-         .filter(|var| var.has_annotation &amp;&amp; var.rhs_span.is_some())
-         .filter_map(|var| {
-             let annotation_text = extract_annotation(source, var.name_span)?;
- 
-             // Quoted forward-reference annotations (e.g. `&quot;Literal[Color.RED]&quot;`)
-             // are not evaluated as value types here; skip to avoid false positives.
--            if annotation_text.starts_with('&quot;') || annotation_text.starts_with('\'') {
-+            if annotation_text.starts_with('&quot;') &amp;&amp; /* ~ changed by cargo-mutants ~ */ annotation_text.starts_with('\'') {
-                 return None;
-             }
- 
-             let declared_type = InferredType::from_annotation(annotation_text);
- 
-             // TypeForm assignments require type-expression validation, not
-             // value-type inference.  Delegate to the dedicated module.
-             if let InferredType::TypeForm(ref inner) = declared_type {
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:290:21</td>
-      <td><code>check_vars</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>41.6s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-33')">▶ show diff</div>
-        <pre id='diff-33' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
-+++ replace || with &amp;&amp; in check_vars
-@@ -282,17 +282,17 @@
-             }
- 
-             // Skip annotations that reference a PEP 695 type alias or a
-             // `TypeAliasType(...)` alias. E0014 cannot evaluate the expanded alias
-             // type, so any assignment check would be unreliable (false positives).
-             if let InferredType::Named(ref name) = declared_type {
-                 let base = name.split('[').next().unwrap_or(name);
-                 if skip.type_alias.contains(base)
--                    || skip.type_alias_type.contains(&amp;base.to_ascii_lowercase())
-+                    &amp;&amp; /* ~ changed by cargo-mutants ~ */ skip.type_alias_type.contains(&amp;base.to_ascii_lowercase())
-                 {
-                     return None;
-                 }
-             }
- 
-             // Skip dict literal assignments to TypedDict annotations. E0014 compares
-             // the top-level type (e.g. `dict[str, str|int]` vs `Movie`) which always
-             // mismatches. Field-level checking is done by E0093 instead.
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:541:5</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:545:5</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>Some(&quot;xyzzy&quot;)</code></td>
-      <td class='dur'>45.6s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-34')">▶ show diff</div>
-        <pre id='diff-34' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
-+++ replace extract_annotation -&gt; Option&lt;&amp;str&gt; with Some(&quot;xyzzy&quot;)
-@@ -533,38 +533,10 @@
- 
- /// Extract the annotation text from the source line containing `name_span`.
- ///
- /// Looks for `: &lt;annotation&gt;` on the same source line as the variable name,
- /// stopping at the `=` sign that introduces the RHS.  Returns `None` if no
- /// such pattern is found.
- pub(super) fn extract_annotation(source: &amp;str, name_span: Span) -&gt; Option&lt;&amp;str&gt; {
-     // Find the byte offset of the start of the line containing the name.
--    let start = usize::try_from(name_span.start).ok()?;
--    let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos + 1);
--    let line_end = source
--        .get(start..)?
--        .find('\n')
--        .map_or(source.len(), |pos| start + pos);
--
--    let line = source.get(line_start..line_end)?;
--
--    // Position of the name within the line.
--    let name_offset = start.checked_sub(line_start)?;
--
--    // Find `: ` after the name position on this line.
--    let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
--    let after_colon = colon_pos + 2; // skip ': '
--
--    // Find `=` that ends the annotation (must be after the colon).
--    let annotation_end = line
--        .get(after_colon..)?
--        .find('=')
--        .map_or(line.len(), |p| after_colon + p);
--
--    let annotation = line.get(after_colon..annotation_end)?.trim();
--
--    if annotation.is_empty() {
--        None
--    } else {
--        Some(annotation)
--    }
-+    Some(&quot;xyzzy&quot;) /* ~ changed by cargo-mutants ~ */
- }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:546:43</td>
-      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>-</code></td>
-      <td class='dur'>37.1s</td>
+      <td><code class='replacement'>None</code></td>
+      <td class='dur'>41.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-35')">▶ show diff</div>
         <pre id='diff-35' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
-+++ replace + with - in extract_annotation
-@@ -538,17 +538,17 @@
- /// such pattern is found.
- pub(super) fn extract_annotation(source: &amp;str, name_span: Span) -&gt; Option&lt;&amp;str&gt; {
-     // Find the byte offset of the start of the line containing the name.
-     let start = usize::try_from(name_span.start).ok()?;
-     let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos + 1);
-     let line_end = source
-         .get(start..)?
-         .find('\n')
--        .map_or(source.len(), |pos| start + pos);
-+        .map_or(source.len(), |pos| start - /* ~ changed by cargo-mutants ~ */ pos);
- 
-     let line = source.get(line_start..line_end)?;
- 
-     // Position of the name within the line.
-     let name_offset = start.checked_sub(line_start)?;
- 
-     // Find `: ` after the name position on this line.
-     let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:541:5</td>
-      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>None</code></td>
-      <td class='dur'>60.2s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-36')">▶ show diff</div>
-        <pre id='diff-36' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
 +++ replace extract_annotation -&gt; Option&lt;&amp;str&gt; with None
-@@ -533,38 +533,10 @@
+@@ -537,38 +537,10 @@
  
  /// Extract the annotation text from the source line containing `name_span`.
  ///
@@ -1569,17 +1517,26 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:554:58</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:550:43</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>39.2s</td>
+      <td class='dur'>23.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-37')">▶ show diff</div>
-        <pre id='diff-37' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
+        <div class='diff-toggle' onclick="toggle('diff-36')">▶ show diff</div>
+        <pre id='diff-36' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
 +++ replace + with - in extract_annotation
-@@ -546,17 +546,17 @@
-         .map_or(source.len(), |pos| start + pos);
+@@ -542,17 +542,17 @@
+ /// such pattern is found.
+ pub(super) fn extract_annotation(source: &amp;str, name_span: Span) -&gt; Option&lt;&amp;str&gt; {
+     // Find the byte offset of the start of the line containing the name.
+     let start = usize::try_from(name_span.start).ok()?;
+     let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos + 1);
+     let line_end = source
+         .get(start..)?
+         .find('\n')
+-        .map_or(source.len(), |pos| start + pos);
++        .map_or(source.len(), |pos| start - /* ~ changed by cargo-mutants ~ */ pos);
  
      let line = source.get(line_start..line_end)?;
  
@@ -1587,60 +1544,20 @@
      let name_offset = start.checked_sub(line_start)?;
  
      // Find `: ` after the name position on this line.
--    let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
-+    let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? - /* ~ changed by cargo-mutants ~ */ name_offset;
-     let after_colon = colon_pos + 2; // skip ': '
- 
-     // Find `=` that ends the annotation (must be after the colon).
-     let annotation_end = line
-         .get(after_colon..)?
-         .find('=')
-         .map_or(line.len(), |p| after_colon + p);
- 
+     let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:542:75</td>
-      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>-</code></td>
-      <td class='dur'>56.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-38')">▶ show diff</div>
-        <pre id='diff-38' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
-+++ replace + with - in extract_annotation
-@@ -534,17 +534,17 @@
- /// Extract the annotation text from the source line containing `name_span`.
- ///
- /// Looks for `: &lt;annotation&gt;` on the same source line as the variable name,
- /// stopping at the `=` sign that introduces the RHS.  Returns `None` if no
- /// such pattern is found.
- pub(super) fn extract_annotation(source: &amp;str, name_span: Span) -&gt; Option&lt;&amp;str&gt; {
-     // Find the byte offset of the start of the line containing the name.
-     let start = usize::try_from(name_span.start).ok()?;
--    let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos + 1);
-+    let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos - /* ~ changed by cargo-mutants ~ */ 1);
-     let line_end = source
-         .get(start..)?
-         .find('\n')
-         .map_or(source.len(), |pos| start + pos);
- 
-     let line = source.get(line_start..line_end)?;
- 
-     // Position of the name within the line.
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:541:5</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:545:5</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Some(&quot;&quot;)</code></td>
-      <td class='dur'>74.3s</td>
+      <td class='dur'>48.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-39')">▶ show diff</div>
-        <pre id='diff-39' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
+        <div class='diff-toggle' onclick="toggle('diff-37')">▶ show diff</div>
+        <pre id='diff-37' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
 +++ replace extract_annotation -&gt; Option&lt;&amp;str&gt; with Some(&quot;&quot;)
-@@ -533,38 +533,10 @@
+@@ -537,38 +537,10 @@
  
  /// Extract the annotation text from the source line containing `name_span`.
  ///
@@ -1683,47 +1600,47 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/directives_assert_type.rs:31:76</td>
-      <td><code><impl Rule for InvalidAssertTypeCall>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>36.6s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:558:58</td>
+      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>-</code></td>
+      <td class='dur'>35.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-40')">▶ show diff</div>
-        <pre id='diff-40' class='diff hidden'>--- crates/basilisk-checker/src/rules/directives_assert_type.rs
-+++ replace != with == in &lt;impl Rule for InvalidAssertTypeCall&gt;::check
-@@ -23,17 +23,17 @@
+        <div class='diff-toggle' onclick="toggle('diff-38')">▶ show diff</div>
+        <pre id='diff-38' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
++++ replace + with - in extract_annotation
+@@ -550,17 +550,17 @@
+         .map_or(source.len(), |pos| start + pos);
  
- impl Rule for InvalidAssertTypeCall {
-     fn check(
-         &amp;self,
-         module: &amp;ResolvedModule,
-         _ctx: &amp;super::CheckContext,
-         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     ) {
--        for call in module.assert_type_calls.iter().filter(|c| c.arg_count != 2) {
-+        for call in module.assert_type_calls.iter().filter(|c| c.arg_count == /* ~ changed by cargo-mutants ~ */ 2) {
-             let arg_count = call.arg_count;
-             diagnostics.push(error_diagnostic_owned(
-                 CODE.clone(),
-                 format!(
-                     &quot;`assert_type()` requires exactly 2 arguments (value, type), got {arg_count}&quot;
-                 ),
-                 call.span,
-                 &amp;module.path,
+     let line = source.get(line_start..line_end)?;
+ 
+     // Position of the name within the line.
+     let name_offset = start.checked_sub(line_start)?;
+ 
+     // Find `: ` after the name position on this line.
+-    let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
++    let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? - /* ~ changed by cargo-mutants ~ */ name_offset;
+     let after_colon = colon_pos + 2; // skip ': '
+ 
+     // Find `=` that ends the annotation (must be after the colon).
+     let annotation_end = line
+         .get(after_colon..)?
+         .find('=')
+         .map_or(line.len(), |p| after_colon + p);
+ 
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:555:33</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:559:33</td>
       <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>-</code></td>
-      <td class='dur'>48.7s</td>
+      <td class='dur'>34.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-41')">▶ show diff</div>
-        <pre id='diff-41' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
+        <div class='diff-toggle' onclick="toggle('diff-39')">▶ show diff</div>
+        <pre id='diff-39' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
 +++ replace + with - in extract_annotation
-@@ -547,17 +547,17 @@
+@@ -551,17 +551,17 @@
  
      let line = source.get(line_start..line_end)?;
  
@@ -1745,14 +1662,128 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/directives_assert_type.rs:31:9</td>
-      <td><code><impl Rule for InvalidAssertTypeCall>::check</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>50.4s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:545:5</td>
+      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>Some(&quot;xyzzy&quot;)</code></td>
+      <td class='dur'>43.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-40')">▶ show diff</div>
+        <pre id='diff-40' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
++++ replace extract_annotation -&gt; Option&lt;&amp;str&gt; with Some(&quot;xyzzy&quot;)
+@@ -537,38 +537,10 @@
+ 
+ /// Extract the annotation text from the source line containing `name_span`.
+ ///
+ /// Looks for `: &lt;annotation&gt;` on the same source line as the variable name,
+ /// stopping at the `=` sign that introduces the RHS.  Returns `None` if no
+ /// such pattern is found.
+ pub(super) fn extract_annotation(source: &amp;str, name_span: Span) -&gt; Option&lt;&amp;str&gt; {
+     // Find the byte offset of the start of the line containing the name.
+-    let start = usize::try_from(name_span.start).ok()?;
+-    let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos + 1);
+-    let line_end = source
+-        .get(start..)?
+-        .find('\n')
+-        .map_or(source.len(), |pos| start + pos);
+-
+-    let line = source.get(line_start..line_end)?;
+-
+-    // Position of the name within the line.
+-    let name_offset = start.checked_sub(line_start)?;
+-
+-    // Find `: ` after the name position on this line.
+-    let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
+-    let after_colon = colon_pos + 2; // skip ': '
+-
+-    // Find `=` that ends the annotation (must be after the colon).
+-    let annotation_end = line
+-        .get(after_colon..)?
+-        .find('=')
+-        .map_or(line.len(), |p| after_colon + p);
+-
+-    let annotation = line.get(after_colon..annotation_end)?.trim();
+-
+-    if annotation.is_empty() {
+-        None
+-    } else {
+-        Some(annotation)
+-    }
++    Some(&quot;xyzzy&quot;) /* ~ changed by cargo-mutants ~ */
+ }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:565:45</td>
+      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>-</code></td>
+      <td class='dur'>43.2s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-41')">▶ show diff</div>
+        <pre id='diff-41' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
++++ replace + with - in extract_annotation
+@@ -557,17 +557,17 @@
+     // Find `: ` after the name position on this line.
+     let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
+     let after_colon = colon_pos + 2; // skip ': '
+ 
+     // Find `=` that ends the annotation (must be after the colon).
+     let annotation_end = line
+         .get(after_colon..)?
+         .find('=')
+-        .map_or(line.len(), |p| after_colon + p);
++        .map_or(line.len(), |p| after_colon - /* ~ changed by cargo-mutants ~ */ p);
+ 
+     let annotation = line.get(after_colon..annotation_end)?.trim();
+ 
+     if annotation.is_empty() {
+         None
+     } else {
+         Some(annotation)
+     }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:546:75</td>
+      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>-</code></td>
+      <td class='dur'>56.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-42')">▶ show diff</div>
-        <pre id='diff-42' class='diff hidden'>--- crates/basilisk-checker/src/rules/directives_assert_type.rs
+        <pre id='diff-42' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
++++ replace + with - in extract_annotation
+@@ -538,17 +538,17 @@
+ /// Extract the annotation text from the source line containing `name_span`.
+ ///
+ /// Looks for `: &lt;annotation&gt;` on the same source line as the variable name,
+ /// stopping at the `=` sign that introduces the RHS.  Returns `None` if no
+ /// such pattern is found.
+ pub(super) fn extract_annotation(source: &amp;str, name_span: Span) -&gt; Option&lt;&amp;str&gt; {
+     // Find the byte offset of the start of the line containing the name.
+     let start = usize::try_from(name_span.start).ok()?;
+-    let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos + 1);
++    let line_start = source.get(..start)?.rfind('\n').map_or(0, |pos| pos - /* ~ changed by cargo-mutants ~ */ 1);
+     let line_end = source
+         .get(start..)?
+         .find('\n')
+         .map_or(source.len(), |pos| start + pos);
+ 
+     let line = source.get(line_start..line_end)?;
+ 
+     // Position of the name within the line.
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/directives_assert_type.rs:31:9</td>
+      <td><code><impl Rule for InvalidAssertTypeCall>::check</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>47.2s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-43')">▶ show diff</div>
+        <pre id='diff-43' class='diff hidden'>--- crates/basilisk-checker/src/rules/directives_assert_type.rs
 +++ replace &lt;impl Rule for InvalidAssertTypeCall&gt;::check with ()
 @@ -23,27 +23,11 @@
  
@@ -1786,41 +1817,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs:561:45</td>
-      <td><code>extract_annotation</code> -> Option<&str> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>-</code></td>
-      <td class='dur'>60.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-44')">▶ show diff</div>
-        <pre id='diff-44' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
-+++ replace + with - in extract_annotation
-@@ -553,17 +553,17 @@
-     // Find `: ` after the name position on this line.
-     let colon_pos = line.get(name_offset..)?.find(&quot;: &quot;)? + name_offset;
-     let after_colon = colon_pos + 2; // skip ': '
- 
-     // Find `=` that ends the annotation (must be after the colon).
-     let annotation_end = line
-         .get(after_colon..)?
-         .find('=')
--        .map_or(line.len(), |p| after_colon + p);
-+        .map_or(line.len(), |p| after_colon - /* ~ changed by cargo-mutants ~ */ p);
- 
-     let annotation = line.get(after_colon..annotation_end)?.trim();
- 
-     if annotation.is_empty() {
-         None
-     } else {
-         Some(annotation)
-     }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/directives_reveal_type.rs:30:76</td>
       <td><code><impl Rule for InvalidRevealTypeCall>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>39.5s</td>
+      <td class='dur'>45.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-45')">▶ show diff</div>
@@ -1848,54 +1848,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/directives_reveal_type.rs:30:9</td>
-      <td><code><impl Rule for InvalidRevealTypeCall>::check</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>49.4s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-46')">▶ show diff</div>
-        <pre id='diff-46' class='diff hidden'>--- crates/basilisk-checker/src/rules/directives_reveal_type.rs
-+++ replace &lt;impl Rule for InvalidRevealTypeCall&gt;::check with ()
-@@ -22,26 +22,11 @@
- 
- impl Rule for InvalidRevealTypeCall {
-     fn check(
-         &amp;self,
-         module: &amp;ResolvedModule,
-         _ctx: &amp;super::CheckContext,
-         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     ) {
--        for call in module.reveal_type_calls.iter().filter(|c| c.arg_count != 1) {
--            let arg_count = call.arg_count;
--            diagnostics.push(error_diagnostic_owned(
--                CODE.clone(),
--                format!(
--                    &quot;`reveal_type()` requires exactly 1 argument, got {arg_count}&quot;
--                ),
--                call.span,
--                &amp;module.path,
--                Some(&quot;Usage: `reveal_type(expression)`&quot;.to_owned()),
--                Some(
--                    &quot;reveal_type() is a static-analysis directive that takes exactly one expression&quot;
--                        .to_owned(),
--                ),
--            ));
--        }
-+        () /* ~ changed by cargo-mutants ~ */
-     }
- }
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/generics_base_class.rs:28:9</td>
       <td><code><impl Rule for DuplicateTypeVarInGeneric>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>44.0s</td>
+      <td class='dur'>45.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-47')">▶ show diff</div>
-        <pre id='diff-47' class='diff hidden'>--- crates/basilisk-checker/src/rules/generics_base_class.rs
+        <div class='diff-toggle' onclick="toggle('diff-46')">▶ show diff</div>
+        <pre id='diff-46' class='diff hidden'>--- crates/basilisk-checker/src/rules/generics_base_class.rs
 +++ replace &lt;impl Rule for DuplicateTypeVarInGeneric&gt;::check with ()
 @@ -20,36 +20,11 @@
  
@@ -1938,14 +1898,147 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/generics_syntax_declarations_2.rs:35:9</td>
-      <td><code><impl Rule for BoundedTypeVarAttrAccess>::check</code>  <span class='badge genre'>FnValue</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/directives_reveal_type.rs:30:9</td>
+      <td><code><impl Rule for InvalidRevealTypeCall>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>59.6s</td>
+      <td class='dur'>58.4s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-47')">▶ show diff</div>
+        <pre id='diff-47' class='diff hidden'>--- crates/basilisk-checker/src/rules/directives_reveal_type.rs
++++ replace &lt;impl Rule for InvalidRevealTypeCall&gt;::check with ()
+@@ -22,26 +22,11 @@
+ 
+ impl Rule for InvalidRevealTypeCall {
+     fn check(
+         &amp;self,
+         module: &amp;ResolvedModule,
+         _ctx: &amp;super::CheckContext,
+         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     ) {
+-        for call in module.reveal_type_calls.iter().filter(|c| c.arg_count != 1) {
+-            let arg_count = call.arg_count;
+-            diagnostics.push(error_diagnostic_owned(
+-                CODE.clone(),
+-                format!(
+-                    &quot;`reveal_type()` requires exactly 1 argument, got {arg_count}&quot;
+-                ),
+-                call.span,
+-                &amp;module.path,
+-                Some(&quot;Usage: `reveal_type(expression)`&quot;.to_owned()),
+-                Some(
+-                    &quot;reveal_type() is a static-analysis directive that takes exactly one expression&quot;
+-                        .to_owned(),
+-                ),
+-            ));
+-        }
++        () /* ~ changed by cargo-mutants ~ */
+     }
+ }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:42:50</td>
+      <td><code><impl Rule for NonExhaustiveMatch>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>45.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-48')">▶ show diff</div>
-        <pre id='diff-48' class='diff hidden'>--- crates/basilisk-checker/src/rules/generics_syntax_declarations_2.rs
+        <pre id='diff-48' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
++++ delete ! in &lt;impl Rule for NonExhaustiveMatch&gt;::check
+@@ -34,17 +34,17 @@
+         &amp;self,
+         module: &amp;ResolvedModule,
+         _ctx: &amp;super::CheckContext,
+         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     ) {
+         module
+             .match_stmts
+             .iter()
+-            .filter(|stmt| !stmt.has_wildcard &amp;&amp; !stmt.has_structural_pattern)
++            .filter(|stmt| !stmt.has_wildcard &amp;&amp;  /* ~ changed by cargo-mutants ~ */stmt.has_structural_pattern)
+             .for_each(|stmt| diagnostics.push(make_diagnostic(stmt, &amp;module.path)));
+     }
+ }
+ 
+ fn make_diagnostic(stmt: &amp;MatchStmtInfo, path: &amp;str) -&gt; Diagnostic {
+     error_diagnostic_owned(
+         CODE.clone(),
+         &quot;Non-exhaustive `match` statement — no wildcard `case _:` branch&quot;.to_owned(),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/directives_assert_type.rs:31:76</td>
+      <td><code><impl Rule for InvalidAssertTypeCall>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>84.3s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-49')">▶ show diff</div>
+        <pre id='diff-49' class='diff hidden'>--- crates/basilisk-checker/src/rules/directives_assert_type.rs
++++ replace != with == in &lt;impl Rule for InvalidAssertTypeCall&gt;::check
+@@ -23,17 +23,17 @@
+ 
+ impl Rule for InvalidAssertTypeCall {
+     fn check(
+         &amp;self,
+         module: &amp;ResolvedModule,
+         _ctx: &amp;super::CheckContext,
+         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     ) {
+-        for call in module.assert_type_calls.iter().filter(|c| c.arg_count != 2) {
++        for call in module.assert_type_calls.iter().filter(|c| c.arg_count == /* ~ changed by cargo-mutants ~ */ 2) {
+             let arg_count = call.arg_count;
+             diagnostics.push(error_diagnostic_owned(
+                 CODE.clone(),
+                 format!(
+                     &quot;`assert_type()` requires exactly 2 arguments (value, type), got {arg_count}&quot;
+                 ),
+                 call.span,
+                 &amp;module.path,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:42:47</td>
+      <td><code><impl Rule for NonExhaustiveMatch>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>66.0s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-50')">▶ show diff</div>
+        <pre id='diff-50' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
++++ replace &amp;&amp; with || in &lt;impl Rule for NonExhaustiveMatch&gt;::check
+@@ -34,17 +34,17 @@
+         &amp;self,
+         module: &amp;ResolvedModule,
+         _ctx: &amp;super::CheckContext,
+         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     ) {
+         module
+             .match_stmts
+             .iter()
+-            .filter(|stmt| !stmt.has_wildcard &amp;&amp; !stmt.has_structural_pattern)
++            .filter(|stmt| !stmt.has_wildcard || /* ~ changed by cargo-mutants ~ */ !stmt.has_structural_pattern)
+             .for_each(|stmt| diagnostics.push(make_diagnostic(stmt, &amp;module.path)));
+     }
+ }
+ 
+ fn make_diagnostic(stmt: &amp;MatchStmtInfo, path: &amp;str) -&gt; Diagnostic {
+     error_diagnostic_owned(
+         CODE.clone(),
+         &quot;Non-exhaustive `match` statement — no wildcard `case _:` branch&quot;.to_owned(),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/generics_syntax_declarations_2.rs:35:9</td>
+      <td><code><impl Rule for BoundedTypeVarAttrAccess>::check</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>80.4s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-51')">▶ show diff</div>
+        <pre id='diff-51' class='diff hidden'>--- crates/basilisk-checker/src/rules/generics_syntax_declarations_2.rs
 +++ replace &lt;impl Rule for BoundedTypeVarAttrAccess&gt;::check with ()
 @@ -27,39 +27,11 @@
  
@@ -1991,16 +2084,16 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:40:28</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:42:28</td>
       <td><code><impl Rule for NonExhaustiveMatch>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>50.3s</td>
+      <td class='dur'>70.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-49')">▶ show diff</div>
-        <pre id='diff-49' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
+        <div class='diff-toggle' onclick="toggle('diff-52')">▶ show diff</div>
+        <pre id='diff-52' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
 +++ delete ! in &lt;impl Rule for NonExhaustiveMatch&gt;::check
-@@ -32,17 +32,17 @@
+@@ -34,17 +34,17 @@
          &amp;self,
          module: &amp;ResolvedModule,
          _ctx: &amp;super::CheckContext,
@@ -2022,78 +2115,51 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:40:47</td>
-      <td><code><impl Rule for NonExhaustiveMatch>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>55.1s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:37:9</td>
+      <td><code><impl Rule for MissingParameterAnnotation>::check</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>59.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-50')">▶ show diff</div>
-        <pre id='diff-50' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
-+++ replace &amp;&amp; with || in &lt;impl Rule for NonExhaustiveMatch&gt;::check
-@@ -32,17 +32,17 @@
+        <div class='diff-toggle' onclick="toggle('diff-53')">▶ show diff</div>
+        <pre id='diff-53' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
++++ replace &lt;impl Rule for MissingParameterAnnotation&gt;::check with ()
+@@ -29,21 +29,17 @@
+     }
+ 
+     fn check(
          &amp;self,
          module: &amp;ResolvedModule,
          _ctx: &amp;super::CheckContext,
          diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
      ) {
-         module
-             .match_stmts
-             .iter()
--            .filter(|stmt| !stmt.has_wildcard &amp;&amp; !stmt.has_structural_pattern)
-+            .filter(|stmt| !stmt.has_wildcard || /* ~ changed by cargo-mutants ~ */ !stmt.has_structural_pattern)
-             .for_each(|stmt| diagnostics.push(make_diagnostic(stmt, &amp;module.path)));
+-        module
+-            .functions
+-            .iter()
+-            .filter(|func| !is_stub_context(func, &amp;module.classes))
+-            .for_each(|func| check_function(func, &amp;module.path, diagnostics));
++        () /* ~ changed by cargo-mutants ~ */
      }
  }
  
- fn make_diagnostic(stmt: &amp;MatchStmtInfo, path: &amp;str) -&gt; Diagnostic {
-     error_diagnostic_owned(
-         CODE.clone(),
-         &quot;Non-exhaustive `match` statement — no wildcard `case _:` branch&quot;.to_owned(),
+ // Implements [TYPEINF-FUNC-SELFCLS] — the self/cls exemption side: `self` and
+ // `cls` are never required to be annotated (their types are implicit). Note: the
+ // spec's full Self / type[Self] inference is not modelled here.
+ fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
+     func.parameters
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:40:50</td>
-      <td><code><impl Rule for NonExhaustiveMatch>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>53.0s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-51')">▶ show diff</div>
-        <pre id='diff-51' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
-+++ delete ! in &lt;impl Rule for NonExhaustiveMatch&gt;::check
-@@ -32,17 +32,17 @@
-         &amp;self,
-         module: &amp;ResolvedModule,
-         _ctx: &amp;super::CheckContext,
-         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     ) {
-         module
-             .match_stmts
-             .iter()
--            .filter(|stmt| !stmt.has_wildcard &amp;&amp; !stmt.has_structural_pattern)
-+            .filter(|stmt| !stmt.has_wildcard &amp;&amp;  /* ~ changed by cargo-mutants ~ */stmt.has_structural_pattern)
-             .for_each(|stmt| diagnostics.push(make_diagnostic(stmt, &amp;module.path)));
-     }
- }
- 
- fn make_diagnostic(stmt: &amp;MatchStmtInfo, path: &amp;str) -&gt; Diagnostic {
-     error_diagnostic_owned(
-         CODE.clone(),
-         &quot;Non-exhaustive `match` statement — no wildcard `case _:` branch&quot;.to_owned(),
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:37:9</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:39:9</td>
       <td><code><impl Rule for NonExhaustiveMatch>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>79.3s</td>
+      <td class='dur'>86.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-52')">▶ show diff</div>
-        <pre id='diff-52' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
+        <div class='diff-toggle' onclick="toggle('diff-54')">▶ show diff</div>
+        <pre id='diff-54' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
 +++ replace &lt;impl Rule for NonExhaustiveMatch&gt;::check with ()
-@@ -29,21 +29,17 @@
+@@ -31,21 +31,17 @@
  
  impl Rule for NonExhaustiveMatch {
      fn check(
@@ -2119,120 +2185,23 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:46:39</td>
-      <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>39.8s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-53')">▶ show diff</div>
-        <pre id='diff-53' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
-+++ replace &amp;&amp; with || in check_function
-@@ -38,17 +38,17 @@
-             .filter(|func| !is_stub_context(func, &amp;module.classes))
-             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-     }
- }
- 
- fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
-     func.parameters
-         .iter()
--        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-+        .filter(|p| !p.has_annotation || /* ~ changed by cargo-mutants ~ */ p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-         .for_each(|p| out.push(make_diagnostic(p, path)));
- }
- 
- fn make_diagnostic(param: &amp;ParameterInfo, path: &amp;str) -&gt; Diagnostic {
-     error_diagnostic_owned(
-         CODE.clone(),
-         format!(&quot;Missing parameter type annotation for `{}`&quot;, param.name),
-         param.name_span,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:38:28</td>
-      <td><code><impl Rule for MissingParameterAnnotation>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>54.3s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-55')">▶ show diff</div>
-        <pre id='diff-55' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
-+++ delete ! in &lt;impl Rule for MissingParameterAnnotation&gt;::check
-@@ -30,17 +30,17 @@
-         &amp;self,
-         module: &amp;ResolvedModule,
-         _ctx: &amp;super::CheckContext,
-         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     ) {
-         module
-             .functions
-             .iter()
--            .filter(|func| !is_stub_context(func, &amp;module.classes))
-+            .filter(|func|  /* ~ changed by cargo-mutants ~ */is_stub_context(func, &amp;module.classes))
-             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-     }
- }
- 
- fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
-     func.parameters
-         .iter()
-         .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:35:9</td>
-      <td><code><impl Rule for MissingParameterAnnotation>::check</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>64.0s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-57')">▶ show diff</div>
-        <pre id='diff-57' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
-+++ replace &lt;impl Rule for MissingParameterAnnotation&gt;::check with ()
-@@ -27,21 +27,17 @@
-     }
- 
-     fn check(
-         &amp;self,
-         module: &amp;ResolvedModule,
-         _ctx: &amp;super::CheckContext,
-         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     ) {
--        module
--            .functions
--            .iter()
--            .filter(|func| !is_stub_context(func, &amp;module.classes))
--            .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-+        () /* ~ changed by cargo-mutants ~ */
-     }
- }
- 
- fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
-     func.parameters
-         .iter()
-         .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-         .for_each(|p| out.push(make_diagnostic(p, path)));
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:44:5</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:49:5</td>
       <td><code>check_function</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>61.2s</td>
+      <td class='dur'>53.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-58')">▶ show diff</div>
-        <pre id='diff-58' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
+        <div class='diff-toggle' onclick="toggle('diff-56')">▶ show diff</div>
+        <pre id='diff-56' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
 +++ replace check_function with ()
-@@ -36,20 +36,17 @@
-             .functions
-             .iter()
-             .filter(|func| !is_stub_context(func, &amp;module.classes))
+@@ -41,20 +41,17 @@
              .for_each(|func| check_function(func, &amp;module.path, diagnostics));
      }
  }
  
+ // Implements [TYPEINF-FUNC-SELFCLS] — the self/cls exemption side: `self` and
+ // `cls` are never required to be annotated (their types are implicit). Note: the
+ // spec's full Self / type[Self] inference is not modelled here.
  fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
 -    func.parameters
 -        .iter()
@@ -2250,21 +2219,52 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:46:59</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:40:28</td>
+      <td><code><impl Rule for MissingParameterAnnotation>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>63.0s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-57')">▶ show diff</div>
+        <pre id='diff-57' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
++++ delete ! in &lt;impl Rule for MissingParameterAnnotation&gt;::check
+@@ -32,17 +32,17 @@
+         &amp;self,
+         module: &amp;ResolvedModule,
+         _ctx: &amp;super::CheckContext,
+         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     ) {
+         module
+             .functions
+             .iter()
+-            .filter(|func| !is_stub_context(func, &amp;module.classes))
++            .filter(|func|  /* ~ changed by cargo-mutants ~ */is_stub_context(func, &amp;module.classes))
+             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
+     }
+ }
+ 
+ // Implements [TYPEINF-FUNC-SELFCLS] — the self/cls exemption side: `self` and
+ // `cls` are never required to be annotated (their types are implicit). Note: the
+ // spec's full Self / type[Self] inference is not modelled here.
+ fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:51:59</td>
       <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>59.0s</td>
+      <td class='dur'>57.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-59')">▶ show diff</div>
         <pre id='diff-59' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
 +++ replace &amp;&amp; with || in check_function
-@@ -38,17 +38,17 @@
-             .filter(|func| !is_stub_context(func, &amp;module.classes))
-             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-     }
+@@ -43,17 +43,17 @@
  }
  
+ // Implements [TYPEINF-FUNC-SELFCLS] — the self/cls exemption side: `self` and
+ // `cls` are never required to be annotated (their types are implicit). Note: the
+ // spec's full Self / type[Self] inference is not modelled here.
  fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
      func.parameters
          .iter()
@@ -2281,21 +2281,21 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:46:49</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:51:49</td>
       <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>38.8s</td>
+      <td class='dur'>30.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-60')">▶ show diff</div>
         <pre id='diff-60' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
 +++ replace != with == in check_function
-@@ -38,17 +38,17 @@
-             .filter(|func| !is_stub_context(func, &amp;module.classes))
-             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-     }
+@@ -43,17 +43,17 @@
  }
  
+ // Implements [TYPEINF-FUNC-SELFCLS] — the self/cls exemption side: `self` and
+ // `cls` are never required to be annotated (their types are implicit). Note: the
+ // spec's full Self / type[Self] inference is not modelled here.
  fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
      func.parameters
          .iter()
@@ -2312,26 +2312,26 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:46:69</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:51:39</td>
       <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>42.9s</td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>46.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-63')">▶ show diff</div>
-        <pre id='diff-63' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
-+++ replace != with == in check_function
-@@ -38,17 +38,17 @@
-             .filter(|func| !is_stub_context(func, &amp;module.classes))
-             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-     }
+        <div class='diff-toggle' onclick="toggle('diff-62')">▶ show diff</div>
+        <pre id='diff-62' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
++++ replace &amp;&amp; with || in check_function
+@@ -43,17 +43,17 @@
  }
  
+ // Implements [TYPEINF-FUNC-SELFCLS] — the self/cls exemption side: `self` and
+ // `cls` are never required to be annotated (their types are implicit). Note: the
+ // spec's full Self / type[Self] inference is not modelled here.
  fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
      func.parameters
          .iter()
 -        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
-+        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name == /* ~ changed by cargo-mutants ~ */ &quot;cls&quot;)
++        .filter(|p| !p.has_annotation || /* ~ changed by cargo-mutants ~ */ p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
          .for_each(|p| out.push(make_diagnostic(p, path)));
  }
  
@@ -2343,21 +2343,21 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:46:21</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:51:21</td>
       <td><code>check_function</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>59.1s</td>
+      <td class='dur'>45.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-64')">▶ show diff</div>
-        <pre id='diff-64' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
+        <div class='diff-toggle' onclick="toggle('diff-63')">▶ show diff</div>
+        <pre id='diff-63' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
 +++ delete ! in check_function
-@@ -38,17 +38,17 @@
-             .filter(|func| !is_stub_context(func, &amp;module.classes))
-             .for_each(|func| check_function(func, &amp;module.path, diagnostics));
-     }
+@@ -43,17 +43,17 @@
  }
  
+ // Implements [TYPEINF-FUNC-SELFCLS] — the self/cls exemption side: `self` and
+ // `cls` are never required to be annotated (their types are implicit). Note: the
+ // spec's full Self / type[Self] inference is not modelled here.
  fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
      func.parameters
          .iter()
@@ -2374,41 +2374,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:38:54</td>
-      <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>35.3s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:51:69</td>
+      <td><code>check_function</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>52.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-65')">▶ show diff</div>
-        <pre id='diff-65' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_return_annotation.rs
-+++ replace &amp;&amp; with || in &lt;impl Rule for MissingReturnAnnotation&gt;::check
-@@ -30,17 +30,17 @@
-         module: &amp;ResolvedModule,
-         _ctx: &amp;super::CheckContext,
-         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     ) {
-         module
-             .functions
-             .iter()
-             .filter(|func| {
--                !func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
-+                !func.return_annotation.is_present() || /* ~ changed by cargo-mutants ~ */ !is_stub_context(func, &amp;module.classes)
-             })
-             .for_each(|func| diagnostics.push(make_diagnostic(func, &amp;module.path)));
-     }
+        <pre id='diff-65' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
++++ replace != with == in check_function
+@@ -43,17 +43,17 @@
  }
  
- fn make_diagnostic(func: &amp;FunctionInfo, path: &amp;str) -&gt; Diagnostic {
+ // Implements [TYPEINF-FUNC-SELFCLS] — the self/cls exemption side: `self` and
+ // `cls` are never required to be annotated (their types are implicit). Note: the
+ // spec's full Self / type[Self] inference is not modelled here.
+ fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
+     func.parameters
+         .iter()
+-        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name != &quot;cls&quot;)
++        .filter(|p| !p.has_annotation &amp;&amp; p.name != &quot;self&quot; &amp;&amp; p.name == /* ~ changed by cargo-mutants ~ */ &quot;cls&quot;)
+         .for_each(|p| out.push(make_diagnostic(p, path)));
+ }
+ 
+ fn make_diagnostic(param: &amp;ParameterInfo, path: &amp;str) -&gt; Diagnostic {
      error_diagnostic_owned(
          CODE.clone(),
+         format!(&quot;Missing parameter type annotation for `{}`&quot;, param.name),
+         param.name_span,
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:34:9</td>
       <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>39.6s</td>
+      <td class='dur'>46.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-66')">▶ show diff</div>
@@ -2442,10 +2442,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:38:54</td>
+      <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>48.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-67')">▶ show diff</div>
+        <pre id='diff-67' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_return_annotation.rs
++++ replace &amp;&amp; with || in &lt;impl Rule for MissingReturnAnnotation&gt;::check
+@@ -30,17 +30,17 @@
+         module: &amp;ResolvedModule,
+         _ctx: &amp;super::CheckContext,
+         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     ) {
+         module
+             .functions
+             .iter()
+             .filter(|func| {
+-                !func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
++                !func.return_annotation.is_present() || /* ~ changed by cargo-mutants ~ */ !is_stub_context(func, &amp;module.classes)
+             })
+             .for_each(|func| diagnostics.push(make_diagnostic(func, &amp;module.path)));
+     }
+ }
+ 
+ fn make_diagnostic(func: &amp;FunctionInfo, path: &amp;str) -&gt; Diagnostic {
+     error_diagnostic_owned(
+         CODE.clone(),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:22:9</td>
       <td><code><impl Rule for MissingReturnAnnotation>::opt_in_spec</code> -> Option<crate::rule_tags::OptInSpec> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>None</code></td>
-      <td class='dur'>53.4s</td>
+      <td class='dur'>57.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-68')">▶ show diff</div>
@@ -2476,14 +2507,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:38:57</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:38:17</td>
       <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>41.5s</td>
+      <td class='dur'>51.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-69')">▶ show diff</div>
-        <pre id='diff-69' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_return_annotation.rs
+        <div class='diff-toggle' onclick="toggle('diff-70')">▶ show diff</div>
+        <pre id='diff-70' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_return_annotation.rs
 +++ delete ! in &lt;impl Rule for MissingReturnAnnotation&gt;::check
 @@ -30,17 +30,17 @@
          module: &amp;ResolvedModule,
@@ -2495,7 +2526,7 @@
              .iter()
              .filter(|func| {
 -                !func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
-+                !func.return_annotation.is_present() &amp;&amp;  /* ~ changed by cargo-mutants ~ */is_stub_context(func, &amp;module.classes)
++                 /* ~ changed by cargo-mutants ~ */func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
              })
              .for_each(|func| diagnostics.push(make_diagnostic(func, &amp;module.path)));
      }
@@ -2507,44 +2538,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:26:9</td>
-      <td><code><impl Rule for MissingVariableType>::opt_in_spec</code> -> Option<crate::rule_tags::OptInSpec> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>None</code></td>
-      <td class='dur'>47.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-70')">▶ show diff</div>
-        <pre id='diff-70' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
-+++ replace &lt;impl Rule for MissingVariableType&gt;::opt_in_spec -&gt; Option&lt;crate::rule_tags::OptInSpec&gt; with None
-@@ -18,20 +18,17 @@
-     docs_url: &quot;https://www.basilisk-python.dev/errors/BSK-E0003&quot;,
- };
- 
- /// Emits BSK-E0003 for every unannotated module-level variable.
- pub(crate) struct MissingVariableType;
- 
- impl Rule for MissingVariableType {
-     fn opt_in_spec(&amp;self) -&gt; Option&lt;crate::rule_tags::OptInSpec&gt; {
--        Some(crate::rule_tags::OptInSpec {
--            code: CODE.code,
--            tags: &amp;[&quot;strictness&quot;],
--        })
-+        None /* ~ changed by cargo-mutants ~ */
-     }
- 
-     fn check(
-         &amp;self,
-         module: &amp;ResolvedModule,
-         _ctx: &amp;super::CheckContext,
-         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     ) {
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:41:47</td>
       <td><code><impl Rule for MissingVariableType>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>42.3s</td>
+      <td class='dur'>43.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-71')">▶ show diff</div>
@@ -2572,10 +2569,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:38:17</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:38:57</td>
       <td><code><impl Rule for MissingReturnAnnotation>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>63.2s</td>
+      <td class='dur'>62.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-72')">▶ show diff</div>
@@ -2591,7 +2588,7 @@
              .iter()
              .filter(|func| {
 -                !func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
-+                 /* ~ changed by cargo-mutants ~ */func.return_annotation.is_present() &amp;&amp; !is_stub_context(func, &amp;module.classes)
++                !func.return_annotation.is_present() &amp;&amp;  /* ~ changed by cargo-mutants ~ */is_stub_context(func, &amp;module.classes)
              })
              .for_each(|func| diagnostics.push(make_diagnostic(func, &amp;module.path)));
      }
@@ -2603,17 +2600,60 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:49:5</td>
-      <td><code>is_unresolvable</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>true</code></td>
-      <td class='dur'>37.6s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:26:9</td>
+      <td><code><impl Rule for MissingVariableType>::opt_in_spec</code> -> Option<crate::rule_tags::OptInSpec> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>None</code></td>
+      <td class='dur'>61.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-73')">▶ show diff</div>
         <pre id='diff-73' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
-+++ replace is_unresolvable -&gt; bool with true
-@@ -41,20 +41,17 @@
-             .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
++++ replace &lt;impl Rule for MissingVariableType&gt;::opt_in_spec -&gt; Option&lt;crate::rule_tags::OptInSpec&gt; with None
+@@ -18,20 +18,17 @@
+     docs_url: &quot;https://www.basilisk-python.dev/errors/BSK-E0003&quot;,
+ };
+ 
+ /// Emits BSK-E0003 for every unannotated module-level variable.
+ pub(crate) struct MissingVariableType;
+ 
+ impl Rule for MissingVariableType {
+     fn opt_in_spec(&amp;self) -&gt; Option&lt;crate::rule_tags::OptInSpec&gt; {
+-        Some(crate::rule_tags::OptInSpec {
+-            code: CODE.code,
+-            tags: &amp;[&quot;strictness&quot;],
+-        })
++        None /* ~ changed by cargo-mutants ~ */
+     }
+ 
+     fn check(
+         &amp;self,
+         module: &amp;ResolvedModule,
+         _ctx: &amp;super::CheckContext,
+         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     ) {
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:41:27</td>
+      <td><code><impl Rule for MissingVariableType>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>54.9s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-74')">▶ show diff</div>
+        <pre id='diff-74' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
++++ delete ! in &lt;impl Rule for MissingVariableType&gt;::check
+@@ -33,17 +33,17 @@
+         &amp;self,
+         module: &amp;ResolvedModule,
+         _ctx: &amp;super::CheckContext,
+         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+     ) {
+         module
+             .module_vars
+             .iter()
+-            .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
++            .filter(|var|  /* ~ changed by cargo-mutants ~ */var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
              .for_each(|var| diagnostics.push(make_diagnostic(var, &amp;module.path)));
      }
  }
@@ -2621,30 +2661,18 @@
  /// Returns `true` for RHS kinds whose element/value type cannot be inferred
  /// from the literal alone.
  fn is_unresolvable(rhs: &amp;RhsKind) -&gt; bool {
--    matches!(
--        rhs,
--        RhsKind::EmptyList | RhsKind::EmptyDict | RhsKind::NoneValue
--    )
-+    true /* ~ changed by cargo-mutants ~ */
- }
- 
- fn make_diagnostic(var: &amp;VariableInfo, path: &amp;str) -&gt; Diagnostic {
-     let (message, help) = match &amp;var.rhs_kind {
-         RhsKind::EmptyList =&gt; (
-             format!(
-                 &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
-                 var.name
+     matches!(
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:38:9</td>
       <td><code><impl Rule for MissingVariableType>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>54.7s</td>
+      <td class='dur'>63.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-74')">▶ show diff</div>
-        <pre id='diff-74' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
+        <div class='diff-toggle' onclick="toggle('diff-75')">▶ show diff</div>
+        <pre id='diff-75' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
 +++ replace &lt;impl Rule for MissingVariableType&gt;::check with ()
 @@ -30,21 +30,17 @@
      }
@@ -2672,26 +2700,17 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:41:27</td>
-      <td><code><impl Rule for MissingVariableType>::check</code>  <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>51.3s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:49:5</td>
+      <td><code>is_unresolvable</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>true</code></td>
+      <td class='dur'>43.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-75')">▶ show diff</div>
-        <pre id='diff-75' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
-+++ delete ! in &lt;impl Rule for MissingVariableType&gt;::check
-@@ -33,17 +33,17 @@
-         &amp;self,
-         module: &amp;ResolvedModule,
-         _ctx: &amp;super::CheckContext,
-         diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-     ) {
-         module
-             .module_vars
-             .iter()
--            .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
-+            .filter(|var|  /* ~ changed by cargo-mutants ~ */var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
+        <div class='diff-toggle' onclick="toggle('diff-76')">▶ show diff</div>
+        <pre id='diff-76' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
++++ replace is_unresolvable -&gt; bool with true
+@@ -41,20 +41,17 @@
+             .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
              .for_each(|var| diagnostics.push(make_diagnostic(var, &amp;module.path)));
      }
  }
@@ -2699,55 +2718,67 @@
  /// Returns `true` for RHS kinds whose element/value type cannot be inferred
  /// from the literal alone.
  fn is_unresolvable(rhs: &amp;RhsKind) -&gt; bool {
-     matches!(
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:64:9</td>
-      <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>46.5s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-77')">▶ show diff</div>
-        <pre id='diff-77' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
-+++ delete match arm RhsKind::EmptyDict in make_diagnostic
-@@ -56,23 +56,17 @@
+-    matches!(
+-        rhs,
+-        RhsKind::EmptyList | RhsKind::EmptyDict | RhsKind::NoneValue
+-    )
++    true /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ fn make_diagnostic(var: &amp;VariableInfo, path: &amp;str) -&gt; Diagnostic {
      let (message, help) = match &amp;var.rhs_kind {
          RhsKind::EmptyList =&gt; (
              format!(
                  &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
                  var.name
-             ),
-             format!(&quot;{}: list[&lt;type&gt;] = []&quot;, var.name),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:71:9</td>
+      <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>48.0s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-78')">▶ show diff</div>
+        <pre id='diff-78' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
++++ delete match arm RhsKind::NoneValue in make_diagnostic
+@@ -63,23 +63,17 @@
          ),
--        RhsKind::EmptyDict =&gt; (
--            format!(
--                &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
--                var.name
--            ),
--            format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
--        ),
-+         /* ~ changed by cargo-mutants ~ */
-         RhsKind::NoneValue =&gt; (
+         RhsKind::EmptyDict =&gt; (
              format!(
-                 &quot;Missing type annotation for `{}` — cannot infer type from `None`&quot;,
+                 &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
                  var.name
              ),
-             format!(&quot;{}: &lt;type&gt; | None = None&quot;, var.name),
+             format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
          ),
+-        RhsKind::NoneValue =&gt; (
+-            format!(
+-                &quot;Missing type annotation for `{}` — cannot infer type from `None`&quot;,
+-                var.name
+-            ),
+-            format!(&quot;{}: &lt;type&gt; | None = None&quot;, var.name),
+-        ),
++         /* ~ changed by cargo-mutants ~ */
          _ =&gt; (
+             format!(
+                 &quot;Missing type annotation for module-level variable `{}`&quot;,
+                 var.name
+             ),
+             format!(&quot;{}: &lt;type&gt; = ...&quot;, var.name),
+         ),
+     };
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:57:9</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>51.5s</td>
+      <td class='dur'>56.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-78')">▶ show diff</div>
-        <pre id='diff-78' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
+        <div class='diff-toggle' onclick="toggle('diff-79')">▶ show diff</div>
+        <pre id='diff-79' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
 +++ delete match arm RhsKind::EmptyList in make_diagnostic
 @@ -49,23 +49,17 @@
      matches!(
@@ -2780,11 +2811,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:49:5</td>
       <td><code>is_unresolvable</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>false</code></td>
-      <td class='dur'>60.9s</td>
+      <td class='dur'>70.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-79')">▶ show diff</div>
-        <pre id='diff-79' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
+        <div class='diff-toggle' onclick="toggle('diff-80')">▶ show diff</div>
+        <pre id='diff-80' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
 +++ replace is_unresolvable -&gt; bool with false
 @@ -41,20 +41,17 @@
              .filter(|var| !var.has_annotation &amp;&amp; is_unresolvable(&amp;var.rhs_kind))
@@ -2811,51 +2842,51 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:71:9</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:64:9</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>MatchArm</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>45.3s</td>
+      <td class='dur'>60.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-80')">▶ show diff</div>
-        <pre id='diff-80' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
-+++ delete match arm RhsKind::NoneValue in make_diagnostic
-@@ -63,23 +63,17 @@
-         ),
-         RhsKind::EmptyDict =&gt; (
+        <div class='diff-toggle' onclick="toggle('diff-81')">▶ show diff</div>
+        <pre id='diff-81' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
++++ delete match arm RhsKind::EmptyDict in make_diagnostic
+@@ -56,23 +56,17 @@
+     let (message, help) = match &amp;var.rhs_kind {
+         RhsKind::EmptyList =&gt; (
              format!(
-                 &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
+                 &quot;Missing type annotation for `{}` — cannot infer element type from empty list `[]`&quot;,
                  var.name
              ),
-             format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
+             format!(&quot;{}: list[&lt;type&gt;] = []&quot;, var.name),
          ),
--        RhsKind::NoneValue =&gt; (
+-        RhsKind::EmptyDict =&gt; (
 -            format!(
--                &quot;Missing type annotation for `{}` — cannot infer type from `None`&quot;,
+-                &quot;Missing type annotation for `{}` — cannot infer key/value types from empty dict `{{}}`&quot;,
 -                var.name
 -            ),
--            format!(&quot;{}: &lt;type&gt; | None = None&quot;, var.name),
+-            format!(&quot;{}: dict[&lt;key&gt;, &lt;value&gt;] = {{}}&quot;, var.name),
 -        ),
 +         /* ~ changed by cargo-mutants ~ */
-         _ =&gt; (
+         RhsKind::NoneValue =&gt; (
              format!(
-                 &quot;Missing type annotation for module-level variable `{}`&quot;,
+                 &quot;Missing type annotation for `{}` — cannot infer type from `None`&quot;,
                  var.name
              ),
-             format!(&quot;{}: &lt;type&gt; = ...&quot;, var.name),
+             format!(&quot;{}: &lt;type&gt; | None = None&quot;, var.name),
          ),
-     };
+         _ =&gt; (
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/tuples_type_form.rs:40:9</td>
       <td><code><impl Rule for MultipleUnboundedTupleTypes>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>42.9s</td>
+      <td class='dur'>58.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-81')">▶ show diff</div>
-        <pre id='diff-81' class='diff hidden'>--- crates/basilisk-checker/src/rules/tuples_type_form.rs
+        <div class='diff-toggle' onclick="toggle('diff-82')">▶ show diff</div>
+        <pre id='diff-82' class='diff hidden'>--- crates/basilisk-checker/src/rules/tuples_type_form.rs
 +++ replace &lt;impl Rule for MultipleUnboundedTupleTypes&gt;::check with ()
 @@ -32,23 +32,11 @@
  
@@ -2885,14 +2916,45 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs:38:66</td>
+      <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>53.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-83')">▶ show diff</div>
+        <pre id='diff-83' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs
++++ replace &amp;&amp; with || in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
+@@ -30,17 +30,17 @@
+                 // __init_subclass__ and __class_getitem__ are synthesised; skip them.
+                 if matches!(
+                     method_name.as_str(),
+                     &quot;__init_subclass__&quot; | &quot;__class_getitem__&quot;
+                 ) {
+                     continue;
+                 }
+                 let func = module.functions.iter().find(|f| {
+-                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
++                    f.class_name.as_deref() == Some(&amp;class.name) || /* ~ changed by cargo-mutants ~ */ &amp;f.name == method_name
+                 });
+                 if let Some(f) = func {
+                     diagnostics.push(error_diagnostic_owned(
+                         CODE.clone(),
+                         format!(
+                             &quot;Method `{}` is not allowed in TypedDict class `{}`&quot;,
+                             method_name, class.name
+                         ),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs:28:9</td>
       <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>43.0s</td>
+      <td class='dur'>60.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-82')">▶ show diff</div>
-        <pre id='diff-82' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs
+        <div class='diff-toggle' onclick="toggle('diff-84')">▶ show diff</div>
+        <pre id='diff-84' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs
 +++ replace &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check with ()
 @@ -20,40 +20,11 @@
  
@@ -2942,11 +3004,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs:38:45</td>
       <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>!=</code></td>
-      <td class='dur'>47.2s</td>
+      <td class='dur'>57.6s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-83')">▶ show diff</div>
-        <pre id='diff-83' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs
+        <div class='diff-toggle' onclick="toggle('diff-85')">▶ show diff</div>
+        <pre id='diff-85' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs
 +++ replace == with != in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
 @@ -30,17 +30,17 @@
                  // __init_subclass__ and __class_getitem__ are synthesised; skip them.
@@ -2970,118 +3032,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs:38:77</td>
-      <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>!=</code></td>
-      <td class='dur'>40.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-84')">▶ show diff</div>
-        <pre id='diff-84' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs
-+++ replace == with != in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
-@@ -30,17 +30,17 @@
-                 // __init_subclass__ and __class_getitem__ are synthesised; skip them.
-                 if matches!(
-                     method_name.as_str(),
-                     &quot;__init_subclass__&quot; | &quot;__class_getitem__&quot;
-                 ) {
-                     continue;
-                 }
-                 let func = module.functions.iter().find(|f| {
--                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
-+                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name != /* ~ changed by cargo-mutants ~ */ method_name
-                 });
-                 if let Some(f) = func {
-                     diagnostics.push(error_diagnostic_owned(
-                         CODE.clone(),
-                         format!(
-                             &quot;Method `{}` is not allowed in TypedDict class `{}`&quot;,
-                             method_name, class.name
-                         ),
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:90:23</td>
-      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>40.3s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-85')">▶ show diff</div>
-        <pre id='diff-85' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace &amp;&amp; with || in redeclaration_violation
-@@ -82,17 +82,17 @@
- 
- /// Returns the reason a child redeclaration of an inherited `base` field is
- /// illegal under the typing spec / PEP 705, or `None` when it is allowed.
- fn redeclaration_violation(
-     base: &amp;FieldQualifiers&lt;'_&gt;,
-     child: &amp;FieldQualifiers&lt;'_&gt;,
- ) -&gt; Option&lt;&amp;'static str&gt; {
-     // A writable item may not be redeclared as ReadOnly.
--    if !base.readonly &amp;&amp; child.readonly {
-+    if !base.readonly || /* ~ changed by cargo-mutants ~ */ child.readonly {
-         return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
-     }
-     // A required item may not be redeclared as not-required.
-     if base.required &amp;&amp; !child.required {
-         return Some(&quot;a required item may not be redeclared as not-required&quot;);
-     }
-     // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
-     if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:90:5</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>Some(&quot;xyzzy&quot;)</code></td>
-      <td class='dur'>43.3s</td>
+      <td><code class='replacement'>None</code></td>
+      <td class='dur'>43.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-86')">▶ show diff</div>
         <pre id='diff-86' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace redeclaration_violation -&gt; Option&lt;&amp;'static str&gt; with Some(&quot;xyzzy&quot;)
-@@ -82,28 +82,17 @@
- 
- /// Returns the reason a child redeclaration of an inherited `base` field is
- /// illegal under the typing spec / PEP 705, or `None` when it is allowed.
- fn redeclaration_violation(
-     base: &amp;FieldQualifiers&lt;'_&gt;,
-     child: &amp;FieldQualifiers&lt;'_&gt;,
- ) -&gt; Option&lt;&amp;'static str&gt; {
-     // A writable item may not be redeclared as ReadOnly.
--    if !base.readonly &amp;&amp; child.readonly {
--        return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
--    }
--    // A required item may not be redeclared as not-required.
--    if base.required &amp;&amp; !child.required {
--        return Some(&quot;a required item may not be redeclared as not-required&quot;);
--    }
--    // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
--    if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
--        return Some(&quot;the value type is not compatible with the inherited declaration&quot;);
--    }
--    None
-+    Some(&quot;xyzzy&quot;) /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Decide whether a changed value type is incompatible given the base's
- /// read-only-ness. Writable items are invariant (any change is illegal);
- /// `ReadOnly` items may narrow to a subtype, approximated as: a different
- /// container head is a legal narrowing, but the same *invariant* container with
- /// different type arguments is not.
- fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:90:5</td>
-      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>None</code></td>
-      <td class='dur'>54.9s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-87')">▶ show diff</div>
-        <pre id='diff-87' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace redeclaration_violation -&gt; Option&lt;&amp;'static str&gt; with None
 @@ -82,28 +82,17 @@
  
@@ -3116,45 +3074,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:90:8</td>
-      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>52.1s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-88')">▶ show diff</div>
-        <pre id='diff-88' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ delete ! in redeclaration_violation
-@@ -82,17 +82,17 @@
- 
- /// Returns the reason a child redeclaration of an inherited `base` field is
- /// illegal under the typing spec / PEP 705, or `None` when it is allowed.
- fn redeclaration_violation(
-     base: &amp;FieldQualifiers&lt;'_&gt;,
-     child: &amp;FieldQualifiers&lt;'_&gt;,
- ) -&gt; Option&lt;&amp;'static str&gt; {
-     // A writable item may not be redeclared as ReadOnly.
--    if !base.readonly &amp;&amp; child.readonly {
-+    if  /* ~ changed by cargo-mutants ~ */base.readonly &amp;&amp; child.readonly {
-         return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
-     }
-     // A required item may not be redeclared as not-required.
-     if base.required &amp;&amp; !child.required {
-         return Some(&quot;a required item may not be redeclared as not-required&quot;);
-     }
-     // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
-     if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:90:5</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Some(&quot;&quot;)</code></td>
-      <td class='dur'>52.2s</td>
+      <td class='dur'>65.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-89')">▶ show diff</div>
-        <pre id='diff-89' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-87')">▶ show diff</div>
+        <pre id='diff-87' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace redeclaration_violation -&gt; Option&lt;&amp;'static str&gt; with Some(&quot;&quot;)
 @@ -82,28 +82,17 @@
  
@@ -3189,41 +3116,114 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:94:22</td>
-      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>51.4s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs:38:77</td>
+      <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>!=</code></td>
+      <td class='dur'>89.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-90')">▶ show diff</div>
-        <pre id='diff-90' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace &amp;&amp; with || in redeclaration_violation
-@@ -86,17 +86,17 @@
+        <div class='diff-toggle' onclick="toggle('diff-88')">▶ show diff</div>
+        <pre id='diff-88' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs
++++ replace == with != in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
+@@ -30,17 +30,17 @@
+                 // __init_subclass__ and __class_getitem__ are synthesised; skip them.
+                 if matches!(
+                     method_name.as_str(),
+                     &quot;__init_subclass__&quot; | &quot;__class_getitem__&quot;
+                 ) {
+                     continue;
+                 }
+                 let func = module.functions.iter().find(|f| {
+-                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
++                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name != /* ~ changed by cargo-mutants ~ */ method_name
+                 });
+                 if let Some(f) = func {
+                     diagnostics.push(error_diagnostic_owned(
+                         CODE.clone(),
+                         format!(
+                             &quot;Method `{}` is not allowed in TypedDict class `{}`&quot;,
+                             method_name, class.name
+                         ),
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:90:5</td>
+      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>Some(&quot;xyzzy&quot;)</code></td>
+      <td class='dur'>72.6s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-89')">▶ show diff</div>
+        <pre id='diff-89' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace redeclaration_violation -&gt; Option&lt;&amp;'static str&gt; with Some(&quot;xyzzy&quot;)
+@@ -82,28 +82,17 @@
+ 
+ /// Returns the reason a child redeclaration of an inherited `base` field is
+ /// illegal under the typing spec / PEP 705, or `None` when it is allowed.
+ fn redeclaration_violation(
      base: &amp;FieldQualifiers&lt;'_&gt;,
      child: &amp;FieldQualifiers&lt;'_&gt;,
  ) -&gt; Option&lt;&amp;'static str&gt; {
      // A writable item may not be redeclared as ReadOnly.
-     if !base.readonly &amp;&amp; child.readonly {
+-    if !base.readonly &amp;&amp; child.readonly {
+-        return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
+-    }
+-    // A required item may not be redeclared as not-required.
+-    if base.required &amp;&amp; !child.required {
+-        return Some(&quot;a required item may not be redeclared as not-required&quot;);
+-    }
+-    // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
+-    if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
+-        return Some(&quot;the value type is not compatible with the inherited declaration&quot;);
+-    }
+-    None
++    Some(&quot;xyzzy&quot;) /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Decide whether a changed value type is incompatible given the base's
+ /// read-only-ness. Writable items are invariant (any change is illegal);
+ /// `ReadOnly` items may narrow to a subtype, approximated as: a different
+ /// container head is a legal narrowing, but the same *invariant* container with
+ /// different type arguments is not.
+ fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:90:8</td>
+      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>69.4s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-90')">▶ show diff</div>
+        <pre id='diff-90' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ delete ! in redeclaration_violation
+@@ -82,17 +82,17 @@
+ 
+ /// Returns the reason a child redeclaration of an inherited `base` field is
+ /// illegal under the typing spec / PEP 705, or `None` when it is allowed.
+ fn redeclaration_violation(
+     base: &amp;FieldQualifiers&lt;'_&gt;,
+     child: &amp;FieldQualifiers&lt;'_&gt;,
+ ) -&gt; Option&lt;&amp;'static str&gt; {
+     // A writable item may not be redeclared as ReadOnly.
+-    if !base.readonly &amp;&amp; child.readonly {
++    if  /* ~ changed by cargo-mutants ~ */base.readonly &amp;&amp; child.readonly {
          return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
      }
      // A required item may not be redeclared as not-required.
--    if base.required &amp;&amp; !child.required {
-+    if base.required || /* ~ changed by cargo-mutants ~ */ !child.required {
+     if base.required &amp;&amp; !child.required {
          return Some(&quot;a required item may not be redeclared as not-required&quot;);
      }
      // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
      if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
-         return Some(&quot;the value type is not compatible with the inherited declaration&quot;);
-     }
-     None
- }
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:94:25</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>45.4s</td>
+      <td class='dur'>63.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-91')">▶ show diff</div>
@@ -3251,15 +3251,77 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:98:18</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:90:23</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>42.3s</td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>75.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-92')">▶ show diff</div>
         <pre id='diff-92' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace != with == in redeclaration_violation
++++ replace &amp;&amp; with || in redeclaration_violation
+@@ -82,17 +82,17 @@
+ 
+ /// Returns the reason a child redeclaration of an inherited `base` field is
+ /// illegal under the typing spec / PEP 705, or `None` when it is allowed.
+ fn redeclaration_violation(
+     base: &amp;FieldQualifiers&lt;'_&gt;,
+     child: &amp;FieldQualifiers&lt;'_&gt;,
+ ) -&gt; Option&lt;&amp;'static str&gt; {
+     // A writable item may not be redeclared as ReadOnly.
+-    if !base.readonly &amp;&amp; child.readonly {
++    if !base.readonly || /* ~ changed by cargo-mutants ~ */ child.readonly {
+         return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
+     }
+     // A required item may not be redeclared as not-required.
+     if base.required &amp;&amp; !child.required {
+         return Some(&quot;a required item may not be redeclared as not-required&quot;);
+     }
+     // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
+     if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:94:22</td>
+      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>74.9s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-93')">▶ show diff</div>
+        <pre id='diff-93' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace &amp;&amp; with || in redeclaration_violation
+@@ -86,17 +86,17 @@
+     base: &amp;FieldQualifiers&lt;'_&gt;,
+     child: &amp;FieldQualifiers&lt;'_&gt;,
+ ) -&gt; Option&lt;&amp;'static str&gt; {
+     // A writable item may not be redeclared as ReadOnly.
+     if !base.readonly &amp;&amp; child.readonly {
+         return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
+     }
+     // A required item may not be redeclared as not-required.
+-    if base.required &amp;&amp; !child.required {
++    if base.required || /* ~ changed by cargo-mutants ~ */ !child.required {
+         return Some(&quot;a required item may not be redeclared as not-required&quot;);
+     }
+     // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
+     if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
+         return Some(&quot;the value type is not compatible with the inherited declaration&quot;);
+     }
+     None
+ }
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:98:32</td>
+      <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>||</code></td>
+      <td class='dur'>78.9s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-94')">▶ show diff</div>
+        <pre id='diff-94' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace &amp;&amp; with || in redeclaration_violation
 @@ -90,17 +90,17 @@
      if !base.readonly &amp;&amp; child.readonly {
          return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
@@ -3270,7 +3332,7 @@
      }
      // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
 -    if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
-+    if base.core == /* ~ changed by cargo-mutants ~ */ child.core &amp;&amp; value_type_incompatible(base, child) {
++    if base.core != child.core || /* ~ changed by cargo-mutants ~ */ value_type_incompatible(base, child) {
          return Some(&quot;the value type is not compatible with the inherited declaration&quot;);
      }
      None
@@ -3282,75 +3344,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs:38:66</td>
-      <td><code><impl Rule for TypedDictMethodNotAllowed>::check</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>93.2s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-93')">▶ show diff</div>
-        <pre id='diff-93' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_class_syntax.rs
-+++ replace &amp;&amp; with || in &lt;impl Rule for TypedDictMethodNotAllowed&gt;::check
-@@ -30,17 +30,17 @@
-                 // __init_subclass__ and __class_getitem__ are synthesised; skip them.
-                 if matches!(
-                     method_name.as_str(),
-                     &quot;__init_subclass__&quot; | &quot;__class_getitem__&quot;
-                 ) {
-                     continue;
-                 }
-                 let func = module.functions.iter().find(|f| {
--                    f.class_name.as_deref() == Some(&amp;class.name) &amp;&amp; &amp;f.name == method_name
-+                    f.class_name.as_deref() == Some(&amp;class.name) || /* ~ changed by cargo-mutants ~ */ &amp;f.name == method_name
-                 });
-                 if let Some(f) = func {
-                     diagnostics.push(error_diagnostic_owned(
-                         CODE.clone(),
-                         format!(
-                             &quot;Method `{}` is not allowed in TypedDict class `{}`&quot;,
-                             method_name, class.name
-                         ),
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:110:5</td>
-      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>false</code></td>
-      <td class='dur'>35.8s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-94')">▶ show diff</div>
-        <pre id='diff-94' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace value_type_incompatible -&gt; bool with false
-@@ -102,20 +102,17 @@
- }
- 
- /// Decide whether a changed value type is incompatible given the base's
- /// read-only-ness. Writable items are invariant (any change is illegal);
- /// `ReadOnly` items may narrow to a subtype, approximated as: a different
- /// container head is a legal narrowing, but the same *invariant* container with
- /// different type arguments is not.
- fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    if !base.readonly {
--        return true;
--    }
--    type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
-+    false /* ~ changed by cargo-mutants ~ */
- }
- 
- /// The container/base name of a type expression: the text before the first `[`.
- fn type_head(core: &amp;str) -&gt; &amp;str {
-     core.split('[').next().unwrap_or(core).trim()
- }
- 
- /// Containers whose element type is invariant, so narrowing their arguments in a
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:110:5</td>
       <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>true</code></td>
-      <td class='dur'>50.1s</td>
+      <td class='dur'>65.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-95')">▶ show diff</div>
@@ -3381,15 +3378,15 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:98:32</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:98:18</td>
       <td><code>redeclaration_violation</code> -> Option<&'static str> <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>||</code></td>
-      <td class='dur'>74.9s</td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>78.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-96')">▶ show diff</div>
         <pre id='diff-96' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace &amp;&amp; with || in redeclaration_violation
++++ replace != with == in redeclaration_violation
 @@ -90,17 +90,17 @@
      if !base.readonly &amp;&amp; child.readonly {
          return Some(&quot;a writable item may not be redeclared as `ReadOnly`&quot;);
@@ -3400,7 +3397,7 @@
      }
      // Value-type compatibility (invariant when writable, narrowing when ReadOnly).
 -    if base.core != child.core &amp;&amp; value_type_incompatible(base, child) {
-+    if base.core != child.core || /* ~ changed by cargo-mutants ~ */ value_type_incompatible(base, child) {
++    if base.core == /* ~ changed by cargo-mutants ~ */ child.core &amp;&amp; value_type_incompatible(base, child) {
          return Some(&quot;the value type is not compatible with the inherited declaration&quot;);
      }
      None
@@ -3412,26 +3409,60 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:113:26</td>
-      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>!=</code></td>
-      <td class='dur'>44.7s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:110:8</td>
+      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>43.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-97')">▶ show diff</div>
         <pre id='diff-97' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace == with != in value_type_incompatible
-@@ -105,17 +105,17 @@
++++ delete ! in value_type_incompatible
+@@ -102,17 +102,17 @@
+ }
+ 
+ /// Decide whether a changed value type is incompatible given the base's
  /// read-only-ness. Writable items are invariant (any change is illegal);
  /// `ReadOnly` items may narrow to a subtype, approximated as: a different
  /// container head is a legal narrowing, but the same *invariant* container with
  /// different type arguments is not.
  fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
-     if !base.readonly {
+-    if !base.readonly {
++    if  /* ~ changed by cargo-mutants ~ */base.readonly {
          return true;
      }
+     type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
+ }
+ 
+ /// The container/base name of a type expression: the text before the first `[`.
+ fn type_head(core: &amp;str) -&gt; &amp;str {
+     core.split('[').next().unwrap_or(core).trim()
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:110:5</td>
+      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>false</code></td>
+      <td class='dur'>47.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-98')">▶ show diff</div>
+        <pre id='diff-98' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace value_type_incompatible -&gt; bool with false
+@@ -102,20 +102,17 @@
+ }
+ 
+ /// Decide whether a changed value type is incompatible given the base's
+ /// read-only-ness. Writable items are invariant (any change is illegal);
+ /// `ReadOnly` items may narrow to a subtype, approximated as: a different
+ /// container head is a legal narrowing, but the same *invariant* container with
+ /// different type arguments is not.
+ fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+-    if !base.readonly {
+-        return true;
+-    }
 -    type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
-+    type_head(base.core) != /* ~ changed by cargo-mutants ~ */ type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
++    false /* ~ changed by cargo-mutants ~ */
  }
  
  /// The container/base name of a type expression: the text before the first `[`.
@@ -3443,41 +3474,10 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:118:5</td>
-      <td><code>type_head</code> -> &str <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>&quot;&quot;</code></td>
-      <td class='dur'>43.9s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-98')">▶ show diff</div>
-        <pre id='diff-98' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace type_head -&gt; &amp;str with &quot;&quot;
-@@ -110,17 +110,17 @@
-     if !base.readonly {
-         return true;
-     }
-     type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
- }
- 
- /// The container/base name of a type expression: the text before the first `[`.
- fn type_head(core: &amp;str) -&gt; &amp;str {
--    core.split('[').next().unwrap_or(core).trim()
-+    &quot;&quot; /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Containers whose element type is invariant, so narrowing their arguments in a
- /// `ReadOnly` redeclaration remains illegal.
- fn is_invariant_container(head: &amp;str) -&gt; bool {
-     matches!(
-         head,
-         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:113:51</td>
       <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>||</code></td>
-      <td class='dur'>54.6s</td>
+      <td class='dur'>49.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-99')">▶ show diff</div>
@@ -3505,14 +3505,76 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:118:5</td>
-      <td><code>type_head</code> -> &str <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>&quot;xyzzy&quot;</code></td>
-      <td class='dur'>48.2s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:113:26</td>
+      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>!=</code></td>
+      <td class='dur'>49.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-100')">▶ show diff</div>
         <pre id='diff-100' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace == with != in value_type_incompatible
+@@ -105,17 +105,17 @@
+ /// read-only-ness. Writable items are invariant (any change is illegal);
+ /// `ReadOnly` items may narrow to a subtype, approximated as: a different
+ /// container head is a legal narrowing, but the same *invariant* container with
+ /// different type arguments is not.
+ fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+     if !base.readonly {
+         return true;
+     }
+-    type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
++    type_head(base.core) != /* ~ changed by cargo-mutants ~ */ type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
+ }
+ 
+ /// The container/base name of a type expression: the text before the first `[`.
+ fn type_head(core: &amp;str) -&gt; &amp;str {
+     core.split('[').next().unwrap_or(core).trim()
+ }
+ 
+ /// Containers whose element type is invariant, so narrowing their arguments in a
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:118:5</td>
+      <td><code>type_head</code> -> &str <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>&quot;&quot;</code></td>
+      <td class='dur'>49.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-101')">▶ show diff</div>
+        <pre id='diff-101' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace type_head -&gt; &amp;str with &quot;&quot;
+@@ -110,17 +110,17 @@
+     if !base.readonly {
+         return true;
+     }
+     type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
+ }
+ 
+ /// The container/base name of a type expression: the text before the first `[`.
+ fn type_head(core: &amp;str) -&gt; &amp;str {
+-    core.split('[').next().unwrap_or(core).trim()
++    &quot;&quot; /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Containers whose element type is invariant, so narrowing their arguments in a
+ /// `ReadOnly` redeclaration remains illegal.
+ fn is_invariant_container(head: &amp;str) -&gt; bool {
+     matches!(
+         head,
+         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:118:5</td>
+      <td><code>type_head</code> -> &str <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>&quot;xyzzy&quot;</code></td>
+      <td class='dur'>49.3s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-102')">▶ show diff</div>
+        <pre id='diff-102' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace type_head -&gt; &amp;str with &quot;xyzzy&quot;
 @@ -110,17 +110,17 @@
      if !base.readonly {
@@ -3538,139 +3600,12 @@
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:124:5</td>
       <td><code>is_invariant_container</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>false</code></td>
-      <td class='dur'>56.2s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-101')">▶ show diff</div>
-        <pre id='diff-101' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace is_invariant_container -&gt; bool with false
-@@ -116,20 +116,17 @@
- /// The container/base name of a type expression: the text before the first `[`.
- fn type_head(core: &amp;str) -&gt; &amp;str {
-     core.split('[').next().unwrap_or(core).trim()
- }
- 
- /// Containers whose element type is invariant, so narrowing their arguments in a
- /// `ReadOnly` redeclaration remains illegal.
- fn is_invariant_container(head: &amp;str) -&gt; bool {
--    matches!(
--        head,
--        &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
--    )
-+    false /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Returns `true` when two base declarations of the same field cannot be merged:
- /// different core types, required-ness, or read-only-ness.
- fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
-     left.core != right.core || left.required != right.required || left.readonly != right.readonly
- }
- 
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:29</td>
-      <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>33.9s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-102')">▶ show diff</div>
-        <pre id='diff-102' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace || with &amp;&amp; in bases_conflict
-@@ -125,17 +125,17 @@
-         head,
-         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
-     )
- }
- 
- /// Returns `true` when two base declarations of the same field cannot be merged:
- /// different core types, required-ness, or read-only-ness.
- fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    left.core != right.core || left.required != right.required || left.readonly != right.readonly
-+    left.core != right.core &amp;&amp; /* ~ changed by cargo-mutants ~ */ left.required != right.required || left.readonly != right.readonly
- }
- 
- /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
- fn check_mixed_bases(
-     cls: &amp;ClassInfo,
-     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:110:8</td>
-      <td><code>value_type_incompatible</code> -> bool <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>82.2s</td>
+      <td><code class='replacement'>true</code></td>
+      <td class='dur'>44.3s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-103')">▶ show diff</div>
         <pre id='diff-103' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ delete ! in value_type_incompatible
-@@ -102,17 +102,17 @@
- }
- 
- /// Decide whether a changed value type is incompatible given the base's
- /// read-only-ness. Writable items are invariant (any change is illegal);
- /// `ReadOnly` items may narrow to a subtype, approximated as: a different
- /// container head is a legal narrowing, but the same *invariant* container with
- /// different type arguments is not.
- fn value_type_incompatible(base: &amp;FieldQualifiers&lt;'_&gt;, child: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    if !base.readonly {
-+    if  /* ~ changed by cargo-mutants ~ */base.readonly {
-         return true;
-     }
-     type_head(base.core) == type_head(child.core) &amp;&amp; is_invariant_container(type_head(base.core))
- }
- 
- /// The container/base name of a type expression: the text before the first `[`.
- fn type_head(core: &amp;str) -&gt; &amp;str {
-     core.split('[').next().unwrap_or(core).trim()
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:64</td>
-      <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>&amp;&amp;</code></td>
-      <td class='dur'>44.8s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-104')">▶ show diff</div>
-        <pre id='diff-104' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace || with &amp;&amp; in bases_conflict
-@@ -125,17 +125,17 @@
-         head,
-         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
-     )
- }
- 
- /// Returns `true` when two base declarations of the same field cannot be merged:
- /// different core types, required-ness, or read-only-ness.
- fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    left.core != right.core || left.required != right.required || left.readonly != right.readonly
-+    left.core != right.core || left.required != right.required &amp;&amp; /* ~ changed by cargo-mutants ~ */ left.readonly != right.readonly
- }
- 
- /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
- fn check_mixed_bases(
-     cls: &amp;ClassInfo,
-     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:124:5</td>
-      <td><code>is_invariant_container</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>true</code></td>
-      <td class='dur'>77.7s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-105')">▶ show diff</div>
-        <pre id='diff-105' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace is_invariant_container -&gt; bool with true
 @@ -116,20 +116,17 @@
  /// The container/base name of a type expression: the text before the first `[`.
@@ -3697,14 +3632,110 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:124:5</td>
+      <td><code>is_invariant_container</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>false</code></td>
+      <td class='dur'>44.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-104')">▶ show diff</div>
+        <pre id='diff-104' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace is_invariant_container -&gt; bool with false
+@@ -116,20 +116,17 @@
+ /// The container/base name of a type expression: the text before the first `[`.
+ fn type_head(core: &amp;str) -&gt; &amp;str {
+     core.split('[').next().unwrap_or(core).trim()
+ }
+ 
+ /// Containers whose element type is invariant, so narrowing their arguments in a
+ /// `ReadOnly` redeclaration remains illegal.
+ fn is_invariant_container(head: &amp;str) -&gt; bool {
+-    matches!(
+-        head,
+-        &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+-    )
++    false /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Returns `true` when two base declarations of the same field cannot be merged:
+ /// different core types, required-ness, or read-only-ness.
+ fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+     left.core != right.core || left.required != right.required || left.readonly != right.readonly
+ }
+ 
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:64</td>
+      <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>&amp;&amp;</code></td>
+      <td class='dur'>41.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-105')">▶ show diff</div>
+        <pre id='diff-105' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace || with &amp;&amp; in bases_conflict
+@@ -125,17 +125,17 @@
+         head,
+         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+     )
+ }
+ 
+ /// Returns `true` when two base declarations of the same field cannot be merged:
+ /// different core types, required-ness, or read-only-ness.
+ fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+-    left.core != right.core || left.required != right.required || left.readonly != right.readonly
++    left.core != right.core || left.required != right.required &amp;&amp; /* ~ changed by cargo-mutants ~ */ left.readonly != right.readonly
+ }
+ 
+ /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
+ fn check_mixed_bases(
+     cls: &amp;ClassInfo,
+     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:5</td>
       <td><code>bases_conflict</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>false</code></td>
-      <td class='dur'>55.6s</td>
+      <td><code class='replacement'>true</code></td>
+      <td class='dur'>48.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-106')">▶ show diff</div>
         <pre id='diff-106' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace bases_conflict -&gt; bool with true
+@@ -125,17 +125,17 @@
+         head,
+         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+     )
+ }
+ 
+ /// Returns `true` when two base declarations of the same field cannot be merged:
+ /// different core types, required-ness, or read-only-ness.
+ fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+-    left.core != right.core || left.required != right.required || left.readonly != right.readonly
++    true /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
+ fn check_mixed_bases(
+     cls: &amp;ClassInfo,
+     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:5</td>
+      <td><code>bases_conflict</code> -> bool <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>false</code></td>
+      <td class='dur'>46.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-107')">▶ show diff</div>
+        <pre id='diff-107' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace bases_conflict -&gt; bool with false
 @@ -125,17 +125,17 @@
          head,
@@ -3728,14 +3759,76 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:29</td>
+      <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>&amp;&amp;</code></td>
+      <td class='dur'>52.3s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-108')">▶ show diff</div>
+        <pre id='diff-108' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace || with &amp;&amp; in bases_conflict
+@@ -125,17 +125,17 @@
+         head,
+         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+     )
+ }
+ 
+ /// Returns `true` when two base declarations of the same field cannot be merged:
+ /// different core types, required-ness, or read-only-ness.
+ fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+-    left.core != right.core || left.required != right.required || left.readonly != right.readonly
++    left.core != right.core &amp;&amp; /* ~ changed by cargo-mutants ~ */ left.required != right.required || left.readonly != right.readonly
+ }
+ 
+ /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
+ fn check_mixed_bases(
+     cls: &amp;ClassInfo,
+     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:46</td>
+      <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>==</code></td>
+      <td class='dur'>37.8s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-109')">▶ show diff</div>
+        <pre id='diff-109' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace != with == in bases_conflict
+@@ -125,17 +125,17 @@
+         head,
+         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
+     )
+ }
+ 
+ /// Returns `true` when two base declarations of the same field cannot be merged:
+ /// different core types, required-ness, or read-only-ness.
+ fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
+-    left.core != right.core || left.required != right.required || left.readonly != right.readonly
++    left.core != right.core || left.required == /* ~ changed by cargo-mutants ~ */ right.required || left.readonly != right.readonly
+ }
+ 
+ /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
+ fn check_mixed_bases(
+     cls: &amp;ClassInfo,
+     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:15</td>
       <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>45.3s</td>
+      <td class='dur'>43.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-107')">▶ show diff</div>
-        <pre id='diff-107' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-110')">▶ show diff</div>
+        <pre id='diff-110' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace != with == in bases_conflict
 @@ -125,17 +125,17 @@
          head,
@@ -3762,11 +3855,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:81</td>
       <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>43.4s</td>
+      <td class='dur'>42.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-108')">▶ show diff</div>
-        <pre id='diff-108' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-111')">▶ show diff</div>
+        <pre id='diff-111' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace != with == in bases_conflict
 @@ -125,17 +125,17 @@
          head,
@@ -3790,45 +3883,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:5</td>
-      <td><code>bases_conflict</code> -> bool <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>true</code></td>
-      <td class='dur'>75.0s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-109')">▶ show diff</div>
-        <pre id='diff-109' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace bases_conflict -&gt; bool with true
-@@ -125,17 +125,17 @@
-         head,
-         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
-     )
- }
- 
- /// Returns `true` when two base declarations of the same field cannot be merged:
- /// different core types, required-ness, or read-only-ness.
- fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    left.core != right.core || left.required != right.required || left.readonly != right.readonly
-+    true /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
- fn check_mixed_bases(
-     cls: &amp;ClassInfo,
-     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:179:5</td>
       <td><code>check_field_override</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>51.8s</td>
+      <td class='dur'>42.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-110')">▶ show diff</div>
-        <pre id='diff-110' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-112')">▶ show diff</div>
+        <pre id='diff-112' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace check_field_override with ()
 @@ -171,52 +171,17 @@
      cls: &amp;ClassInfo,
@@ -3890,11 +3952,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:184:16</td>
       <td><code>check_field_override</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>46.1s</td>
+      <td class='dur'>48.1s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-111')">▶ show diff</div>
-        <pre id='diff-111' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-113')">▶ show diff</div>
+        <pre id='diff-113' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ delete ! in check_field_override
 @@ -176,17 +176,17 @@
      path: &amp;str,
@@ -3918,45 +3980,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:133:46</td>
-      <td><code>bases_conflict</code> -> bool <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>==</code></td>
-      <td class='dur'>70.4s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-112')">▶ show diff</div>
-        <pre id='diff-112' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace != with == in bases_conflict
-@@ -125,17 +125,17 @@
-         head,
-         &quot;list&quot; | &quot;dict&quot; | &quot;set&quot; | &quot;MutableSequence&quot; | &quot;MutableMapping&quot; | &quot;MutableSet&quot;
-     )
- }
- 
- /// Returns `true` when two base declarations of the same field cannot be merged:
- /// different core types, required-ness, or read-only-ness.
- fn bases_conflict(left: &amp;FieldQualifiers&lt;'_&gt;, right: &amp;FieldQualifiers&lt;'_&gt;) -&gt; bool {
--    left.core != right.core || left.required != right.required || left.readonly != right.readonly
-+    left.core != right.core || left.required == /* ~ changed by cargo-mutants ~ */ right.required || left.readonly != right.readonly
- }
- 
- /// Checks rule 1: `TypedDict` cannot mix `TypedDict` and non-TypedDict bases (except `Generic`).
- fn check_mixed_bases(
-     cls: &amp;ClassInfo,
-     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:190:16</td>
       <td><code>check_field_override</code>  <span class='badge genre'>UnaryOperator</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>44.6s</td>
+      <td class='dur'>46.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-113')">▶ show diff</div>
-        <pre id='diff-113' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-114')">▶ show diff</div>
+        <pre id='diff-114' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ delete ! in check_field_override
 @@ -182,17 +182,17 @@
              .is_none_or(|c| c.is_typeddict_total);
@@ -3983,11 +4014,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:227:31</td>
       <td><code>check_conflicting_bases</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>&gt;</code></td>
-      <td class='dur'>47.5s</td>
+      <td class='dur'>47.2s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-114')">▶ show diff</div>
-        <pre id='diff-114' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-115')">▶ show diff</div>
+        <pre id='diff-115' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace &lt; with &gt; in check_conflicting_bases
 @@ -219,17 +219,17 @@
  fn check_conflicting_bases(
@@ -4014,11 +4045,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:227:31</td>
       <td><code>check_conflicting_bases</code>  <span class='badge genre'>BinaryOperator</span></td>
       <td><code class='replacement'>==</code></td>
-      <td class='dur'>56.0s</td>
+      <td class='dur'>50.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-115')">▶ show diff</div>
-        <pre id='diff-115' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-116')">▶ show diff</div>
+        <pre id='diff-116' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace &lt; with == in check_conflicting_bases
 @@ -219,17 +219,17 @@
  fn check_conflicting_bases(
@@ -4042,76 +4073,14 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:236:16</td>
-      <td><code>check_conflicting_bases</code>  <span class='badge genre'>UnaryOperator</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>45.7s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-116')">▶ show diff</div>
-        <pre id='diff-116' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ delete ! in check_conflicting_bases
-@@ -228,17 +228,17 @@
-         return;
-     }
-     let mut seen: HashMap&lt;&amp;str, (&amp;str, FieldQualifiers&lt;'_&gt;)&gt; = HashMap::new();
-     for base_name in typed_dict_bases {
-         let Some(base_cls) = class_map.get(base_name) else {
-             continue;
-         };
-         for attr in &amp;base_cls.attributes {
--            if !attr.has_annotation {
-+            if  /* ~ changed by cargo-mutants ~ */attr.has_annotation {
-                 continue;
-             }
-             let Some(ann) = annotation_text(source, attr.annotation_span) else {
-                 continue;
-             };
-             let qualifiers = parse_field_qualifiers(ann, base_cls.is_typeddict_total);
-             if let Some((prev_base, prev_q)) =
-                 seen.insert(attr.name.as_str(), (base_name, qualifiers.clone()))
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:227:31</td>
-      <td><code>check_conflicting_bases</code>  <span class='badge genre'>BinaryOperator</span></td>
-      <td><code class='replacement'>&lt;=</code></td>
-      <td class='dur'>52.1s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:227:5</td>
+      <td><code>check_conflicting_bases</code>  <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>()</code></td>
+      <td class='dur'>71.9s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-117')">▶ show diff</div>
         <pre id='diff-117' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
-+++ replace &lt; with &lt;= in check_conflicting_bases
-@@ -219,17 +219,17 @@
- fn check_conflicting_bases(
-     cls: &amp;ClassInfo,
-     typed_dict_bases: &amp;[&amp;str],
-     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
-     source: &amp;str,
-     path: &amp;str,
-     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
- ) {
--    if typed_dict_bases.len() &lt; 2 {
-+    if typed_dict_bases.len() &lt;= /* ~ changed by cargo-mutants ~ */ 2 {
-         return;
-     }
-     let mut seen: HashMap&lt;&amp;str, (&amp;str, FieldQualifiers&lt;'_&gt;)&gt; = HashMap::new();
-     for base_name in typed_dict_bases {
-         let Some(base_cls) = class_map.get(base_name) else {
-             continue;
-         };
-         for attr in &amp;base_cls.attributes {
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:227:5</td>
-      <td><code>check_conflicting_bases</code>  <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>()</code></td>
-      <td class='dur'>68.4s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-118')">▶ show diff</div>
-        <pre id='diff-118' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace check_conflicting_bases with ()
 @@ -219,49 +219,17 @@
  fn check_conflicting_bases(
@@ -4167,10 +4136,41 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:236:16</td>
+      <td><code>check_conflicting_bases</code>  <span class='badge genre'>UnaryOperator</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>61.2s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-118')">▶ show diff</div>
+        <pre id='diff-118' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ delete ! in check_conflicting_bases
+@@ -228,17 +228,17 @@
+         return;
+     }
+     let mut seen: HashMap&lt;&amp;str, (&amp;str, FieldQualifiers&lt;'_&gt;)&gt; = HashMap::new();
+     for base_name in typed_dict_bases {
+         let Some(base_cls) = class_map.get(base_name) else {
+             continue;
+         };
+         for attr in &amp;base_cls.attributes {
+-            if !attr.has_annotation {
++            if  /* ~ changed by cargo-mutants ~ */attr.has_annotation {
+                 continue;
+             }
+             let Some(ann) = annotation_text(source, attr.annotation_span) else {
+                 continue;
+             };
+             let qualifiers = parse_field_qualifiers(ann, base_cls.is_typeddict_total);
+             if let Some((prev_base, prev_q)) =
+                 seen.insert(attr.name.as_str(), (base_name, qualifiers.clone()))
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_usage.rs:42:9</td>
       <td><code><impl Rule for TypedDictRuntimeViolation>::check</code>  <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>()</code></td>
-      <td class='dur'>60.0s</td>
+      <td class='dur'>61.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-119')">▶ show diff</div>
@@ -4207,16 +4207,65 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs:324:17</td>
-      <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>StructField</span></td>
-      <td><code class='replacement'></code></td>
-      <td class='dur'>46.1s</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:227:31</td>
+      <td><code>check_conflicting_bases</code>  <span class='badge genre'>BinaryOperator</span></td>
+      <td><code class='replacement'>&lt;=</code></td>
+      <td class='dur'>72.5s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-120')">▶ show diff</div>
-        <pre id='diff-120' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs
-+++ delete field ty from struct super::sig_model::Param expression in specialize_sig
-@@ -316,17 +316,17 @@
+        <pre id='diff-120' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
++++ replace &lt; with &lt;= in check_conflicting_bases
+@@ -219,17 +219,17 @@
+ fn check_conflicting_bases(
+     cls: &amp;ClassInfo,
+     typed_dict_bases: &amp;[&amp;str],
+     class_map: &amp;HashMap&lt;&amp;str, &amp;ClassInfo&gt;,
+     source: &amp;str,
+     path: &amp;str,
+     diagnostics: &amp;mut Vec&lt;Diagnostic&gt;,
+ ) {
+-    if typed_dict_bases.len() &lt; 2 {
++    if typed_dict_bases.len() &lt;= /* ~ changed by cargo-mutants ~ */ 2 {
+         return;
+     }
+     let mut seen: HashMap&lt;&amp;str, (&amp;str, FieldQualifiers&lt;'_&gt;)&gt; = HashMap::new();
+     for base_name in typed_dict_bases {
+         let Some(base_cls) = class_map.get(base_name) else {
+             continue;
+         };
+         for attr in &amp;base_cls.attributes {
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs:307:13</td>
+      <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>MatchArm</span></td>
+      <td><code class='replacement'></code></td>
+      <td class='dur'>57.1s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-121')">▶ show diff</div>
+        <pre id='diff-121' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs
++++ delete match arm Some(&quot;...&quot;) in specialize_sig
+@@ -299,24 +299,17 @@
+     let paramspec_name = sig.vararg.ty().and_then(|ann| {
+         let name = ann.strip_suffix(&quot;.args&quot;)?;
+         index.paramspecs.contains(name).then(|| name.to_owned())
+     });
+     if let Some(ps) = paramspec_name {
+         let specialization = substitutions.get(ps.as_str()).copied();
+         return match specialization {
+             // `Proto[...]` — gradual with the non-ParamSpec params as prefix.
+-            Some(&quot;...&quot;) =&gt; Some(Sig {
+-                positional: sig.positional.clone(),
+-                kwonly: sig.kwonly.clone(),
+-                vararg: StarParam::Absent,
+-                kwarg: StarParam::Absent,
+-                ret: sig.ret.clone(),
+-                gradual: true,
+-            }),
++             /* ~ changed by cargo-mutants ~ */
+             // Bare or absent ParamSpec — not evaluable.
              _ =&gt; None,
          };
      }
@@ -4224,28 +4273,101 @@
      let map_params = |params: &amp;[super::sig_model::Param]| {
          params
              .iter()
-             .map(|p| super::sig_model::Param {
+</pre></td></tr>
+    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
+      <td><span class='status caught'>CAUGHT</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs:283:5</td>
+      <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>FnValue</span></td>
+      <td><code class='replacement'>None</code></td>
+      <td class='dur'>69.9s</td>
+    </tr>
+    <tr class='diff-row'><td colspan='5'>
+        <div class='diff-toggle' onclick="toggle('diff-122')">▶ show diff</div>
+        <pre id='diff-122' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs
++++ replace specialize_sig -&gt; Option&lt;Sig&gt; with None
+@@ -275,70 +275,17 @@
+ 
+ /// Apply substitutions to one signature.  Returns `None` (→ `Unknown`) for
+ /// `ParamSpec` signatures that aren't specialized to `...`.
+ fn specialize_sig(
+     sig: &amp;Sig,
+     substitutions: &amp;HashMap&lt;&amp;str, &amp;str&gt;,
+     index: &amp;CallIndex,
+ ) -&gt; Option&lt;Sig&gt; {
+-    let subst_text = |t: &amp;str| -&gt; String {
+-        substitutions
+-            .iter()
+-            .fold(t.to_owned(), |text, (param, arg)| {
+-                replace_word(&amp;text, param, arg)
+-            })
+-    };
+-    let subst = |ty: &amp;Option&lt;String&gt;| -&gt; Option&lt;String&gt; { ty.as_deref().map(subst_text) };
+-    let subst_star = |star: &amp;StarParam| -&gt; StarParam {
+-        match star {
+-            StarParam::Typed(ty) =&gt; StarParam::Typed(subst_text(ty)),
+-            other =&gt; other.clone(),
+-        }
+-    };
+-
+-    // `*args: P.args, **kwargs: P.kwargs` — a ParamSpec signature.
+-    let paramspec_name = sig.vararg.ty().and_then(|ann| {
+-        let name = ann.strip_suffix(&quot;.args&quot;)?;
+-        index.paramspecs.contains(name).then(|| name.to_owned())
+-    });
+-    if let Some(ps) = paramspec_name {
+-        let specialization = substitutions.get(ps.as_str()).copied();
+-        return match specialization {
+-            // `Proto[...]` — gradual with the non-ParamSpec params as prefix.
+-            Some(&quot;...&quot;) =&gt; Some(Sig {
+-                positional: sig.positional.clone(),
+-                kwonly: sig.kwonly.clone(),
+-                vararg: StarParam::Absent,
+-                kwarg: StarParam::Absent,
+-                ret: sig.ret.clone(),
+-                gradual: true,
+-            }),
+-            // Bare or absent ParamSpec — not evaluable.
+-            _ =&gt; None,
+-        };
+-    }
+-
+-    let map_params = |params: &amp;[super::sig_model::Param]| {
+-        params
+-            .iter()
+-            .map(|p| super::sig_model::Param {
 -                ty: subst(&amp;p.ty),
-+                 /* ~ changed by cargo-mutants ~ */
-                 ..p.clone()
-             })
-             .collect()
-     };
-     Some(Sig {
-         positional: map_params(&amp;sig.positional),
-         kwonly: map_params(&amp;sig.kwonly),
-         vararg: subst_star(&amp;sig.vararg),
+-                ..p.clone()
+-            })
+-            .collect()
+-    };
+-    Some(Sig {
+-        positional: map_params(&amp;sig.positional),
+-        kwonly: map_params(&amp;sig.kwonly),
+-        vararg: subst_star(&amp;sig.vararg),
+-        kwarg: subst_star(&amp;sig.kwarg),
+-        ret: subst(&amp;sig.ret),
+-        gradual: sig.gradual,
+-    })
++    None /* ~ changed by cargo-mutants ~ */
+ }
+ 
+ /// Substitute a single-free-parameter alias's parameter with the use-site
+ /// argument (e.g. `Callback[...]` with `Callback = Callable[P, str]`).
+ fn substitute_alias(alias_rhs: &amp;str, args: Option&lt;&amp;[String]&gt;, index: &amp;CallIndex) -&gt; Option&lt;String&gt; {
+     let Some([arg]) = args else {
+         // Bare alias use — keep the RHS as-is.
+         return args.is_none().then(|| alias_rhs.to_owned());
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
       <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs:283:5</td>
       <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Some(Default::default())</code></td>
-      <td class='dur'>51.9s</td>
+      <td class='dur'>71.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-121')">▶ show diff</div>
-        <pre id='diff-121' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs
+        <div class='diff-toggle' onclick="toggle('diff-123')">▶ show diff</div>
+        <pre id='diff-123' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs
 +++ replace specialize_sig -&gt; Option&lt;Sig&gt; with Some(Default::default())
 @@ -275,70 +275,17 @@
  
@@ -4322,34 +4444,16 @@
 </pre></td></tr>
     <tr class='row-caught' onclick="this.classList.toggle('expanded')">
       <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs:307:13</td>
-      <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>MatchArm</span></td>
+      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs:324:17</td>
+      <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>StructField</span></td>
       <td><code class='replacement'></code></td>
-      <td class='dur'>52.6s</td>
+      <td class='dur'>57.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-122')">▶ show diff</div>
-        <pre id='diff-122' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs
-+++ delete match arm Some(&quot;...&quot;) in specialize_sig
-@@ -299,24 +299,17 @@
-     let paramspec_name = sig.vararg.ty().and_then(|ann| {
-         let name = ann.strip_suffix(&quot;.args&quot;)?;
-         index.paramspecs.contains(name).then(|| name.to_owned())
-     });
-     if let Some(ps) = paramspec_name {
-         let specialization = substitutions.get(ps.as_str()).copied();
-         return match specialization {
-             // `Proto[...]` — gradual with the non-ParamSpec params as prefix.
--            Some(&quot;...&quot;) =&gt; Some(Sig {
--                positional: sig.positional.clone(),
--                kwonly: sig.kwonly.clone(),
--                vararg: StarParam::Absent,
--                kwarg: StarParam::Absent,
--                ret: sig.ret.clone(),
--                gradual: true,
--            }),
-+             /* ~ changed by cargo-mutants ~ */
-             // Bare or absent ParamSpec — not evaluable.
+        <div class='diff-toggle' onclick="toggle('diff-124')">▶ show diff</div>
+        <pre id='diff-124' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs
++++ delete field ty from struct super::sig_model::Param expression in specialize_sig
+@@ -316,17 +316,17 @@
              _ =&gt; None,
          };
      }
@@ -4357,90 +4461,17 @@
      let map_params = |params: &amp;[super::sig_model::Param]| {
          params
              .iter()
-</pre></td></tr>
-    <tr class='row-caught' onclick="this.classList.toggle('expanded')">
-      <td><span class='status caught'>CAUGHT</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs:283:5</td>
-      <td><code>specialize_sig</code> -> Option<Sig> <span class='badge genre'>FnValue</span></td>
-      <td><code class='replacement'>None</code></td>
-      <td class='dur'>55.0s</td>
-    </tr>
-    <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-123')">▶ show diff</div>
-        <pre id='diff-123' class='diff hidden'>--- crates/basilisk-checker/src/rules/assignment_compatibility/callable_check.rs
-+++ replace specialize_sig -&gt; Option&lt;Sig&gt; with None
-@@ -275,70 +275,17 @@
- 
- /// Apply substitutions to one signature.  Returns `None` (→ `Unknown`) for
- /// `ParamSpec` signatures that aren't specialized to `...`.
- fn specialize_sig(
-     sig: &amp;Sig,
-     substitutions: &amp;HashMap&lt;&amp;str, &amp;str&gt;,
-     index: &amp;CallIndex,
- ) -&gt; Option&lt;Sig&gt; {
--    let subst_text = |t: &amp;str| -&gt; String {
--        substitutions
--            .iter()
--            .fold(t.to_owned(), |text, (param, arg)| {
--                replace_word(&amp;text, param, arg)
--            })
--    };
--    let subst = |ty: &amp;Option&lt;String&gt;| -&gt; Option&lt;String&gt; { ty.as_deref().map(subst_text) };
--    let subst_star = |star: &amp;StarParam| -&gt; StarParam {
--        match star {
--            StarParam::Typed(ty) =&gt; StarParam::Typed(subst_text(ty)),
--            other =&gt; other.clone(),
--        }
--    };
--
--    // `*args: P.args, **kwargs: P.kwargs` — a ParamSpec signature.
--    let paramspec_name = sig.vararg.ty().and_then(|ann| {
--        let name = ann.strip_suffix(&quot;.args&quot;)?;
--        index.paramspecs.contains(name).then(|| name.to_owned())
--    });
--    if let Some(ps) = paramspec_name {
--        let specialization = substitutions.get(ps.as_str()).copied();
--        return match specialization {
--            // `Proto[...]` — gradual with the non-ParamSpec params as prefix.
--            Some(&quot;...&quot;) =&gt; Some(Sig {
--                positional: sig.positional.clone(),
--                kwonly: sig.kwonly.clone(),
--                vararg: StarParam::Absent,
--                kwarg: StarParam::Absent,
--                ret: sig.ret.clone(),
--                gradual: true,
--            }),
--            // Bare or absent ParamSpec — not evaluable.
--            _ =&gt; None,
--        };
--    }
--
--    let map_params = |params: &amp;[super::sig_model::Param]| {
--        params
--            .iter()
--            .map(|p| super::sig_model::Param {
+             .map(|p| super::sig_model::Param {
 -                ty: subst(&amp;p.ty),
--                ..p.clone()
--            })
--            .collect()
--    };
--    Some(Sig {
--        positional: map_params(&amp;sig.positional),
--        kwonly: map_params(&amp;sig.kwonly),
--        vararg: subst_star(&amp;sig.vararg),
--        kwarg: subst_star(&amp;sig.kwarg),
--        ret: subst(&amp;sig.ret),
--        gradual: sig.gradual,
--    })
-+    None /* ~ changed by cargo-mutants ~ */
- }
- 
- /// Substitute a single-free-parameter alias's parameter with the use-site
- /// argument (e.g. `Callback[...]` with `Callback = Callable[P, str]`).
- fn substitute_alias(alias_rhs: &amp;str, args: Option&lt;&amp;[String]&gt;, index: &amp;CallIndex) -&gt; Option&lt;String&gt; {
-     let Some([arg]) = args else {
-         // Bare alias use — keep the RHS as-is.
-         return args.is_none().then(|| alias_rhs.to_owned());
++                 /* ~ changed by cargo-mutants ~ */
+                 ..p.clone()
+             })
+             .collect()
+     };
+     Some(Sig {
+         positional: map_params(&amp;sig.positional),
+         kwonly: map_params(&amp;sig.kwonly),
+         vararg: subst_star(&amp;sig.vararg),
 </pre></td></tr></tbody>
         </table>
 </div>
@@ -4454,16 +4485,16 @@
           <tbody>
     <tr class='row-unviable' onclick="this.classList.toggle('expanded')">
       <td><span class='status unviable'>UNVIABLE</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:46:5</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/match_exhaustiveness.rs:48:5</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>6.2s</td>
+      <td class='dur'>5.7s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-43')">▶ show diff</div>
-        <pre id='diff-43' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
+        <div class='diff-toggle' onclick="toggle('diff-44')">▶ show diff</div>
+        <pre id='diff-44' class='diff hidden'>--- crates/basilisk-checker/src/rules/match_exhaustiveness.rs
 +++ replace make_diagnostic -&gt; Diagnostic with Default::default()
-@@ -38,21 +38,10 @@
+@@ -40,21 +40,10 @@
              .match_stmts
              .iter()
              .filter(|stmt| !stmt.has_wildcard &amp;&amp; !stmt.has_structural_pattern)
@@ -4489,16 +4520,16 @@
 </pre></td></tr>
     <tr class='row-unviable' onclick="this.classList.toggle('expanded')">
       <td><span class='status unviable'>UNVIABLE</span></td>
-      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:51:5</td>
+      <td class='loc'>crates/basilisk-checker/src/rules/missing_parameter_annotation.rs:56:5</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>10.8s</td>
+      <td class='dur'>7.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-54')">▶ show diff</div>
-        <pre id='diff-54' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
+        <div class='diff-toggle' onclick="toggle('diff-55')">▶ show diff</div>
+        <pre id='diff-55' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_parameter_annotation.rs
 +++ replace make_diagnostic -&gt; Diagnostic with Default::default()
-@@ -43,17 +43,10 @@
+@@ -48,17 +48,10 @@
  fn check_function(func: &amp;FunctionInfo, path: &amp;str, out: &amp;mut Vec&lt;Diagnostic&gt;) {
      func.parameters
          .iter()
@@ -4523,11 +4554,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:22:9</td>
       <td><code><impl Rule for MissingReturnAnnotation>::opt_in_spec</code> -> Option<crate::rule_tags::OptInSpec> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Some(Default::default())</code></td>
-      <td class='dur'>10.4s</td>
+      <td class='dur'>7.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-56')">▶ show diff</div>
-        <pre id='diff-56' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_return_annotation.rs
+        <div class='diff-toggle' onclick="toggle('diff-58')">▶ show diff</div>
+        <pre id='diff-58' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_return_annotation.rs
 +++ replace &lt;impl Rule for MissingReturnAnnotation&gt;::opt_in_spec -&gt; Option&lt;crate::rule_tags::OptInSpec&gt; with Some(Default::default())
 @@ -14,20 +14,17 @@
  
@@ -4557,7 +4588,7 @@
       <td class='loc'>crates/basilisk-checker/src/rules/missing_return_annotation.rs:45:5</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>11.6s</td>
+      <td class='dur'>7.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
         <div class='diff-toggle' onclick="toggle('diff-61')">▶ show diff</div>
@@ -4597,11 +4628,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:26:9</td>
       <td><code><impl Rule for MissingVariableType>::opt_in_spec</code> -> Option<crate::rule_tags::OptInSpec> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Some(Default::default())</code></td>
-      <td class='dur'>8.0s</td>
+      <td class='dur'>5.8s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-62')">▶ show diff</div>
-        <pre id='diff-62' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
+        <div class='diff-toggle' onclick="toggle('diff-64')">▶ show diff</div>
+        <pre id='diff-64' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
 +++ replace &lt;impl Rule for MissingVariableType&gt;::opt_in_spec -&gt; Option&lt;crate::rule_tags::OptInSpec&gt; with Some(Default::default())
 @@ -18,20 +18,17 @@
      docs_url: &quot;https://www.basilisk-python.dev/errors/BSK-E0003&quot;,
@@ -4631,11 +4662,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/missing_variable_type.rs:56:5</td>
       <td><code>make_diagnostic</code> -> Diagnostic <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>7.0s</td>
+      <td class='dur'>6.4s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-67')">▶ show diff</div>
-        <pre id='diff-67' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
+        <div class='diff-toggle' onclick="toggle('diff-69')">▶ show diff</div>
+        <pre id='diff-69' class='diff hidden'>--- crates/basilisk-checker/src/rules/missing_variable_type.rs
 +++ replace make_diagnostic -&gt; Diagnostic with Default::default()
 @@ -48,50 +48,10 @@
  fn is_unresolvable(rhs: &amp;RhsKind) -&gt; bool {
@@ -4695,11 +4726,11 @@
       <td class='loc'>crates/basilisk-checker/src/rules/typeddicts_inheritance.rs:66:5</td>
       <td><code>parse_field_qualifiers</code> -> FieldQualifiers<'_> <span class='badge genre'>FnValue</span></td>
       <td><code class='replacement'>Default::default()</code></td>
-      <td class='dur'>13.7s</td>
+      <td class='dur'>15.0s</td>
     </tr>
     <tr class='diff-row'><td colspan='5'>
-        <div class='diff-toggle' onclick="toggle('diff-76')">▶ show diff</div>
-        <pre id='diff-76' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
+        <div class='diff-toggle' onclick="toggle('diff-77')">▶ show diff</div>
+        <pre id='diff-77' class='diff hidden'>--- crates/basilisk-checker/src/rules/typeddicts_inheritance.rs
 +++ replace parse_field_qualifiers -&gt; FieldQualifiers&lt;'_&gt; with Default::default()
 @@ -58,31 +58,17 @@
      required: bool,

--- a/mutation_testing/mutation_scores.json
+++ b/mutation_testing/mutation_scores.json
@@ -2,7 +2,7 @@
   "scores": {
     "working": {
       "caught": 118,
-      "date": "2026-07-03",
+      "date": "2026-07-09",
       "kill_rate": 100.0,
       "missed": 0,
       "timeout": 0,


### PR DESCRIPTION
## TLDR
Fixes the LSP stack-overflow restart loop on self-named external bases (#278) and makes external-member hover actually work — pydantic's `model_validate` now hovers on real packages (#287).

## What Was Added?
- `chase_py_typed_reexport` / `sibling_module_file` in `crates/basilisk-checker/src/exports.rs`: when a `from pkg import Name` lookup misses in a py.typed package's resolved file, the population pass now follows the `__init__`'s module-level named **and star** re-export imports (including inside `if TYPE_CHECKING:` blocks) into sibling module files and takes the symbol — with its methods — from there. Cycle-guarded via a visited set; runs only on a miss, only for py.typed sources.
- Regression tests:
  - `self_named_external_base_constructor_call_does_not_overflow` (checker) — the `class Client(httpx.Client)` + `Client()` shape that SIGABRT'd the process.
  - `test_hover_on_method_reexported_through_py_typed_package_init` (hover) — an on-disk pydantic-v2-shaped package: `__init__.py` containing only `if TYPE_CHECKING: from .main import *`, `main.py` defining the class with a `@classmethod`.
  - `default_mode_analysis_populates_external_imported_symbols` (salsa engine) — default-mode analysis must carry external `imported_symbols`.
- `benchmarks/status/darwin-arm64-apple-m4.csv` — first bench baseline for this machine, per the trend policy.

## What Was Changed or Deleted?
- **`constructors_call_init` cycle guards (#278):** `find_init_in_hierarchy`, `has_custom_init_in_bases`, and `is_subclass` walked base-class chains with no cycle guard. A class named after its unresolved external base (`class Client(httpx.Client)`) resolves by simple name back to itself in the class map, so constructing it recursed to a stack overflow — SIGABRT, LSP restart loop, unusable editor. All three walks now thread `visited` sets, the same pattern as the twelve walks guarded in #298. Behaviour is unchanged except termination.
- **Salsa engine wiring (#287):** `SalsaAnalysisEngine::analyse` populated `imported_symbols` only in `crossModule` analysis mode — which is documented "reserved for future use" and never the default, so the external-member hover shipped in #298 was dead in every real editor session (its unit test injected the symbols by hand). The resolved view handed to hover/completion/navigation now always comes from the memoized `cross_resolved_module` query; **diagnostics remain mode-gated exactly as before**, so non-cross modes keep byte-for-byte CLI parity on what they report. Doc comments updated to match.
- Mutation baseline re-dated by the fresh run (identical 100% score, same 125-mutant pool).

## How Do The Automated Tests Prove It Works?
- `self_named_external_base_constructor_call_does_not_overflow` aborted the test process with `stack overflow / SIGABRT` before the fix and now passes, pinning both termination and the no-false-positive behaviour (`constructors_call_init` must not fire).
- `test_hover_on_method_reexported_through_py_typed_package_init` failed at `imported_symbols.contains_key("BaseModel")` before the extraction fix (and again when the fixture switched to the real star-import shape before the star chase existed); it now asserts hover renders `BaseModel.model_validate` from the re-exported class.
- `default_mode_analysis_populates_external_imported_symbols` failed with empty `imported_symbols` before the engine change; it now proves default-mode analysis populates them while the diagnostics path is untouched.
- Verified end-to-end over raw LSP against real pydantic 2.13.4: hover on `model_validate` returns `(method) def BaseModel.model_validate(cls, obj: Any, …) -> Self`; `basilisk check` on the crashing repro file went from exit 134 (SIGABRT) to a clean run.
- Full local CI pass: lint (fmt/clippy/eslint/deslop), workspace tests + coverage thresholds (all 10 crates), conformance **141/141 = 100%** against freshly fetched `python/typing@main` fixtures, VS Code E2E (510 passing against the staged release VSIX), Neovim (43% ≥ 42%), Zed (97 tests), Shipwright version contracts, mutation testing (125 mutants, 118 caught, 0 missed, 100% kill rate, baseline unchanged), `make bench` PASS, release build.

## Spec / Doc Changes
None — code-level doc comments only (`salsa_engine.rs` module/method docs now describe the always-cross resolved view; the new exports helpers document the re-export chase).

## Breaking Changes
- [x] None
