### PR TITLE
Reactive server-side configuration, basilisk format CLI, and release-notes provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,12 +161,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # shipwright.json and the notes generator live in the repo; check out
+      # BEFORE downloading artifacts so checkout's clean cannot remove them.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Download platform archives
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: basilisk-*
           merge-multiple: true
+
+      # Release notes cannot drift from what actually shipped: the component
+      # block is generated from shipwright.json and the release binary itself
+      # ([LSPFMT-RELEASE-NOTES]), then appended to the auto-generated notes.
+      # Drift-tested against the built binary in
+      # crates/basilisk-cli/tests/e2e_release_notes_block.rs.
+      - name: Generate release-notes component block
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -xzf artifacts/basilisk-*-linux-x64.tar.gz basilisk
+          chmod +x basilisk
+          python3 scripts/gen_release_notes.py ./basilisk "$GITHUB_REF_NAME" > release-notes-block.md
 
       # Create the release up front and attach the platform archives to it.
       # Every downstream job (VSIX, Homebrew, Scoop) pulls its binaries from
@@ -176,6 +193,10 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           generate_release_notes: true
+          # The generated component block ([LSPFMT-RELEASE-NOTES]) is appended
+          # to the auto-generated notes rather than replacing them.
+          body_path: release-notes-block.md
+          append_body: true
           # Publish immediately — never leave the release as a draft. The action
           # defaults to draft=false, but it only WRITES the fields you give it:
           # on a re-run over a tag whose release already exists as a draft (a

--- a/basilisk.nvim/doc/basilisk.txt
+++ b/basilisk.nvim/doc/basilisk.txt
@@ -160,6 +160,15 @@ All options with defaults: >lua
   })
 <
 
+Formatting                                              *basilisk-formatting*
+
+Format the current buffer with the embedded Ruff formatter (no `ruff`
+install needed): >lua
+  vim.lsp.buf.format({ name = "basilisk" })
+<
+Style options come from `[tool.ruff]` / `[tool.ruff.format]` in the
+project's pyproject.toml. Set `formatter = "none"` in setup() to disable.
+
 ==============================================================================
 5. COMMANDS                                                 *basilisk-commands*
 

--- a/basilisk.nvim/tests/lsp/client_modules_spec.lua
+++ b/basilisk.nvim/tests/lsp/client_modules_spec.lua
@@ -1,0 +1,122 @@
+--- Client-local module tests, run inside the LSP e2e gate so their lines
+--- count toward the enforced Lua coverage threshold (scripts/test-nvim.sh).
+---
+--- Tests [NVIM-NEOVIM-ONLY-CONFIGURATION] (config validation/resolution),
+--- [ANALYSIS-OPEN] (tab tracking setup for openFilesOnly), and the Code Lens
+--- row of [NVIM-LSP-CLIENT-CONFIGURATION-API-MAPPINGS] (version-gated
+--- activation). No server needed: everything here is client-side behaviour,
+--- so no binary guard — these run on every matrix leg.
+
+local codelens = require("basilisk.codelens")
+local config = require("basilisk.config")
+local tab_tracking = require("basilisk.tab_tracking")
+
+local function messages_of(errors)
+  return table.concat(errors, "\n")
+end
+
+describe("config.validate [NVIM-NEOVIM-ONLY-CONFIGURATION]", function()
+  it("accepts the shipped defaults", function()
+    assert.same({}, config.validate(config.defaults))
+  end)
+
+  it("names every invalid enum value", function()
+    local bad = vim.tbl_deep_extend("force", {}, config.defaults, {
+      analysis_mode = "everything",
+      test_explorer = { framework = "nose", position = "top" },
+      log_level = "loud",
+    })
+    local errors = config.validate(bad)
+    assert.equals(4, #errors)
+    local all = messages_of(errors)
+    assert.truthy(all:find("invalid analysis_mode: everything", 1, true))
+    assert.truthy(all:find("invalid test_explorer.framework: nose", 1, true))
+    assert.truthy(all:find("invalid test_explorer.position: top", 1, true))
+    assert.truthy(all:find("invalid log_level: loud", 1, true))
+  end)
+end)
+
+describe("config.resolve [NVIM-NEOVIM-ONLY-CONFIGURATION]", function()
+  it("returns the defaults when called with no opts", function()
+    assert.same(config.defaults, config.resolve())
+  end)
+
+  it("deep-merges user opts over the defaults", function()
+    local resolved = config.resolve({
+      analysis_mode = "openFilesOnly",
+      keymaps = { prefix = "<leader>x" },
+    })
+    assert.equals("openFilesOnly", resolved.analysis_mode)
+    assert.equals("<leader>x", resolved.keymaps.prefix)
+    -- Sibling keys of a partially-overridden table keep their defaults.
+    assert.is_true(resolved.keymaps.enabled)
+    assert.equals("ruff", resolved.formatter)
+  end)
+
+  it("logs but does not reject an invalid value", function()
+    -- Validation errors are reported through the log ([NVIM-HEALTH-CHECK]
+    -- surfaces them); resolve still returns the merged config unchanged.
+    local resolved = config.resolve({ log_level = "shout" })
+    assert.equals("shout", resolved.log_level)
+  end)
+end)
+
+describe("tab_tracking.setup [ANALYSIS-OPEN]", function()
+  local function tracking_autocmds()
+    local ok, autocmds = pcall(vim.api.nvim_get_autocmds, { group = "BasiliskTabTracking" })
+    if not ok then
+      return nil
+    end
+    return autocmds
+  end
+
+  it("is inert outside openFilesOnly mode", function()
+    tab_tracking.setup(config.resolve({ analysis_mode = "wholeModule" }))
+    assert.is_nil(tracking_autocmds())
+  end)
+
+  it("registers hidden-buffer tracking in openFilesOnly mode", function()
+    -- A visible python buffer seeds the known-open set via the same
+    -- collect path the autocmd uses.
+    vim.cmd.edit("tracked_visible.py")
+    vim.bo.filetype = "python"
+
+    tab_tracking.setup(config.resolve({ analysis_mode = "openFilesOnly" }))
+
+    local autocmds = tracking_autocmds()
+    assert.is_table(autocmds)
+    local events = {}
+    for _, autocmd in ipairs(autocmds or {}) do
+      events[autocmd.event] = true
+      assert.equals("*.py", autocmd.pattern)
+    end
+    assert.is_true(events.BufHidden)
+    assert.is_true(events.WinClosed)
+    assert.is_true(events.BufDelete)
+
+    vim.api.nvim_del_augroup_by_name("BasiliskTabTracking")
+    vim.cmd.bwipeout({ bang = true })
+  end)
+end)
+
+describe("codelens.activate [NVIM-LSP-CLIENT-CONFIGURATION-API-MAPPINGS]", function()
+  it("activates through the API the runtime exposes", function()
+    local buf = vim.api.nvim_create_buf(false, true)
+    codelens.activate(buf)
+    if vim.lsp.codelens.enable then
+      -- 0.12+ path: enable() owns refresh; report its own view when the
+      -- runtime can be asked.
+      if vim.lsp.codelens.is_enabled then
+        assert.is_true(vim.lsp.codelens.is_enabled({ bufnr = buf }))
+      end
+    else
+      -- 0.10/0.11 fallback: a manual refresh loop is installed.
+      local autocmds = vim.api.nvim_get_autocmds({
+        event = { "BufEnter", "InsertLeave" },
+        buffer = buf,
+      })
+      assert.is_true(#autocmds >= 2)
+    end
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end)
+end)

--- a/coverage-thresholds.json
+++ b/coverage-thresholds.json
@@ -13,7 +13,7 @@
       "threshold": 100
     },
     "basilisk-lsp": {
-      "threshold": 83
+      "threshold": 84
     },
     "basilisk-mojo": {
       "threshold": 90
@@ -31,7 +31,7 @@
       "threshold": 92
     },
     "basilisk-config": {
-      "threshold": 96
+      "threshold": 97
     },
     "vsix": {
       "threshold": 92

--- a/crates/basilisk-cli/src/format.rs
+++ b/crates/basilisk-cli/src/format.rs
@@ -1,0 +1,140 @@
+//! Implements [LSPFMT-CLIENTS] and [CHKARCH-CLI-COMMANDS]. See
+//! docs/specs/LSP-FORMATTING-SPEC.md#LSPFMT-CLIENTS
+//! `basilisk format` subcommand — format Python files in place, or verify
+//! them with `--check`, using the embedded Ruff formatter.
+//!
+//! Same engine, same style source as LSP `textDocument/formatting`
+//! ([LSPFMT-ENGINE]): for identical input and configuration the output bytes
+//! are identical. No `ruff` executable is ever spawned ([LSPFMT-DECISION]).
+
+use basilisk_lsp::config::{FormatStyle, FormatterEngine};
+use basilisk_lsp::formatting::{format_document, EMBEDDED_RUFF_FORMATTER_VERSION};
+use tracing::warn;
+
+use crate::pipeline::pluralise;
+
+/// Run the format subcommand.
+///
+/// Exit codes:
+/// - `0` — write mode completed, or check mode found every file formatted
+/// - `1` — check mode found unformatted files, or a file failed to parse
+/// - `3` — internal error (path collection, config discovery)
+pub(crate) fn run_format(paths: &[String], check: bool) -> u8 {
+    let config_root = crate::pipeline::first_path_dir(paths);
+    let workspace = basilisk_lsp::config::load_config(&config_root);
+    if workspace.formatter == FormatterEngine::Disabled {
+        // [LSPFMT-CONFIG]: `"none"` disables formatting; mirror the LSP,
+        // which stops advertising the formatting capabilities.
+        println!("Formatter is disabled (formatter = \"none\"); nothing to do.");
+        return 0;
+    }
+    match collect_and_format(paths, &workspace.format_style, check) {
+        Ok(summary) => summarise(&summary, check),
+        Err(err) => {
+            tracing::error!(%err, "internal error");
+            3
+        }
+    }
+}
+
+/// Outcome of formatting one file.
+enum FileOutcome {
+    /// The file was rewritten (write mode) or would be (check mode).
+    Changed,
+    /// The file is already formatted.
+    Clean,
+}
+
+/// Result of a whole format run.
+#[derive(Default)]
+struct FormatSummary {
+    /// Files rewritten (write mode) or needing a rewrite (check mode).
+    changed: usize,
+    /// Files already formatted.
+    unchanged: usize,
+    /// Files that could not be read or parsed.
+    failures: usize,
+}
+
+/// Collect Python files under `paths` and format each one.
+///
+/// Path collection honours the same `[tool.basilisk]` `exclude` semantics as
+/// `check` and `fix` ([CHKARCH-CONFIG-EXCLUDE]).
+fn collect_and_format(
+    paths: &[String],
+    style: &FormatStyle,
+    check: bool,
+) -> Result<FormatSummary, String> {
+    let config_root = crate::pipeline::first_path_dir(paths);
+    let config = basilisk_config::load_basilisk_config(&config_root);
+    let excluded = crate::pipeline::excluded_dirs_and_log(&config, &config_root);
+    let python_files = crate::pipeline::collect_python_files(paths, &excluded)?;
+
+    let mut summary = FormatSummary::default();
+    for path in python_files {
+        match format_single_file(&path, style, check) {
+            Ok(FileOutcome::Changed) => summary.changed += 1,
+            Ok(FileOutcome::Clean) => summary.unchanged += 1,
+            Err(err) => {
+                warn!(path, %err, "cannot format file");
+                summary.failures += 1;
+            }
+        }
+    }
+    Ok(summary)
+}
+
+/// Format one file: rewrite it in write mode, report it in check mode.
+fn format_single_file(path: &str, style: &FormatStyle, check: bool) -> Result<FileOutcome, String> {
+    let source = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let Some(formatted) = formatted_text(&source, style) else {
+        // `format_document` returns `None` for already-formatted AND for
+        // unparseable sources; parse to tell them apart. Like `ruff format`,
+        // invalid syntax is refused, never rewritten.
+        return match basilisk_parser::parse_source(source, path.to_owned()) {
+            Ok(_) => Ok(FileOutcome::Clean),
+            Err(err) => Err(err.to_string()),
+        };
+    };
+    if check {
+        println!("Would reformat: {path}");
+        return Ok(FileOutcome::Changed);
+    }
+    std::fs::write(path, formatted).map_err(|e| e.to_string())?;
+    Ok(FileOutcome::Changed)
+}
+
+/// The full formatted text, or `None` when the source is already formatted
+/// or does not parse ([LSPFMT-ENGINE] pure passthrough).
+fn formatted_text(source: &str, style: &FormatStyle) -> Option<String> {
+    format_document(source, style)?
+        .into_iter()
+        .next()
+        .map(|edit| edit.new_text)
+}
+
+/// Print the run summary and derive the exit code.
+///
+/// The summary names the engine and version — the CLI face of the
+/// provenance contract ([LSPFMT-PROVENANCE]).
+fn summarise(summary: &FormatSummary, check: bool) -> u8 {
+    let changed = summary.changed;
+    let verb = if check {
+        format!("{changed} file{} would be reformatted", pluralise(changed))
+    } else {
+        format!("Reformatted {changed} file{}", pluralise(changed))
+    };
+    println!(
+        "{verb}, {} already formatted (embedded Ruff {EMBEDDED_RUFF_FORMATTER_VERSION}).",
+        summary.unchanged
+    );
+    if summary.failures > 0 {
+        println!(
+            "{} file{} failed to parse and {} left unchanged.",
+            summary.failures,
+            pluralise(summary.failures),
+            if summary.failures == 1 { "was" } else { "were" }
+        );
+    }
+    u8::from(summary.failures > 0 || (check && changed > 0))
+}

--- a/crates/basilisk-cli/src/main.rs
+++ b/crates/basilisk-cli/src/main.rs
@@ -6,6 +6,7 @@
 //! basilisk check [paths...]
 //! basilisk check [paths...] --output json
 //! basilisk analyze [paths...]
+//! basilisk format [paths...] [--check]
 //! ```
 
 use std::process::ExitCode;
@@ -22,6 +23,7 @@ use crate::pipeline::{collect_and_check, pluralise, DiagnosticScope, PipelineErr
 mod adopt;
 mod cache_check;
 mod fix;
+mod format;
 mod import_search;
 mod output;
 mod pipeline;
@@ -78,7 +80,7 @@ struct CheckArgs {
 }
 
 // Implements [CHKARCH-CLI-COMMANDS]: the `check`/`analyze` core commands
-// ([CHKARCH-COMMANDS]) plus `fix`/`adopt`/`unadopt`/`lsp`/`stubs`.
+// ([CHKARCH-COMMANDS]) plus `format`/`fix`/`adopt`/`unadopt`/`lsp`/`stubs`.
 // See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CLI-COMMANDS
 #[derive(Subcommand)]
 enum Command {
@@ -93,6 +95,16 @@ enum Command {
     Analyze {
         #[command(flatten)]
         args: CheckArgs,
+    },
+    /// Format Python files with the embedded Ruff formatter — the same
+    /// engine and style configuration as LSP formatting ([LSPFMT-CLIENTS]).
+    Format {
+        /// Paths to format. Directories are traversed recursively for `.py` files.
+        #[arg(default_value = ".")]
+        paths: Vec<String>,
+        /// Report files that would change without rewriting them.
+        #[arg(long)]
+        check: bool,
     },
     /// Apply autofixes to one or more files or directories.
     Fix {
@@ -247,6 +259,7 @@ fn run_command(command: Command) -> u8 {
         // [CHKARCH-COMMANDS]: identical pipeline, different edge filter.
         Command::Check { args } => run_scoped_check(&args, DiagnosticScope::Check),
         Command::Analyze { args } => run_scoped_check(&args, DiagnosticScope::Analyze),
+        Command::Format { paths, check } => format::run_format(&paths, check),
         Command::Fix {
             paths,
             r#unsafe: include_unsafe,

--- a/crates/basilisk-cli/tests/e2e_format.rs
+++ b/crates/basilisk-cli/tests/e2e_format.rs
@@ -1,0 +1,259 @@
+//! Tests for [LSPFMT-CLIENTS] / [CHKARCH-CLI-COMMANDS]. See
+//! docs/specs/LSP-FORMATTING-SPEC.md#LSPFMT-CLIENTS
+#![allow(
+    clippy::allow_attributes,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+//! Real-binary tests for `basilisk format`: write and `--check` behaviour,
+//! multiple paths, parse failures, `[tool.ruff]` style configuration,
+//! formatter disablement, and byte-parity with the LSP formatting path.
+//!
+//! Every test spawns the compiled binary with `PATH` pointing at an empty
+//! directory, so no external `ruff` (or anything else) is findable — the
+//! embedded engine must do all the work ([LSPFMT-DECISION]).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static DIR_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// A unique, empty project directory for one test.
+fn project_dir(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "basilisk_fmt_{tag}_{}_{}",
+        std::process::id(),
+        DIR_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir).expect("create project dir");
+    dir
+}
+
+fn write(dir: &Path, rel: &str, content: &str) -> PathBuf {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    std::fs::write(&path, content).expect("write fixture");
+    path
+}
+
+fn read(path: &Path) -> String {
+    std::fs::read_to_string(path).expect("read fixture back")
+}
+
+/// Run `basilisk format <args>` inside `dir` with an empty `PATH`.
+fn run_format(dir: &Path, args: &[&str]) -> Output {
+    let empty_path = dir.join(".empty-path");
+    std::fs::create_dir_all(&empty_path).expect("create empty PATH dir");
+    Command::new(env!("CARGO_BIN_EXE_basilisk"))
+        .current_dir(dir)
+        .env("PATH", &empty_path)
+        .arg("format")
+        .args(args)
+        .output()
+        .expect("spawn basilisk format")
+}
+
+fn stdout_of(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn exit_code(output: &Output) -> i32 {
+    output.status.code().expect("exit code")
+}
+
+// ── Write mode ───────────────────────────────────────────────────────────────
+
+/// Write mode rewrites the file to exactly the embedded Ruff output. The
+/// input is the same source the LSP no-ruff test formats, so the expected
+/// bytes pin CLI/LSP parity ([LSPFMT-CLIENTS] acceptance).
+#[test]
+fn write_mode_produces_ruff_output_with_no_ruff_on_path() {
+    let dir = project_dir("write");
+    let file = write(&dir, "app.py", "x=1\ny  =   'two'\n");
+
+    let output = run_format(&dir, &["."]);
+
+    assert_eq!(exit_code(&output), 0, "write mode must exit 0: {output:?}");
+    assert_eq!(
+        read(&file),
+        "x = 1\ny = \"two\"\n",
+        "output must be byte-identical to the embedded Ruff formatter"
+    );
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("Reformatted 1 file"),
+        "summary must count the rewrite: {stdout}"
+    );
+    // [LSPFMT-PROVENANCE]: the CLI names the engine that produced the bytes.
+    assert!(
+        stdout.contains("embedded Ruff"),
+        "summary must attribute the embedded engine: {stdout}"
+    );
+}
+
+/// An already-formatted file is left byte-identical and reported unchanged.
+#[test]
+fn write_mode_leaves_formatted_file_untouched() {
+    let dir = project_dir("clean");
+    let file = write(&dir, "app.py", "x = 1\n");
+
+    let output = run_format(&dir, &["."]);
+
+    assert_eq!(exit_code(&output), 0);
+    assert_eq!(read(&file), "x = 1\n", "clean file must not be rewritten");
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("Reformatted 0 files") && stdout.contains("1 already formatted"),
+        "summary must report the file as already formatted: {stdout}"
+    );
+}
+
+// ── Check mode ───────────────────────────────────────────────────────────────
+
+/// `--check` reports the file and exits 1 without writing anything.
+#[test]
+fn check_mode_reports_without_writing() {
+    let dir = project_dir("check");
+    let file = write(&dir, "app.py", "x=1\n");
+
+    let output = run_format(&dir, &["--check", "."]);
+
+    assert_eq!(exit_code(&output), 1, "--check must exit 1 on a diff");
+    assert_eq!(read(&file), "x=1\n", "--check must never write");
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("Would reformat") && stdout.contains("app.py"),
+        "--check must name the unformatted file: {stdout}"
+    );
+}
+
+/// `--check` on a formatted tree exits 0.
+#[test]
+fn check_mode_clean_tree_exits_zero() {
+    let dir = project_dir("check_clean");
+    let _ = write(&dir, "app.py", "x = 1\n");
+
+    let output = run_format(&dir, &["--check", "."]);
+
+    assert_eq!(exit_code(&output), 0, "clean --check must exit 0");
+    let stdout = stdout_of(&output);
+    assert!(
+        stdout.contains("0 files would be reformatted"),
+        "clean --check summary: {stdout}"
+    );
+}
+
+// ── Multiple paths ───────────────────────────────────────────────────────────
+
+/// A directory argument recurses and an explicit file argument is taken
+/// verbatim; both format in one run.
+#[test]
+fn multiple_paths_mix_directories_and_files() {
+    let dir = project_dir("multi");
+    let one = write(&dir, "pkg/one.py", "a=1\n");
+    let two = write(&dir, "two.py", "b =  2\n");
+
+    let output = run_format(&dir, &["pkg", "two.py"]);
+
+    assert_eq!(exit_code(&output), 0);
+    assert_eq!(read(&one), "a = 1\n");
+    assert_eq!(read(&two), "b = 2\n");
+    assert!(
+        stdout_of(&output).contains("Reformatted 2 files"),
+        "both paths must be formatted: {}",
+        stdout_of(&output)
+    );
+}
+
+// ── Parse failures ───────────────────────────────────────────────────────────
+
+/// Invalid syntax is refused (never rewritten), the rest of the run still
+/// formats, and the exit code is 1.
+#[test]
+fn parse_failure_exits_one_and_never_rewrites_the_broken_file() {
+    let dir = project_dir("parse_fail");
+    let broken = write(&dir, "broken.py", "def f(:\n");
+    let good = write(&dir, "good.py", "x=1\n");
+
+    let output = run_format(&dir, &["."]);
+
+    assert_eq!(exit_code(&output), 1, "parse failure must exit 1");
+    assert_eq!(read(&broken), "def f(:\n", "broken file must be untouched");
+    assert_eq!(read(&good), "x = 1\n", "healthy files must still format");
+    assert!(
+        stdout_of(&output).contains("failed to parse"),
+        "summary must surface the parse failure: {}",
+        stdout_of(&output)
+    );
+}
+
+// ── Style configuration ──────────────────────────────────────────────────────
+
+/// `[tool.ruff]` / `[tool.ruff.format]` style options are honoured, exactly
+/// as the LSP path reads them ([LSPFMT-ENGINE] config-respecting).
+#[test]
+fn style_options_from_pyproject_are_honoured() {
+    let dir = project_dir("style");
+    let _ = write(
+        &dir,
+        "pyproject.toml",
+        "[tool.ruff]\nline-length = 100\n\n[tool.ruff.format]\nquote-style = \"single\"\n",
+    );
+    let file = write(&dir, "app.py", "x=\"s\"\n");
+
+    let output = run_format(&dir, &["."]);
+
+    assert_eq!(exit_code(&output), 0);
+    assert_eq!(
+        read(&file),
+        "x = 's'\n",
+        "quote-style = single must produce single quotes"
+    );
+}
+
+// ── Formatter disablement ────────────────────────────────────────────────────
+
+/// `formatter = "none"` disables the CLI exactly as it stops the LSP
+/// advertising formatting capabilities ([LSPFMT-CONFIG]).
+#[test]
+fn disabled_formatter_is_a_no_op() {
+    let dir = project_dir("disabled");
+    let _ = write(&dir, "pyrightconfig.json", "{\"formatter\": \"none\"}");
+    let file = write(&dir, "app.py", "x=1\n");
+
+    let output = run_format(&dir, &["."]);
+
+    assert_eq!(exit_code(&output), 0, "disabled formatter must exit 0");
+    assert_eq!(read(&file), "x=1\n", "disabled formatter must not write");
+    assert!(
+        stdout_of(&output).contains("disabled"),
+        "the no-op must be explicit, never silent: {}",
+        stdout_of(&output)
+    );
+}
+
+// ── Exclude semantics ────────────────────────────────────────────────────────
+
+/// `[tool.basilisk] exclude` is honoured by the same shared matcher as
+/// `check` and `fix` ([CHKARCH-CONFIG-EXCLUDE]).
+#[test]
+fn excluded_directories_are_skipped() {
+    let dir = project_dir("exclude");
+    let _ = write(
+        &dir,
+        "pyproject.toml",
+        "[tool.basilisk]\nexclude = [\"vendor\"]\n",
+    );
+    let vendored = write(&dir, "vendor/gen.py", "x=1\n");
+    let app = write(&dir, "app.py", "y=2\n");
+
+    let output = run_format(&dir, &["."]);
+
+    assert_eq!(exit_code(&output), 0);
+    assert_eq!(read(&vendored), "x=1\n", "excluded file must be untouched");
+    assert_eq!(read(&app), "y = 2\n", "included file must format");
+}

--- a/crates/basilisk-cli/tests/e2e_release_notes_block.rs
+++ b/crates/basilisk-cli/tests/e2e_release_notes_block.rs
@@ -1,0 +1,87 @@
+//! Tests for [LSPFMT-RELEASE-NOTES]. See
+//! docs/specs/LSP-FORMATTING-SPEC.md#LSPFMT-RELEASE-NOTES
+#![allow(
+    clippy::allow_attributes,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+//! Drift test for the generated release-notes component block
+//! (`scripts/gen_release_notes.py`): the block is generated from
+//! `shipwright.json` and the real binary, so the notes can never claim
+//! different formatter bytes from the build. This test runs the generator
+//! against the freshly compiled binary and proves the block enumerates every
+//! manifest component and reports exactly the binary's embedded Ruff version.
+
+use std::path::Path;
+use std::process::Command;
+
+/// The `Ruff formatter: X` line straight from the binary — the ground truth
+/// the generated block must match.
+fn formatter_version_from_binary() -> String {
+    let out = Command::new(env!("CARGO_BIN_EXE_basilisk"))
+        .arg("--version")
+        .output()
+        .expect("run basilisk --version");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("Ruff formatter: "))
+        .unwrap_or_else(|| panic!("--version must report the embedded formatter: {stdout}"))
+        .to_owned()
+}
+
+#[test]
+fn generated_block_matches_the_binary_and_the_manifest() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root");
+
+    let out = Command::new("python3")
+        .arg(repo_root.join("scripts/gen_release_notes.py"))
+        .arg(env!("CARGO_BIN_EXE_basilisk"))
+        .arg("v9.9.9-test")
+        .arg(repo_root.join("shipwright.json"))
+        .output()
+        .expect("run gen_release_notes.py (python3 required, as for conformance)");
+    assert!(
+        out.status.success(),
+        "generator must succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let block = String::from_utf8_lossy(&out.stdout).into_owned();
+
+    // Every shipwright.json component is enumerated; versioned components
+    // carry the release version passed in.
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(repo_root.join("shipwright.json")).expect("read manifest"),
+    )
+    .expect("parse manifest");
+    let components = manifest["components"].as_array().expect("components");
+    assert!(!components.is_empty(), "manifest must declare components");
+    for component in components {
+        let id = component["id"].as_str().expect("component id");
+        assert!(
+            block.contains(&format!("| `{id}` |")),
+            "block must enumerate component `{id}`:\n{block}"
+        );
+        if component["expectedVersion"].as_str() == Some("${PRODUCT_VERSION}") {
+            assert!(
+                block
+                    .lines()
+                    .any(|l| l.contains(&format!("| `{id}` |")) && l.contains("v9.9.9-test")),
+                "component `{id}` must carry the release version:\n{block}"
+            );
+        }
+    }
+
+    // The formatter line is the binary's own, byte for byte — the whole
+    // point of generating the block ([LSPFMT-RELEASE-NOTES]).
+    let expected = formatter_version_from_binary();
+    assert!(
+        block.contains(&format!("Embedded Ruff formatter: `{expected}`")),
+        "block must report the binary's embedded Ruff version {expected}:\n{block}"
+    );
+}

--- a/crates/basilisk-config/src/lib.rs
+++ b/crates/basilisk-config/src/lib.rs
@@ -93,6 +93,33 @@ pub fn load_basilisk_config(start: &Path) -> BasiliskConfig {
     config
 }
 
+/// Load the discovered-config chain for `start` bounded to directories
+/// strictly below `stop` (exclusive): nested child configs only, never
+/// `stop`'s own config file.
+///
+/// Implements [LSPARCH-CONFIG] via [CHKARCH-CONFIG-DISCOVERY]: a live server
+/// holds the authoritative effective config for each workspace root in memory
+/// — an applied configuration-editor change or an open, unsaved config buffer
+/// is authoritative over whatever is currently on disk — so the root's file
+/// must NOT be re-read here and merged back over it. Callers merge this
+/// result over that in-memory root config. With no nested config on the
+/// chain, the result is `BasiliskConfig::default()` with no `project_root`,
+/// so the merge keeps the root config's own anchoring.
+#[must_use]
+pub fn load_basilisk_config_below(start: &Path, stop: &Path) -> BasiliskConfig {
+    let chain: Vec<BasiliskConfig> = absolute_start(start)
+        .ancestors()
+        .take_while(|dir| *dir != stop)
+        .filter_map(load_dir_config)
+        .collect();
+    // `ancestors()` yields nearest-first; fold from the outermost ancestor so
+    // configs nearer to `start` end up in front of the rule chain.
+    chain
+        .into_iter()
+        .rev()
+        .fold(BasiliskConfig::default(), BasiliskConfig::merged_with)
+}
+
 /// The nearest directory at or above `start` holding a recognized config file
 /// (`pyproject.toml` with a `[tool.basilisk]` table).
 ///

--- a/crates/basilisk-lsp/src/configuration_editor/mod.rs
+++ b/crates/basilisk-lsp/src/configuration_editor/mod.rs
@@ -9,8 +9,13 @@ mod protocol;
 mod snapshot;
 mod state;
 mod transaction;
+mod watch;
 
 pub(crate) use state::ConfigurationEditorState;
 pub(crate) use transaction::{
     apply_rule_updates, configuration_document, refresh_after_configuration_change,
+    ConfigurationRefreshHandles,
+};
+pub(crate) use watch::{
+    refresh_environment_from_disk, refresh_root_from_disk, spawn_configuration_watcher,
 };

--- a/crates/basilisk-lsp/src/configuration_editor/state.rs
+++ b/crates/basilisk-lsp/src/configuration_editor/state.rs
@@ -56,6 +56,10 @@ pub(crate) struct ConfigurationEditorState {
     applied: Mutex<HashMap<PathBuf, AppliedDocument>>,
     open: Mutex<HashMap<PathBuf, OpenDocument>>,
     pending_open_edits: Mutex<HashMap<PathBuf, PendingOpenEdit>>,
+    // Implements [LSPARCH-CONFIG]: the last on-disk configuration
+    // content observed per root, shared by the server-owned watcher and the
+    // client `didChangeWatchedFiles` path so one disk change refreshes once.
+    disk_contents: Mutex<HashMap<PathBuf, String>>,
 }
 
 impl Default for ConfigurationEditorState {
@@ -66,6 +70,7 @@ impl Default for ConfigurationEditorState {
             applied: Mutex::new(HashMap::new()),
             open: Mutex::new(HashMap::new()),
             pending_open_edits: Mutex::new(HashMap::new()),
+            disk_contents: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -262,6 +267,30 @@ impl ConfigurationEditorState {
                 document,
             },
         );
+    }
+
+    /// Seed the observed on-disk configuration baseline for `root` without
+    /// treating it as a change (startup / new-root registration). Never
+    /// overwrites an existing baseline. Implements [LSPARCH-CONFIG].
+    pub(crate) fn seed_disk_content(&self, root: &Path, content: String) {
+        let _ = lock(&self.disk_contents)
+            .entry(root.to_path_buf())
+            .or_insert(content);
+    }
+
+    /// Record the latest observed on-disk configuration content for `root`,
+    /// returning whether it differs from the recorded baseline. A first
+    /// observation counts as changed, so a missed seed refreshes rather than
+    /// going stale. Implements [LSPARCH-CONFIG].
+    pub(crate) fn record_disk_content(&self, root: &Path, content: &str) -> bool {
+        let mut contents = lock(&self.disk_contents);
+        match contents.get(root) {
+            Some(previous) if previous == content => false,
+            _ => {
+                let _ = contents.insert(root.to_path_buf(), content.to_owned());
+                true
+            }
+        }
     }
 
     /// Bridge the short interval between a successful client edit and didChange.

--- a/crates/basilisk-lsp/src/configuration_editor/transaction.rs
+++ b/crates/basilisk-lsp/src/configuration_editor/transaction.rs
@@ -1,6 +1,7 @@
 //! Workspace-edit apply and deterministic configuration refresh tail.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use basilisk_config::{build_rule_patch, ConfigDocument, ConfigPatch, RuleConfigUpdate};
 use tower_lsp::jsonrpc::Result as LspResult;
@@ -12,7 +13,25 @@ use tower_lsp::lsp_types::{
 
 use super::model::ConfigurationChanged;
 use super::protocol::{config_error, path_uri, rpc_error, rpc_error_data};
+use super::state::ConfigurationEditorState;
 use crate::server::LspServer;
+
+/// Cloneable server handles for the shared configuration refresh tail, so the
+/// server-owned configuration watcher ([LSPARCH-CONFIG]) and request
+/// handlers run the exact same reload → recheck → republish → notify sequence.
+#[derive(Clone)]
+pub(crate) struct ConfigurationRefreshHandles {
+    /// The workspace index holding per-root checker configuration.
+    pub(crate) index: Arc<tokio::sync::RwLock<Option<crate::workspace::WorkspaceIndex>>>,
+    /// LSP client for publishing diagnostics and notifications.
+    pub(crate) client: tower_lsp::Client,
+    /// The `basilisk.enabled` toggle gate ([ANALYSIS-ENABLED]).
+    pub(crate) type_checking_enabled: Arc<tokio::sync::RwLock<bool>>,
+    /// The analyze-scope publication gate ([LSPARCH-DIAGNOSTIC-SCOPE]).
+    pub(crate) analyze_enabled: Arc<std::sync::atomic::AtomicBool>,
+    /// Open-buffer overlays and disk baselines for configuration sources.
+    pub(crate) configuration_editor: Arc<ConfigurationEditorState>,
+}
 
 pub(crate) fn configuration_document(server: &LspServer, root: &Path) -> LspResult<ConfigDocument> {
     server
@@ -146,7 +165,7 @@ pub(super) async fn apply_prepared_patch(
             applied.clone(),
         );
     }
-    refresh_with_document(server, root, reason, &applied).await?;
+    refresh_with_document(&server.refresh_handles(), root, reason, &applied).await?;
     Ok(applied)
 }
 
@@ -156,24 +175,35 @@ pub(crate) async fn refresh_after_configuration_change(
     root: &Path,
     reason: &str,
 ) -> LspResult<()> {
-    let document = configuration_document(server, root)?;
-    refresh_with_document(server, root, reason, &document).await
+    refresh_after_configuration_change_with(&server.refresh_handles(), root, reason).await
+}
+
+/// Handle-based variant of [`refresh_after_configuration_change`] for spawned
+/// tasks (the server-owned configuration watcher, [LSPARCH-CONFIG]).
+pub(crate) async fn refresh_after_configuration_change_with(
+    handles: &ConfigurationRefreshHandles,
+    root: &Path,
+    reason: &str,
+) -> LspResult<()> {
+    let document = handles
+        .configuration_editor
+        .effective_document(root)
+        .map_err(config_error)?;
+    refresh_with_document(handles, root, reason, &document).await
 }
 
 pub(super) async fn refresh_with_document(
-    server: &LspServer,
+    handles: &ConfigurationRefreshHandles,
     root: &Path,
     reason: &str,
     document: &ConfigDocument,
 ) -> LspResult<()> {
     let results = {
-        let mut guard = server.index.write().await;
+        let mut guard = handles.index.write().await;
         let index = guard
             .as_mut()
             .ok_or_else(|| rpc_error("invalidMutation", "workspace index is not ready"))?;
-        let _ = index
-            .root_configs
-            .insert(root.to_path_buf(), document.config.clone());
+        index.set_root_config(root.to_path_buf(), document.config.clone());
         let mut results = index.reresolve_imports_and_recheck();
         if index.mode() == crate::config::AnalysisMode::OpenFilesOnly {
             results.retain(|(uri, _)| configuration_result_is_publishable(index, uri));
@@ -181,9 +211,14 @@ pub(super) async fn refresh_with_document(
         results
     };
     for (uri, diagnostics) in results {
-        server
-            .publish_diagnostics_if_enabled(uri, diagnostics)
-            .await;
+        crate::server::publish_diagnostics_gated(
+            &handles.client,
+            &handles.type_checking_enabled,
+            &handles.analyze_enabled,
+            uri,
+            diagnostics,
+        )
+        .await;
     }
     tracing::info!(
         root = %root.display(),
@@ -191,7 +226,7 @@ pub(super) async fn refresh_with_document(
         reason,
         "configuration refresh complete"
     );
-    server
+    handles
         .client
         .send_notification::<ConfigurationChangedNotification>(ConfigurationChanged {
             root_uri: path_uri(root),

--- a/crates/basilisk-lsp/src/configuration_editor/watch.rs
+++ b/crates/basilisk-lsp/src/configuration_editor/watch.rs
@@ -1,0 +1,187 @@
+//! Server-owned configuration and environment watcher.
+//!
+//! Implements [LSPARCH-CONFIG]. See
+//! docs/specs/LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG.
+//!
+//! The LSP never relies on clients to observe configuration changes: some
+//! clients cannot watch files at all (Zed advertises no file watchers —
+//! docs/specs/ZED-SPEC.md), and external tools edit configuration behind
+//! every client. The server polls each workspace root's configuration
+//! sources itself — the active config (`pyproject.toml`) plus the
+//! environment sources `uv.lock` and `.python-version` ([LSPUV-WATCHERS]) —
+//! and, on any content change, runs the shared refresh tail — reload →
+//! recheck → republish → `basilisk/configurationChanged` — so diagnostics
+//! and configuration UIs update in real time on every IDE.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use basilisk_config::active_config_path;
+use tokio::sync::RwLock;
+
+use super::transaction::{refresh_after_configuration_change_with, ConfigurationRefreshHandles};
+
+/// Poll interval for the server-owned configuration watcher (milliseconds).
+/// A few small-file reads per root per tick — cheap enough to feel real-time.
+pub(crate) const CONFIG_WATCH_POLL_MS: u64 = 250;
+
+/// Environment sources watched per root alongside the active configuration:
+/// they drive the package registry and target Python version ([LSPUV-WATCHERS]).
+const ENVIRONMENT_SOURCES: [&str; 2] = ["uv.lock", ".python-version"];
+
+/// Spawn the watcher task. Returns its abort handle for shutdown.
+///
+/// The task seeds a baseline from the sources already loaded at
+/// initialization, then refreshes any root whose on-disk content later
+/// differs — regardless of how the change arrived.
+pub(crate) fn spawn_configuration_watcher(
+    handles: ConfigurationRefreshHandles,
+    roots: Arc<RwLock<Vec<PathBuf>>>,
+) -> tokio::task::AbortHandle {
+    let task = tokio::spawn(async move {
+        seed_baselines(&handles, &roots).await;
+        loop {
+            tokio::time::sleep(Duration::from_millis(CONFIG_WATCH_POLL_MS)).await;
+            let current_roots = roots.read().await.clone();
+            for root in &current_roots {
+                refresh_root_from_disk(&handles, &current_roots, root, "externalEdit").await;
+                refresh_environment_from_disk(&handles, &current_roots, root).await;
+            }
+        }
+    });
+    task.abort_handle()
+}
+
+/// Record the source content already loaded during initialization so the
+/// first poll tick does not refresh a workspace that has not changed.
+async fn seed_baselines(handles: &ConfigurationRefreshHandles, roots: &RwLock<Vec<PathBuf>>) {
+    let current_roots = roots.read().await.clone();
+    for root in current_roots {
+        for path in watched_sources(&root) {
+            let content = read_source_content(&path).await;
+            handles
+                .configuration_editor
+                .seed_disk_content(&path, content);
+        }
+    }
+}
+
+/// Every file the server watches for one root: the active configuration
+/// source first, then the environment sources.
+fn watched_sources(root: &Path) -> Vec<PathBuf> {
+    let mut sources = vec![active_config_path(root)];
+    sources.extend(ENVIRONMENT_SOURCES.iter().map(|name| root.join(name)));
+    sources
+}
+
+/// Refresh one root when its active configuration content changed on disk.
+///
+/// The shared baseline in `ConfigurationEditorState` means the poll loop and
+/// the client `didChangeWatchedFiles` path observe the same state: whichever
+/// sees a disk change first refreshes, and the other becomes a no-op. A
+/// config change also refreshes the import search paths before the recheck —
+/// `stub-paths`, `typeshed-path`, and dependency edits take effect in the
+/// same single recheck ([ANALYSIS-INCR-IMPORTS]).
+pub(crate) async fn refresh_root_from_disk(
+    handles: &ConfigurationRefreshHandles,
+    roots: &[PathBuf],
+    root: &Path,
+    reason: &str,
+) {
+    let path = active_config_path(root);
+    let content = read_source_content(&path).await;
+    if !handles
+        .configuration_editor
+        .record_disk_content(&path, &content)
+    {
+        return;
+    }
+    tracing::info!(root = %root.display(), reason, "configuration source changed on disk");
+    refresh_search_paths(handles, roots).await;
+    if let Err(error) = refresh_after_configuration_change_with(handles, root, reason).await {
+        // Malformed mid-write content is retried on the next observed change;
+        // the recorded baseline prevents a hot refresh loop.
+        tracing::debug!(
+            root = %root.display(),
+            %error,
+            "configuration refresh deferred: source not currently valid"
+        );
+    }
+}
+
+/// Refresh one root when an environment source (`uv.lock`,
+/// `.python-version`) changed on disk: reload root configs for a Python
+/// version change, rebuild the package registry and import search paths, and
+/// recheck. Mirrors the client-watcher path ([LSPUV-WATCHERS]) so clients
+/// without file watchers behave identically.
+pub(crate) async fn refresh_environment_from_disk(
+    handles: &ConfigurationRefreshHandles,
+    roots: &[PathBuf],
+    root: &Path,
+) {
+    let mut environment_changed = false;
+    let mut python_version_changed = false;
+    for name in ENVIRONMENT_SOURCES {
+        let path = root.join(name);
+        let content = read_source_content(&path).await;
+        if handles
+            .configuration_editor
+            .record_disk_content(&path, &content)
+        {
+            environment_changed = true;
+            python_version_changed |= name == ".python-version";
+            tracing::info!(root = %root.display(), source = name, "environment source changed on disk");
+        }
+    }
+    if !environment_changed {
+        return;
+    }
+    if python_version_changed {
+        let mut guard = handles.index.write().await;
+        if let Some(index) = guard.as_mut() {
+            index.reload_root_configs();
+        }
+    }
+    refresh_search_paths(handles, roots).await;
+    recheck_and_publish(handles).await;
+}
+
+/// Rebuild the package registry and import search paths from the current
+/// on-disk configuration and cache them on the index ([ANALYSIS-INCR-IMPORTS]).
+async fn refresh_search_paths(handles: &ConfigurationRefreshHandles, roots: &[PathBuf]) {
+    let guard = handles.index.read().await;
+    let Some(index) = guard.as_ref() else { return };
+    let config = roots
+        .first()
+        .map(|root| crate::config::load_config(root))
+        .unwrap_or_default();
+    let registry = crate::server::init::build_uv_registry(roots);
+    let search_paths = crate::import_resolver::search_paths_from_config(roots, &config, registry);
+    index.set_search_paths(search_paths);
+}
+
+/// Recheck every indexed file and publish the diagnostics that changed.
+async fn recheck_and_publish(handles: &ConfigurationRefreshHandles) {
+    let results = {
+        let guard = handles.index.read().await;
+        let Some(index) = guard.as_ref() else { return };
+        index.reresolve_imports_and_recheck()
+    };
+    for (uri, diagnostics) in results {
+        crate::server::publish_diagnostics_gated(
+            &handles.client,
+            &handles.type_checking_enabled,
+            &handles.analyze_enabled,
+            uri,
+            diagnostics,
+        )
+        .await;
+    }
+}
+
+/// A watched source's current bytes; a missing or unreadable file is the
+/// empty content (deleting a source is itself a change).
+async fn read_source_content(path: &Path) -> String {
+    tokio::fs::read_to_string(path).await.unwrap_or_default()
+}

--- a/crates/basilisk-lsp/src/server/document.rs
+++ b/crates/basilisk-lsp/src/server/document.rs
@@ -254,21 +254,7 @@ pub(super) async fn did_change_watched_files(
 ) {
     log_uv_config_changes(&params);
     refresh_changed_configuration_sources(server, &params).await;
-
-    let needs_python_version_refresh = params
-        .changes
-        .iter()
-        .any(|change| change.uri.path().ends_with(".python-version"));
-    if needs_python_version_refresh {
-        reload_index_configs(server).await;
-    }
-    let needs_registry_refresh = params.changes.iter().any(|change| {
-        let path = change.uri.path();
-        path.ends_with("uv.lock") || path.ends_with("pyproject.toml")
-    });
-    if needs_registry_refresh || needs_python_version_refresh {
-        super::init::rebuild_registry_and_resolve(server).await;
-    }
+    refresh_changed_environment_sources(server, &params).await;
 
     // Config changes are relevant in every analysis mode. Only disk-driven
     // Python module reloads are skipped when the server tracks open files.
@@ -410,26 +396,71 @@ async fn refresh_changed_configuration_sources(
             changed_roots.push(root.clone());
         }
     }
+    // Route through the shared disk baseline ([LSPARCH-CONFIG]) so a
+    // change seen by both the client watcher and the server-owned watcher
+    // refreshes exactly once — whichever observes it first wins.
+    let handles = server.refresh_handles();
     for root in changed_roots {
-        if let Err(error) = crate::configuration_editor::refresh_after_configuration_change(
-            server,
+        crate::configuration_editor::refresh_root_from_disk(
+            &handles,
+            &roots,
             &root,
             "externalEdit",
         )
-        .await
-        {
-            warn!(root = %root.display(), %error, "failed to refresh changed configuration");
-        }
+        .await;
     }
 }
 
-/// Re-read each workspace root's checker config from disk after a watched config
-/// file changed, so version-aware rules and severity overrides update without an
-/// LSP restart. Implements [CHKARCH-VERSION-TARGET] reactivity.
-async fn reload_index_configs(server: &LspServer) {
-    let mut guard = server.index.write().await;
-    if let Some(index) = guard.as_mut() {
-        index.reload_root_configs();
+/// Route client-watched environment changes (`uv.lock`, `.python-version`,
+/// nested `pyproject.toml`) through the same guarded refresh the server-owned
+/// watcher uses, so both observers share one baseline ([LSPARCH-CONFIG] /
+/// [LSPUV-WATCHERS], [CHKARCH-VERSION-TARGET] reactivity).
+async fn refresh_changed_environment_sources(
+    server: &LspServer,
+    params: &DidChangeWatchedFilesParams,
+) {
+    let roots = server.workspace_roots.read().await.clone();
+    let mut changed_roots = Vec::new();
+    let mut nested_change = false;
+    for change in &params.changes {
+        let Ok(path) = change.uri.to_file_path() else {
+            continue;
+        };
+        let is_environment_source = path
+            .file_name()
+            .is_some_and(|name| name == "uv.lock" || name == ".python-version");
+        let is_nested_pyproject = path
+            .file_name()
+            .is_some_and(|name| name == "pyproject.toml")
+            && !roots
+                .iter()
+                .any(|root| path.parent() == Some(root.as_path()));
+        if !is_environment_source && !is_nested_pyproject {
+            continue;
+        }
+        match roots
+            .iter()
+            .find(|root| path.parent() == Some(root.as_path()))
+        {
+            Some(root) if !changed_roots.contains(root) => changed_roots.push(root.clone()),
+            Some(_) => {}
+            // A nested workspace-member file still shifts the registry and the
+            // discovered folder configs — fall back to the whole-workspace path.
+            None => nested_change = true,
+        }
+    }
+    let handles = server.refresh_handles();
+    for root in changed_roots {
+        crate::configuration_editor::refresh_environment_from_disk(&handles, &roots, &root).await;
+    }
+    if nested_change {
+        {
+            let mut guard = server.index.write().await;
+            if let Some(index) = guard.as_mut() {
+                index.reload_root_configs();
+            }
+        }
+        super::init::rebuild_registry_and_resolve(server).await;
     }
 }
 

--- a/crates/basilisk-lsp/src/server/init.rs
+++ b/crates/basilisk-lsp/src/server/init.rs
@@ -279,6 +279,18 @@ pub(super) async fn initialized(server: &LspServer) {
         register_file_watchers(&client).await;
     }));
 
+    // Implements [LSPARCH-CONFIG]: the server watches the active
+    // configuration source itself. Client `didChangeWatchedFiles` support is
+    // an optimization, never a requirement — clients without watchers (Zed)
+    // get identical reactive configuration behaviour.
+    let watcher = crate::configuration_editor::spawn_configuration_watcher(
+        server.refresh_handles(),
+        Arc::clone(&server.workspace_roots),
+    );
+    if let Some(previous) = server.config_watcher.lock().await.replace(watcher) {
+        previous.abort();
+    }
+
     // Read the analysis mode, then release the lock immediately so the
     // message loop is not blocked while the workspace scan runs.
     let mode = {
@@ -1023,9 +1035,13 @@ async fn check_pytest_from_index(
     }
 }
 
-/// Handle the `shutdown` request: stop all debug and profiling sessions.
+/// Handle the `shutdown` request: stop all debug and profiling sessions and
+/// the server-owned configuration watcher ([LSPARCH-CONFIG]).
 pub(super) async fn shutdown(server: &LspServer) -> LspResult<()> {
     server.debug_manager.stop_all().await;
     server.profiler_manager.stop_all().await;
+    if let Some(watcher) = server.config_watcher.lock().await.take() {
+        watcher.abort();
+    }
     Ok(())
 }

--- a/crates/basilisk-lsp/src/server/mod.rs
+++ b/crates/basilisk-lsp/src/server/mod.rs
@@ -124,8 +124,10 @@ pub struct LspServer {
     pub(super) client: Client,
     /// Workspace index (None until initialized).
     pub(super) index: Arc<RwLock<Option<WorkspaceIndex>>>,
-    /// Workspace root folders discovered during initialization.
-    pub(super) workspace_roots: RwLock<Vec<std::path::PathBuf>>,
+    /// Workspace root folders discovered during initialization. Shared as an
+    /// `Arc` so the server-owned configuration watcher ([LSPARCH-CONFIG])
+    /// follows root changes after the handler returns.
+    pub(super) workspace_roots: Arc<RwLock<Vec<std::path::PathBuf>>>,
     // Implements [LSPDEBUG-WIRE] (DebugSessionManager added to LspServer)
     /// Debug session manager — spawns debugpy and tracks active sessions.
     pub(super) debug_manager: crate::debug::DebugSessionManager,
@@ -168,7 +170,15 @@ pub struct LspServer {
     /// Whether the initial workspace scan has completed.
     pub(super) initial_scan_complete: Arc<std::sync::atomic::AtomicBool>,
     /// Revision-checked configuration previews awaiting an explicit apply.
-    pub(crate) configuration_editor: crate::configuration_editor::ConfigurationEditorState,
+    /// Shared as an `Arc` so the server-owned configuration watcher
+    /// ([LSPARCH-CONFIG]) runs the same refresh tail from its own task.
+    pub(crate) configuration_editor: Arc<crate::configuration_editor::ConfigurationEditorState>,
+    // Implements [LSPARCH-CONFIG]: the server watches the active
+    // configuration source itself — reactivity never depends on the client
+    // supporting `workspace/didChangeWatchedFiles` (Zed advertises no file
+    // watchers at all; see docs/specs/ZED-SPEC.md).
+    /// The server-owned configuration watcher task, aborted on shutdown.
+    pub(super) config_watcher: Mutex<Option<AbortHandle>>,
 }
 
 impl std::fmt::Debug for LspServer {
@@ -184,7 +194,7 @@ impl LspServer {
         Self {
             client,
             index: Arc::new(RwLock::new(None)),
-            workspace_roots: RwLock::new(Vec::new()),
+            workspace_roots: Arc::new(RwLock::new(Vec::new())),
             debug_manager: crate::debug::DebugSessionManager::new(),
             profiler_manager: crate::profiler::ProfileSessionManager::new(),
             memory_manager: crate::profiler::memory::session::MemorySessionManager::new(),
@@ -203,7 +213,25 @@ impl LspServer {
             // No scan has run yet: zero-file rollups are NOT trustworthy until
             // the first scan completes. [EXTACT-MODULES-HEADER-LOADING], #144.
             initial_scan_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            configuration_editor: crate::configuration_editor::ConfigurationEditorState::default(),
+            configuration_editor: Arc::new(
+                crate::configuration_editor::ConfigurationEditorState::default(),
+            ),
+            config_watcher: Mutex::new(None),
+        }
+    }
+
+    /// Cloneable handles for the shared configuration refresh tail, so the
+    /// server-owned configuration watcher can run it from a spawned task.
+    /// Implements [LSPARCH-CONFIG].
+    pub(crate) fn refresh_handles(
+        &self,
+    ) -> crate::configuration_editor::ConfigurationRefreshHandles {
+        crate::configuration_editor::ConfigurationRefreshHandles {
+            index: Arc::clone(&self.index),
+            client: self.client.clone(),
+            type_checking_enabled: Arc::clone(&self.type_checking_enabled),
+            analyze_enabled: Arc::clone(&self.analyze_enabled),
+            configuration_editor: Arc::clone(&self.configuration_editor),
         }
     }
 

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -259,6 +259,18 @@ impl WorkspaceIndex {
         }
     }
 
+    /// Replace one root's checker config with an already-resolved document
+    /// (a live configuration buffer or a freshly observed disk edit) and drop
+    /// the discovered per-directory config cache so the next lookup re-merges
+    /// instead of serving the stale entry. Implements [LSPARCH-CONFIG]
+    /// via [CHKARCH-CONFIG-DISCOVERY].
+    pub fn set_root_config(&mut self, root: PathBuf, config: BasiliskConfig) {
+        let _ = self.root_configs.insert(root, config);
+        if let Ok(mut dir_configs) = self.dir_configs.write() {
+            dir_configs.clear();
+        }
+    }
+
     /// Cache the import search paths built during the workspace scan.
     ///
     /// Subsequent incremental analyses (`didOpen` / `didChange` / disk reload)

--- a/crates/basilisk-lsp/src/workspace.rs
+++ b/crates/basilisk-lsp/src/workspace.rs
@@ -393,17 +393,26 @@ impl WorkspaceIndex {
         }
 
         // Find the longest matching root (most specific) for the base config,
-        // then merge the discovered ancestor chain over it. Merging is
-        // idempotent, so re-applying the root's own file config is harmless.
-        let base = self
+        // then merge the discovered ancestor chain over it. Inside a root the
+        // walk stops BELOW the root ([LSPARCH-CONFIG]): the in-memory root
+        // config is the authoritative effective config — an applied
+        // configuration-editor change or an open, unsaved config buffer beats
+        // disk — so re-reading the root's file here would resurrect stale
+        // disk state over it.
+        let owning_root = self
             .roots
             .iter()
             .filter(|root| file_path.starts_with(root))
-            .max_by_key(|root| root.components().count())
+            .max_by_key(|root| root.components().count());
+        let base = owning_root
             .and_then(|root| self.root_configs.get(root))
             .unwrap_or(&self.checker_config)
             .clone();
-        let merged = Arc::new(base.merged_with(basilisk_config::load_basilisk_config(&dir)));
+        let discovered = owning_root.map_or_else(
+            || basilisk_config::load_basilisk_config(&dir),
+            |root| basilisk_config::load_basilisk_config_below(&dir, root),
+        );
+        let merged = Arc::new(base.merged_with(discovered));
         if let Ok(mut cache) = self.dir_configs.write() {
             let _ = cache.insert(dir, Arc::clone(&merged));
         }
@@ -2979,6 +2988,51 @@ mod tests {
         assert!(
             !cfg.has_config_table(),
             "fallback config should have no rule tables"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn set_root_config_is_authoritative_over_stale_disk_config() {
+        // [LSPARCH-CONFIG] via [CHKARCH-CONFIG-DISCOVERY]: after an applied
+        // configuration-editor change or an open, unsaved config buffer, the
+        // in-memory root config decides. config_for_file must not re-read the
+        // root's pyproject.toml from disk and merge its stale severities back
+        // over the applied one (crates/basilisk-lsp/src/workspace.rs
+        // config_for_file bounded walk).
+        let root = unique_tmp("bsk_cfg_authority");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join("pyproject.toml"),
+            "[tool.basilisk.rules]\n\"BSK-0001\" = \"error\"\n",
+        )
+        .unwrap();
+
+        let mut idx = WorkspaceIndex::new(
+            vec![root.clone()],
+            AnalysisMode::WholeModule,
+            BasiliskConfig::default(),
+        );
+        let file = root.join("app.py");
+        assert_eq!(
+            idx.config_for_file(&file).resolve_severity("BSK-0001", &[]),
+            Some(basilisk_config::RuleSeverity::Error),
+            "disk config decides before any in-memory update"
+        );
+
+        // The applied document parses exactly as the configuration editor
+        // builds it; disk still holds the stale "error" entry.
+        let applied = basilisk_config::discover_config_document_with_content(
+            &root,
+            "[tool.basilisk.rules]\n\"BSK-0001\" = \"warning\"\n".to_owned(),
+        )
+        .unwrap();
+        idx.set_root_config(root.clone(), applied.config);
+        assert_eq!(
+            idx.config_for_file(&file).resolve_severity("BSK-0001", &[]),
+            Some(basilisk_config::RuleSeverity::Warning),
+            "the in-memory root config must beat the stale on-disk entry"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/basilisk-lsp/tests/lsp/ws_test_configuration_preview.rs
+++ b/crates/basilisk-lsp/tests/lsp/ws_test_configuration_preview.rs
@@ -13,7 +13,7 @@ use super::ws_test_configuration_editor::{
     tag_state, APPLY, OCCURRENCES, PREVIEW,
 };
 
-async fn snapshot_revision(fixture: &mut WsTestFixture, id: u64) -> TestResult<String> {
+pub async fn snapshot_revision(fixture: &mut WsTestFixture, id: u64) -> TestResult<String> {
     let snapshot = snapshot_result(fixture, id).await?;
     Ok(snapshot
         .get("revision")
@@ -22,7 +22,7 @@ async fn snapshot_revision(fixture: &mut WsTestFixture, id: u64) -> TestResult<S
         .to_owned())
 }
 
-async fn preview_result(
+pub async fn preview_result(
     fixture: &mut WsTestFixture,
     id: u64,
     revision: &str,
@@ -62,7 +62,7 @@ async fn apply_preview(
     .await
 }
 
-fn preview_id_of(preview: &serde_json::Value) -> TestResult<String> {
+pub fn preview_id_of(preview: &serde_json::Value) -> TestResult<String> {
     Ok(preview
         .get("previewId")
         .and_then(serde_json::Value::as_str)

--- a/crates/basilisk-lsp/tests/lsp/ws_test_configuration_watch.rs
+++ b/crates/basilisk-lsp/tests/lsp/ws_test_configuration_watch.rs
@@ -9,6 +9,8 @@
 //! docs/specs/ZED-SPEC.md) get identical behaviour to VS Code.
 
 use super::ws_test_common::*;
+use super::ws_test_configuration_editor::{answer_apply_edit, file_uri, root_uri, APPLY};
+use super::ws_test_configuration_preview::{preview_id_of, preview_result, snapshot_revision};
 
 /// [LSPARCH-CONFIG]: rewriting `pyproject.toml` on disk — with NO
 /// `workspace/didChangeWatchedFiles`, no open config buffer, no LSP message
@@ -75,6 +77,123 @@ async fn disk_config_edit_without_client_watcher_republishes_and_notifies() -> T
         saw_warning_severity,
         "BSK-0001 was never republished at warning severity after the \
          external disk edit — diagnostics went stale"
+    );
+    Ok(())
+}
+
+/// What the client observed while the apply round trip ran: the refresh tail
+/// fires before the apply response, so both signals arrive interleaved.
+struct ReactivitySignals {
+    configuration_changed: bool,
+    warning_republished: bool,
+}
+
+/// Send `basilisk/applyConfigurationChange` and pump the connection, answering
+/// the server's `workspace/applyEdit` request, until the apply response AND
+/// both reactivity signals (republish at the new severity for `python_uri`,
+/// `basilisk/configurationChanged`) have been observed — or the message budget
+/// runs out, leaving the flags false for the caller's assertions.
+async fn apply_observing_reactivity(
+    fixture: &mut WsTestFixture,
+    id: u64,
+    preview_id: &str,
+    python_uri: &str,
+) -> TestResult<ReactivitySignals> {
+    let root = root_uri(fixture);
+    fixture
+        .send_json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": APPLY,
+            "params": { "rootUri": root, "previewId": preview_id }
+        }))
+        .await?;
+    let mut signals = ReactivitySignals {
+        configuration_changed: false,
+        warning_republished: false,
+    };
+    let mut apply_succeeded = false;
+    for _ in 0..40 {
+        if apply_succeeded && signals.configuration_changed && signals.warning_republished {
+            break;
+        }
+        let Some(msg) = fixture.recv().await else {
+            break;
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&msg)?;
+        if answer_apply_edit(fixture, &parsed).await? {
+            continue;
+        }
+        if parsed.get("id") == Some(&serde_json::json!(id)) {
+            apply_succeeded = !parsed["result"].is_null();
+            continue;
+        }
+        match parsed.get("method").and_then(serde_json::Value::as_str) {
+            Some("basilisk/configurationChanged") => signals.configuration_changed = true,
+            Some("textDocument/publishDiagnostics")
+                if parsed["params"]["uri"].as_str() == Some(python_uri) =>
+            {
+                if let Some(updated) = extract_diagnostic(&parsed, "BSK-0001") {
+                    signals.warning_republished |= updated["severity"].as_u64() == Some(2);
+                }
+            }
+            _ => {}
+        }
+    }
+    if !apply_succeeded {
+        return Err("applyConfigurationChange never returned a successful result".into());
+    }
+    Ok(signals)
+}
+
+/// [LSPARCH-CONFIG] / [CONFIGEDITOR-OPERATIONS]: changing a rule severity
+/// through the configuration-editor UI protocol (snapshot → preview → apply)
+/// must run the same shared refresh tail as an external disk edit — the open
+/// Python file's diagnostics are republished at the new severity and
+/// `basilisk/configurationChanged` is pushed, with no client polling.
+#[tokio::test]
+async fn ui_apply_republishes_diagnostics_and_notifies() -> TestResult<()> {
+    let mut fixture = WsTestFixture::new().await?;
+    let _ = fixture.initialize().await?;
+
+    let uri = file_uri(&fixture, "ui_apply_reactivity.py");
+    fixture
+        .did_open(&uri, "def handler(value):\n    return value\n")
+        .await?;
+    let raw = fixture.wait_for_diagnostics().await?;
+    let json: serde_json::Value = serde_json::from_str(&raw)?;
+    let diag = extract_diagnostic(&json, "BSK-0001")
+        .ok_or("BSK-0001 should fire before the configuration change")?;
+    assert_eq!(
+        diag["severity"].as_u64(),
+        Some(1),
+        "BSK-0001 must start at error severity: {diag}"
+    );
+
+    let revision = snapshot_revision(&mut fixture, 910).await?;
+    let preview = preview_result(
+        &mut fixture,
+        911,
+        &revision,
+        serde_json::json!([{
+            "kind": "SetRule",
+            "code": "BSK-0001",
+            "severity": { "kind": "Warning" }
+        }]),
+    )
+    .await?;
+    let preview_id = preview_id_of(&preview)?;
+
+    let signals = apply_observing_reactivity(&mut fixture, 912, &preview_id, &uri).await?;
+    assert!(
+        signals.configuration_changed,
+        "server never sent basilisk/configurationChanged after a UI apply — \
+         the configuration editor is not reactive"
+    );
+    assert!(
+        signals.warning_republished,
+        "BSK-0001 was never republished at warning severity after a UI \
+         apply — diagnostics went stale"
     );
     Ok(())
 }

--- a/crates/basilisk-lsp/tests/lsp/ws_test_configuration_watch.rs
+++ b/crates/basilisk-lsp/tests/lsp/ws_test_configuration_watch.rs
@@ -1,0 +1,80 @@
+//! Tests for [LSPARCH-CONFIG]. See
+//! docs/specs/LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG.
+//!
+//! The LSP itself watches the active configuration source (the root's
+//! `pyproject.toml`) and reactively pushes updates — republished diagnostics
+//! plus `basilisk/configurationChanged` — for EVERY way the configuration can
+//! change, including external disk edits that arrive through no LSP channel
+//! at all. Clients without file-watcher support (Zed advertises none —
+//! docs/specs/ZED-SPEC.md) get identical behaviour to VS Code.
+
+use super::ws_test_common::*;
+
+/// [LSPARCH-CONFIG]: rewriting `pyproject.toml` on disk — with NO
+/// `workspace/didChangeWatchedFiles`, no open config buffer, no LSP message
+/// of any kind — must be detected by the server's own watcher, which then
+/// rechecks the workspace, republishes the open file's diagnostics at the new
+/// severity, and emits `basilisk/configurationChanged` so UIs refresh.
+#[tokio::test]
+async fn disk_config_edit_without_client_watcher_republishes_and_notifies() -> TestResult<()> {
+    let mut fixture = WsTestFixture::new().await?;
+    let _ = fixture.initialize().await?;
+
+    let uri = format!(
+        "file://{}/watched_config_app.py",
+        fixture.workspace_root.to_string_lossy()
+    );
+    fixture
+        .did_open(&uri, "def handler(value):\n    return value\n")
+        .await?;
+    let raw = fixture.wait_for_diagnostics().await?;
+    let json: serde_json::Value = serde_json::from_str(&raw)?;
+    let diag = extract_diagnostic(&json, "BSK-0001")
+        .ok_or("BSK-0001 should fire before the config change")?;
+    assert_eq!(
+        diag["severity"].as_u64(),
+        Some(1),
+        "BSK-0001 must start at error severity: {diag}"
+    );
+
+    // External edit: BSK-0001 drops to "warning" on disk. Deliberately sent
+    // through no LSP channel — the server must notice on its own.
+    std::fs::write(
+        fixture.workspace_root.join("pyproject.toml"),
+        "[tool.basilisk.rules]\n\"BSK-0001\" = \"warning\"\n\"BSK-0002\" = \"error\"\n",
+    )?;
+
+    let mut saw_configuration_changed = false;
+    let mut saw_warning_severity = false;
+    for _ in 0..20 {
+        if saw_configuration_changed && saw_warning_severity {
+            break;
+        }
+        let Some(msg) = fixture.recv().await else {
+            break;
+        };
+        if msg.contains("\"method\":\"basilisk/configurationChanged\"") {
+            saw_configuration_changed = true;
+        }
+        if msg.contains("\"method\":\"textDocument/publishDiagnostics\"") {
+            let parsed: serde_json::Value = serde_json::from_str(&msg)?;
+            if parsed["params"]["uri"].as_str() == Some(uri.as_str()) {
+                if let Some(updated) = extract_diagnostic(&parsed, "BSK-0001") {
+                    saw_warning_severity = updated["severity"].as_u64() == Some(2);
+                }
+            }
+        }
+    }
+
+    assert!(
+        saw_configuration_changed,
+        "server never sent basilisk/configurationChanged after an external \
+         disk edit — the configuration is not watched server-side"
+    );
+    assert!(
+        saw_warning_severity,
+        "BSK-0001 was never republished at warning severity after the \
+         external disk edit — diagnostics went stale"
+    );
+    Ok(())
+}

--- a/crates/basilisk-lsp/tests/ws_features_tests.rs
+++ b/crates/basilisk-lsp/tests/ws_features_tests.rs
@@ -32,6 +32,8 @@ mod ws_test_configuration_adoption;
 mod ws_test_configuration_editor;
 #[path = "lsp/ws_test_configuration_preview.rs"]
 mod ws_test_configuration_preview;
+#[path = "lsp/ws_test_configuration_watch.rs"]
+mod ws_test_configuration_watch;
 #[path = "lsp/ws_test_execute_command.rs"]
 mod ws_test_execute_command;
 #[path = "lsp/ws_test_execute_stubs.rs"]

--- a/docs/plans/LSP-FORMATTING-PLAN.md
+++ b/docs/plans/LSP-FORMATTING-PLAN.md
@@ -3,35 +3,46 @@
 Implements [LSPFMT](../specs/LSP-FORMATTING-SPEC.md#LSPFMT).
 
 The embedded Ruff formatter, native import hygiene, range formatting,
-`basilisk.formatter`, provenance/version reporting, and no-`ruff` regression
-coverage are complete. The `ruff` CLI is not a runtime dependency.
+`basilisk.formatter`, provenance/version reporting, no-`ruff` regression
+coverage, `basilisk format`, generated release-notes provenance, and the
+formatting docs page are complete. The `ruff` CLI is not a runtime
+dependency. Open: the VS Code default-formatter opt-in prompt and the two
+published-artifact verifications, which need a live editor/release.
 
 ## Release provenance {#LSPFMT-PLAN-RELEASE}
 
-- [ ] Generate a release-note component block from `shipwright.json` plus
-  `EMBEDDED_RUFF_FORMATTER_VERSION`.
-- [ ] Drift-test the generated block so release notes cannot claim different
-  formatter bytes from the build.
+- [x] Generate a release-note component block from `shipwright.json` plus
+  `EMBEDDED_RUFF_FORMATTER_VERSION` (`scripts/gen_release_notes.py`, appended
+  to the auto-generated notes by the `release` job).
+- [x] Drift-test the generated block so release notes cannot claim different
+  formatter bytes from the build
+  (`crates/basilisk-cli/tests/e2e_release_notes_block.rs` runs the generator
+  against the freshly built binary).
 
 ## Client wiring {#LSPFMT-PLAN-CLIENTS}
 
 - [ ] VS Code: offer a one-time, dismissible opt-in to set Basilisk as the Python
   default formatter only when the user has not chosen another formatter.
 - [ ] Zed: verify the published extension selects the language-server formatter.
-- [ ] Neovim: document and test `vim.lsp.buf.format({ name = "basilisk" })`.
+- [x] Neovim: document and test `vim.lsp.buf.format({ name = "basilisk" })`
+  (`:h basilisk-formatting` in `doc/basilisk.txt`; real-LSP format call in
+  `tests/lsp/ui_spec.lua`).
 
 ## CLI {#LSPFMT-PLAN-CLI}
 
-- [ ] Add `basilisk format [paths]` using the same embedded engine and project
-  Ruff-format options as the LSP.
-- [ ] Cover check/write behavior, multiple paths, parse failures, and formatter
-  disablement with real-binary tests.
+- [x] Add `basilisk format [paths]` using the same embedded engine and project
+  Ruff-format options as the LSP (`crates/basilisk-cli/src/format.rs`, plus
+  `--check`).
+- [x] Cover check/write behavior, multiple paths, parse failures, and formatter
+  disablement with real-binary tests
+  (`crates/basilisk-cli/tests/e2e_format.rs`, run with an empty `PATH`).
 
 ## Documentation {#LSPFMT-PLAN-DOCS}
 
-- [ ] Document that formatting embeds Ruff while import hygiene is Basilisk's
+- [x] Document that formatting embeds Ruff while import hygiene is Basilisk's
   native implementation; link to Ruff for formatter behavior rather than
-  duplicating its manual.
+  duplicating its manual (`website/src/docs/formatting.md`,
+  `:h basilisk-formatting`).
 - [ ] Verify formatting and import actions in published VS Code, Zed, and Neovim
   artifacts with no `ruff` executable on `PATH`.
 

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -870,24 +870,25 @@ Compatibility anchors: supported methods {#CHKARCH-LSP-METHODS}; custom commands
 
 ### Commands {#CHKARCH-CLI-COMMANDS}
 
-- `basilisk check [paths]`
-- `basilisk fix [paths]` and `--unsafe`
+- `basilisk check [paths]` / `basilisk analyze [paths]` — the two scopes of the
+  partition ([CHKARCH-COMMANDS](#CHKARCH-COMMANDS)), identical pipeline
+- `basilisk fix [paths] [--unsafe] [--rules ...]`
 - `basilisk adopt|unadopt [paths]`
 - `basilisk lsp [--transport stdio|ws]`
-- `basilisk stubs generate|status`
+- `basilisk stubs generate|status` (plus the Pyright-compat `createstub` spelling)
 
 ### Output {#CHKARCH-CLI-OUTPUT}
 
-`check` supports human-readable text and structured JSON. Other formats are
-not part of the current contract.
+`check` and `analyze` support human-readable text and structured JSON. Other
+formats are not part of the current contract.
 
 ### Exit codes {#CHKARCH-CLI-EXITCODES}
 
 | Code | Meaning |
 |---|---|
-| 0 | Check completed without error diagnostics |
+| 0 | Completed without error diagnostics |
 | 1 | Error diagnostics were found |
-| 2 | Invalid configuration (required target; tracked in the remediation backlog) |
+| 2 | Invalid configuration (e.g. a `pep` rule resolved to `disabled`) |
 | 3 | Internal failure |
 
 ### CI use {#CHKARCH-CLI-CI}
@@ -1051,8 +1052,11 @@ config's directory becomes the merged config's `project_root`, anchoring
   so `adopt` writes exactly where `check` discovers.
 - **LSP**: per-file config is the owning workspace root's config merged with
   the file's discovered ancestor chain (`WorkspaceIndex::config_for_file`,
-  memoized per directory, invalidated on config reload). A workspace folder
-  opened *inside* a project discovers the project's config the same way.
+  memoized per directory; the shared refresh tail the server runs on every
+  configuration change invalidates the memo —
+  [LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)). A workspace
+  folder opened *inside* a project discovers the project's config the same
+  way.
 
 ### Include Semantics {#CHKARCH-CONFIG-INCLUDE}
 

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -872,6 +872,8 @@ Compatibility anchors: supported methods {#CHKARCH-LSP-METHODS}; custom commands
 
 - `basilisk check [paths]` / `basilisk analyze [paths]` — the two scopes of the
   partition ([CHKARCH-COMMANDS](#CHKARCH-COMMANDS)), identical pipeline
+- `basilisk format [paths] [--check]` — the embedded Ruff formatter
+  ([LSPFMT-CLIENTS](LSP-FORMATTING-SPEC.md#LSPFMT-CLIENTS))
 - `basilisk fix [paths] [--unsafe] [--rules ...]`
 - `basilisk adopt|unadopt [paths]`
 - `basilisk lsp [--transport stdio|ws]`
@@ -1050,13 +1052,17 @@ config's directory becomes the merged config's `project_root`, anchoring
 - **CLI `adopt`/`unadopt`**: the config root anchors at the nearest ancestor
   directory holding a config table (`basilisk_config::discover_config_dir`),
   so `adopt` writes exactly where `check` discovers.
-- **LSP**: per-file config is the owning workspace root's config merged with
-  the file's discovered ancestor chain (`WorkspaceIndex::config_for_file`,
-  memoized per directory; the shared refresh tail the server runs on every
-  configuration change invalidates the memo —
-  [LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)). A workspace
-  folder opened *inside* a project discovers the project's config the same
-  way.
+- **LSP**: per-file config is the owning workspace root's **in-memory** config
+  merged with the ancestor chain discovered strictly *below* that root
+  (`WorkspaceIndex::config_for_file` / `load_basilisk_config_below`, memoized
+  per directory; the shared refresh tail the server runs on every
+  configuration change invalidates the memo). The root's own config file is
+  never re-read from disk here: the in-memory root config already reflects it
+  — or, authoritatively, an applied editor-UI change or an open, unsaved
+  config buffer ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)).
+  A workspace folder opened *inside* a project discovers the project's config
+  the same way (its root config is loaded through the full ancestor walk at
+  index build/reload).
 
 ### Include Semantics {#CHKARCH-CONFIG-INCLUDE}
 

--- a/docs/specs/CHECKER-STUB-RESOLUTION-SPEC.md
+++ b/docs/specs/CHECKER-STUB-RESOLUTION-SPEC.md
@@ -81,8 +81,13 @@ modified version of typeshed; if this option is provided, type checkers SHOULD
 use this as the canonical source for standard-library types in this step"
 ([typing spec, import resolution ordering](https://typing.python.org/en/latest/spec/distributing.html#import-resolution-ordering)).
 
-Basilisk satisfies this with `typeshed-path` (`pyproject.toml`; LSP JSON:
-`typeshedPath`) — a single path to the root of a typeshed-layout directory that
+Basilisk satisfies this with `typeshed-path` in the one project configuration —
+`pyproject.toml` `[tool.basilisk]`
+([CHKARCH-CONFIG-FILE](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CONFIG-FILE)); the
+pyright-compat camelCase spelling `typeshedPath` is accepted in the same table
+and in the pyright compatibility sources
+([ANALYSIS-CONFIG-PRI](LSP-ANALYSIS-MODES-SPEC.md#ANALYSIS-CONFIG-PRI)). The
+value is a single path to the root of a typeshed-layout directory that
 supplies standard-library stubs:
 
 ```toml
@@ -324,13 +329,20 @@ Stub/import diagnostics use the checker's ordinary severity and inline-suppressi
 there is no stub-specific suppression grammar. See
 [CHKARCH-STRICTNESS-SUPPRESSION](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-STRICTNESS-SUPPRESSION).
 
-| Setting Key | Type | Default | Description |
-|------------|------|---------|-------------|
-| `basilisk.stubPaths` | `string[]` | `[]` | Additional directories to search for `.pyi` stubs (resolution step 1 — [§STUBRES-PEP561](#STUBRES-PEP561)) |
-| `basilisk.typeshedPath` | `string` | _(built-in index)_ | Path to a custom/modified typeshed directory that becomes the canonical source for standard-library types (resolution step 3 — [§STUBRES-CUSTOM-TYPESHED](#STUBRES-CUSTOM-TYPESHED)) |
+| Config key (`[tool.basilisk]`) | Type | Default | Description |
+|-------------------------------|------|---------|-------------|
+| `stub-paths` | `string[]` | `[]` | Additional directories to search for `.pyi` stubs (resolution step 1 — [§STUBRES-PEP561](#STUBRES-PEP561)) |
+| `typeshed-path` | `string` | _(built-in index)_ | Path to a custom/modified typeshed directory that becomes the canonical source for standard-library types (resolution step 3 — [§STUBRES-CUSTOM-TYPESHED](#STUBRES-CUSTOM-TYPESHED)) |
 
-Both keys accept the `pyproject.toml` kebab-case (`stub-paths`, `typeshed-path`)
-and the LSP JSON camelCase (`stubPaths`, `typeshedPath`) spellings.
+Both keys live in the one project configuration — `pyproject.toml`
+`[tool.basilisk]`
+([CHKARCH-CONFIG-FILE](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CONFIG-FILE)) —
+with kebab-case as the canonical spelling. The camelCase spellings
+(`stubPaths`, `typeshedPath`) are pyright-migration aliases accepted in the
+same table and in the pyright compatibility sources (`[tool.pyright]`,
+`pyrightconfig.json` —
+[ANALYSIS-CONFIG-PRI](LSP-ANALYSIS-MODES-SPEC.md#ANALYSIS-CONFIG-PRI)). There
+is no separate LSP-side JSON configuration.
 
 `pyproject.toml` configuration:
 

--- a/docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md
+++ b/docs/specs/EXTENSION-ACTIVITY-PANEL-SPEC.md
@@ -148,7 +148,11 @@ while the server is running, and Fix Workspace also requires
 
 Manual refresh clears cached modules and refetches. Server start, module changes,
 `scanComplete`, and debounced diagnostics update the shared analysis revision, which causes
-reactive consumers to refetch.
+reactive consumers to refetch. Configuration changes are server-pushed, never polled
+([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)): the refresh tail's
+republished diagnostics bump the analysis revision for the panel, and
+`basilisk/configurationChanged` refreshes the configuration editor state directly
+(`src/store.ts` notification subscriptions).
 
 ### Centralized reactive state {#EXTACT-REACTIVE-STATE}
 

--- a/docs/specs/LSP-ANALYSIS-MODES-SPEC.md
+++ b/docs/specs/LSP-ANALYSIS-MODES-SPEC.md
@@ -77,10 +77,12 @@ Default: `"wholeModule"`. The user must explicitly opt down to `openFilesOnly`.
 Resolution order (highest wins):
 
 1. Editor workspace setting (`basilisk.analysisMode`) — delivered as `initializationOptions.analysisMode` at startup and re-applied at runtime via `workspace/didChangeConfiguration` (top-level `analysisMode` or nested `basilisk.analysisMode`). Editors that always forward a value (the VS Code extension and basilisk.nvim both send their `wholeModule` default) pin the mode from the editor side; clients that send no value (e.g. the Zed extension) fall through to the file tier.
-2. The first parseable config file in the first workspace root, checked in this order: `pyrightconfig.json` (pyright compatibility), then `pyproject.toml` — `[tool.basilisk]` or, failing that, `[tool.pyright]`. The winning file supplies the entire workspace config: precedence is first-file-wins, NOT per-field merging, so a `pyrightconfig.json` that omits `analysisMode` resolves to the default even if `pyproject.toml` sets one (mirroring [pyright's own whole-file precedence](https://microsoft.github.io/pyright/#/configuration) of `pyrightconfig.json` over `pyproject.toml`).
+2. The first parseable config file in the first workspace root, checked in this order: `pyrightconfig.json` (pyright compatibility), then `pyproject.toml` — `[tool.basilisk]` or, failing that, `[tool.pyright]`. The winning file supplies the entire workspace config: precedence is first-file-wins, NOT per-field merging, so a `pyrightconfig.json` that omits `analysisMode` resolves to the default even if `pyproject.toml` sets one (mirroring [pyright's own whole-file precedence](https://microsoft.github.io/pyright/#/configuration) of `pyrightconfig.json` over `pyproject.toml`). These pyright files are **compatibility inputs to this analysis tier only**, parsed into the one shared model — rule and tag entries live solely in `pyproject.toml` `[tool.basilisk]` ([CHKARCH-CONFIG-FILE](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CONFIG-FILE)), which the server watches live ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)); `pyrightconfig.json` is read at startup and registry rebuilds, and is not watched.
 3. Hard default: `wholeModule`.
 
 Tier 1 and the fallback are resolved by `resolve_analysis_mode` (`crates/basilisk-lsp/src/workspace_analysis.rs`); the file tier is `load_config` (`crates/basilisk-lsp/src/config.rs`), which the CLI shares.
+
+To be explicit about liveness ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)): the analysis **mode** is resolved when the index is (re)built — at `initialize`, on a `didChangeConfiguration` that supplies a mode, and on workspace-folder changes — it is a session-scoped structural choice, not hot-swapped per keystroke. **Rule** configuration, include/exclude, and the import environment are fully live: the server's own watcher refreshes them through the shared refresh tail without any client watcher support and without a restart.
 
 This tiering governs the **analysis-level** workspace config (mode, formatter,
 etc.) only. **Rule** config (severities, per-module/per-path overrides) is
@@ -120,6 +122,11 @@ A `FileEntry` is invalidated when:
 - Its on-disk content changes (file-watcher event) AND `source_hash` changes
 - The editor sends a `didChange` notification for it
 - A file it depends on changes in a way that affects its output (`crossModule` only)
+- The root configuration changes — config-editor apply, edit to an open config
+  buffer, or a disk change seen by the server-owned watcher: the shared refresh
+  tail replaces the root config, invalidates the per-directory config memo, and
+  rechecks every indexed file
+  ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG))
 
 When invalidated, the file is re-analysed **through the salsa engine**
 ([CHKARCH-INCREMENTAL-SALSA]), which re-runs only the queries whose inputs
@@ -273,6 +280,8 @@ Incremental edits are applied to the in-memory buffer, then parse → resolve �
 ### Import resolution on incremental re-check {#ANALYSIS-INCR-IMPORTS}
 
 The `resolve` step of any incremental re-check (`didOpen`, `didChange`, disk reload, dependent invalidation) MUST resolve third-party and workspace imports against the **same** `ImportSearchPaths` (venv site-packages, workspace members, stub paths, uv registry) the full scan used. The full scan builds and caches these on the workspace index; incremental re-checks reuse the cached value (site-packages discovery may touch the filesystem or spawn a subprocess and MUST NOT run per keystroke).
+
+The cached `ImportSearchPaths` are a **derived config cache**: they are built from configuration (`stub-paths`, `typeshed-path`, venv/uv state), so every observed change to a watched configuration or environment source rebuilds them before the recheck runs — via the server-owned watcher or a client watcher event, whichever fires first ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG), [LSPUV-WATCHERS](LSP-UV-INTEGRATION-SPEC.md#LSPUV-WATCHERS)). "Cached" means reused across keystrokes, never past a configuration change.
 
 Otherwise the syntactic resolver marks every import `Unresolved`, resurrecting false `imports_unresolved` for packages that resolve cleanly on the CLI and at startup. The diagnostics an incremental re-check **publishes** MUST reflect import resolution — not just the cached symbol table used by navigation.
 

--- a/docs/specs/LSP-ARCHITECTURE-SPEC.md
+++ b/docs/specs/LSP-ARCHITECTURE-SPEC.md
@@ -54,6 +54,15 @@ Client `didChangeWatchedFiles` events are only a latency optimization; both path
 one per-source disk baseline so a change refreshes exactly once
 (E2E: `tests/lsp/ws_test_configuration_watch.rs`).
 
+The refreshed in-memory root config is **authoritative over disk**: an applied
+editor-UI change or an open, unsaved config buffer decides even while the root's
+on-disk file still holds older content. Per-file config discovery therefore never
+re-reads a root's own config file — inside a root, the discovered ancestor chain is
+bounded to directories strictly below it (`workspace.rs` `config_for_file`,
+`load_basilisk_config_below`); only nested child configs come from disk. Re-merging
+the root's disk file over the in-memory config would silently resurrect stale state
+between the apply and the client's write reaching disk.
+
 Two tiers, stated once: **project configuration** (the watched files above) defines
 semantics and is fully live. **Editor session settings** (`initializationOptions` /
 `workspace/didChangeConfiguration` — formatter selection, analysis-mode override, inlay

--- a/docs/specs/LSP-ARCHITECTURE-SPEC.md
+++ b/docs/specs/LSP-ARCHITECTURE-SPEC.md
@@ -38,6 +38,29 @@ The stable shared surface includes the executable and Python paths, analysis mod
 typeshed paths, formatter selection, inlay-hint switches, debugger settings, and the uv,
 test, profiling, and memory namespaces. Detailed contracts live in their feature specs.
 
+There is ONE project configuration
+([CHKARCH-CONFIG-MODEL](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CONFIG-MODEL)), shared by
+every surface and identical across IDEs: the CLI reads it fresh on every run; the LSP
+watches it live; any future server surface (e.g. MCP) MUST consume the same model. The
+LSP watches each root's active source itself, along with the `uv.lock` and
+`.python-version` environment sources (`configuration_editor/watch.rs`,
+`CONFIG_WATCH_POLL_MS`) — it MUST NOT depend on client file watchers (Zed has none).
+Every change — editor-UI apply, open-buffer edit, or external disk edit/create/delete —
+runs one shared refresh tail (`configuration_editor/transaction.rs`): reload the
+effective document, update root config **and invalidate every derived config cache**,
+recheck, republish, push `basilisk/configurationChanged`. The server pushes; clients
+never poll; no configuration change ever requires a restart; the UI is never left stale.
+Client `didChangeWatchedFiles` events are only a latency optimization; both paths share
+one per-source disk baseline so a change refreshes exactly once
+(E2E: `tests/lsp/ws_test_configuration_watch.rs`).
+
+Two tiers, stated once: **project configuration** (the watched files above) defines
+semantics and is fully live. **Editor session settings** (`initializationOptions` /
+`workspace/didChangeConfiguration` — formatter selection, analysis-mode override, inlay
+hints, the analyze/enabled toggles) are per-user ergonomics delivered by the client;
+they never define project semantics and their capability advertisements are fixed at
+`initialize` unless a feature spec says otherwise.
+
 ## Diagnostic scope {#LSPARCH-DIAGNOSTIC-SCOPE}
 
 The LSP publishes the **union** of both command scopes — every `pep`-tagged
@@ -112,7 +135,7 @@ patch, and returns normalized changes plus full-root diagnostic impact. Apply
 accepts only that preview and its unchanged root/base revision, asks the client
 to perform one `WorkspaceEdit`, then reloads, rechecks, republishes, and sends
 `basilisk/configurationChanged`. External config-file changes use the same
-refresh tail.
+refresh tail ([LSPARCH-CONFIG](#LSPARCH-CONFIG)).
 
 Rule and tag entries are stored in `pyproject.toml` (`[tool.basilisk]`) config
 files; the nearest folder table that decides a rule wins

--- a/docs/specs/LSP-CONFIGURATION-EDITOR-SPEC.md
+++ b/docs/specs/LSP-CONFIGURATION-EDITOR-SPEC.md
@@ -31,13 +31,13 @@ A mutation is `SetRule`, `RemoveRule`, `SetTag`, or `RemoveTag` — nothing else
 
 Snapshot, preview, and occurrence inventory cover the complete selected root, even when analysis is configured to publish only open files. Open buffers stay authoritative; eligible closed files are loaded from disk into the server index without publishing additional diagnostics.
 
-The legacy `basilisk.disableRule` command writes an explicit `disabled` rule entry through the same validated, root-aware mutation service, and is rejected for `pep`-tagged rules. Active configuration watchers run the shared refresh tail and emit the changed notification.
+The `basilisk.disableRule` command writes an explicit `disabled` rule entry through the same validated, root-aware mutation service, and is rejected for `pep`-tagged rules. Configuration watching is server-owned ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)).
 
 Unknown roots, rule codes, tags, severities, and selectors, pep-disable requests, stale revisions, malformed configuration, expired previews, and client-rejected edits are request errors ([LSPARCH-CONFIG-EDITOR-ERRORS](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG-EDITOR-ERRORS)).
 
 ## Wire model {#CONFIGEDITOR-MODEL}
 
-The editor protocol's design source is [`models/configuration_editor.td`](../../models/configuration_editor.td). It builds on the core configuration model in [`models/configuration.td`](../../models/configuration.td) ([CHKARCH-CONFIG-MODEL](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CONFIG-MODEL)) — `RuleCode`, `RuleTag`, `RuleSeverity` — and **MUST NOT add anything to it**: the two models are separate files precisely so editor machinery can never contaminate the config model. Language DTOs are regenerated from the two files together; an automated drift check remains open.
+The editor protocol's design source is [`models/configuration_editor.td`](../../models/configuration_editor.td). It builds on the core configuration model in [`models/configuration.td`](../../models/configuration.td) ([CHKARCH-CONFIG-MODEL](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CONFIG-MODEL)) — `RuleCode`, `RuleTag`, `RuleSeverity` — and **MUST NOT add anything to it**: the two models are separate files precisely so editor machinery can never contaminate the config model. Language DTOs are regenerated from the two files together.
 
 The protocol is deliberately small:
 
@@ -60,20 +60,11 @@ Closed-source apply sends a whole-document `WorkspaceEdit`, then keeps a root-sc
 
 Clients synchronize candidate `pyproject.toml` documents in addition to Python. The LSP accepts both the root-level document and nested folder-config documents into its configuration state — nested candidates participate as folder overrides ([CHKARCH-CONFIG-MODEL](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-CONFIG-MODEL)) and are never analysed as Python. `didOpen`, incremental `didChange`, `didSave`, and `didClose` keep that state aligned with the editor.
 
-When the active source is open, its in-memory text is authoritative for snapshot, preview, validation, and apply, even if the disk source is malformed. Apply rechecks the content revision and emits a `TextDocumentEdit` carrying the current LSP document version. A processed content change fails the revision check; a change racing the client edit fails the versioned workspace edit. A short-lived pending projection bridges successful `workspace/applyEdit` and its following `didChange` without changing the base text used for incremental edits. Closing the buffer removes the projection and restores disk authority.
+When the active source is open, its in-memory text is authoritative for snapshot, preview, validation, and apply, even if the disk source is malformed. Apply rechecks the content revision and emits a `TextDocumentEdit` carrying the current LSP document version. A processed content change fails the revision check; a change racing the client edit fails the versioned workspace edit. A short-lived pending projection bridges successful `workspace/applyEdit` and its following `didChange` without changing the base text used for incremental edits. Closing the buffer removes the projection, restores disk authority, and runs the shared refresh tail from the on-disk content ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)): discarding unsaved edits changes the effective configuration without touching disk, so no watcher fires — the close itself triggers the refresh.
 
 ## Suppression diagnostics {#CONFIGEDITOR-SUPPRESSIONS}
 
-The suppression-audit family consists of four ordinary analyze-scope rules — `check` never emits them, and the standard seed's `"basilisk" = "error"` tag entry turns them on ([LSPARCH-CONFIG-SEEDING](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG-SEEDING)):
-
-| Rule | Meaning |
-|---|---|
-| `BSK-0060` | Active code-specific directive |
-| `BSK-0061` | Active blanket directive |
-| `BSK-0062` | Unused directive |
-| `BSK-0063` | Malformed, unknown, conflicting, or unpaired directive |
-
-Audit diagnostics are emitted after ordinary inline suppression is applied, so a directive cannot hide its own audit. Malformed or misplaced directives are audited but never applied to ordinary diagnostics. All four rules carry `basilisk` and `suppressions` tags and participate in tag facets, occurrence pagination, and preview/apply like any rule.
+The four suppression-audit rules (`BSK-0060`–`BSK-0063`) are ordinary analyze-scope rules whose classification, emission order, and precedence are defined in [CHKARCH-STRICTNESS-SUPPRESSION-DIAGNOSTICS](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-STRICTNESS-SUPPRESSION-DIAGNOSTICS); the standard seed turns them on ([LSPARCH-CONFIG-SEEDING](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG-SEEDING)). In the editor they behave like any rule: they carry the `basilisk` and `suppressions` tags and participate in tag facets, occurrence pagination, and preview/apply.
 
 ## VS Code experience {#CONFIGEDITOR-VSIX-EXPERIENCE}
 
@@ -89,18 +80,8 @@ The webview uses theme tokens, text-labelled severities, keyboard controls, high
 
 Automated tests cover the CSP/data boundary, intent decoding, semantic labels, responsive/reduced-motion styles, stale async result rejection, singleton message binding, capability gating, and typed routing. Recorded cross-platform keyboard, screen-reader, zoom, CSP, and injection audits remain release gates.
 
-## Acceptance and removals {#CONFIGEDITOR-ACCEPTANCE}
+## Acceptance {#CONFIGEDITOR-ACCEPTANCE}
 
-The v1 acceptance surface is: the four LSP operations over the core configuration model (rule entries + tag entries, pep-disable rejected), the thin tag-first VS Code client, and unsaved-buffer/apply-race safety. The partition, seeding, and diagnostic scope are accepted where they are specified ([CHKARCH-COMMANDS](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-COMMANDS), [LSPARCH-CONFIG-SEEDING](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG-SEEDING), [LSPARCH-DIAGNOSTIC-SCOPE](LSP-ARCHITECTURE-SPEC.md#LSPARCH-DIAGNOSTIC-SCOPE)).
+The acceptance surface is: the four LSP operations over the core configuration model (rule entries + tag entries, pep-disable rejected), the thin tag-first VS Code client, and unsaved-buffer/apply-race safety. The partition, seeding, and diagnostic scope are accepted where they are specified ([CHKARCH-COMMANDS](CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-COMMANDS), [LSPARCH-CONFIG-SEEDING](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG-SEEDING), [LSPARCH-DIAGNOSTIC-SCOPE](LSP-ARCHITECTURE-SPEC.md#LSPARCH-DIAGNOSTIC-SCOPE)).
 
-**Removed from this contract** (implementations still carrying them are legacy to remove):
-
-- the fused single model file — the config model lives in `models/configuration.td`, the editor wire protocol in `models/configuration_editor.td`, and the latter never contaminates the former;
-- selector-based mutations, `Inherit`/`Native` intents, `defaultSeverity`, `defaultEnabled`, and every notion of a rule's "native" severity;
-- presets (`ConfigurationPreset`) and the strict-first preset workflow — the two-line seed replaces them;
-- glob path overrides (`MutationScope::Path`, `PathOverrideState`, path-precedence scoring) and per-module overrides — folder configs replace them;
-- per-file adoption in the editor contract (`adoption` provenance, adoption counts, debt summary);
-- fixability selectors (`CurrentViolations`, `SafeFixable`, `WithoutSafeFix`) and per-occurrence fix-safety metadata — mass fixes remain a standalone command ([AUTOFIX](LSP-MASS-AUTOFIX-SPEC.md#AUTOFIX));
-- `ConfigurationFormat` (including the deprecated `BasiliskJson` wire variant), shadowed-source reporting, and `ConfigurationProblem` — malformed configuration is a structured request error.
-
-Neovim/Zed clients and the generated-DTO drift check remain non-blocking follow-up work.
+The contract deliberately excludes — and tests assert the absence of — selector-based mutations, `Inherit`/`Native` intents, native/default severities, presets, glob path and per-module overrides (folder configs cover scoped grading), per-file adoption state, fixability selectors and per-occurrence fix-safety metadata (mass fixes are the standalone [AUTOFIX](LSP-MASS-AUTOFIX-SPEC.md#AUTOFIX) command), configuration-format enums, shadowed-source reporting, and problem lists (malformed configuration is a structured request error).

--- a/docs/specs/LSP-FORMATTING-SPEC.md
+++ b/docs/specs/LSP-FORMATTING-SPEC.md
@@ -8,12 +8,12 @@ Design principle (per [LSPARCH](LSP-ARCHITECTURE-SPEC.md#LSPARCH)): the LSP owns
 
 ## Decision: everything in the binary, no `ruff` subprocess {#LSPFMT-DECISION}
 
-Formatting and import hygiene are **self-contained in the `basilisk` binary**. The external `ruff` CLI is **jettisoned** — it is never spawned. Two independent mechanisms replace it:
+Formatting and import hygiene are **self-contained in the `basilisk` binary**. The external `ruff` CLI is never spawned. Two independent mechanisms:
 
-| Concern | Old (removed) | New |
-|---|---|---|
-| Formatting | spawn `ruff format` | link the `ruff_python_formatter` crate, call it in-process ([LSPFMT-ENGINE]) |
-| Import hygiene | spawn `ruff check --select I/F403/E401 --fix` | native AST fixers in the binary ([LSPFMT-IMPORTS]) |
+| Concern | Mechanism |
+|---|---|
+| Formatting | the `ruff_python_formatter` crate, linked and called in-process ([LSPFMT-ENGINE]) |
+| Import hygiene | native AST fixers in the binary ([LSPFMT-IMPORTS]) |
 
 Rationale — one engine in one binary is the only design uniform across all four consumers, removes the PATH/bundle/silent-no-op failure mode, and eliminates version skew between "the ruff that parses" and "the ruff that formats". The CLI-bundle and VS-Code-extension-dependency approaches were rejected because each serves at most one editor and splits ownership away from the LSP.
 
@@ -43,7 +43,7 @@ Each release's notes MUST enumerate, from a single generated source (not hand-ty
 
 ## Configuration {#LSPFMT-CONFIG}
 
-One new setting replaces the two removed `basilisk.ruff.*` settings (there is no `ruff` binary, so `executablePath` is meaningless):
+One setting selects the formatter engine (there is no `ruff` binary, so no executable path exists to configure):
 
 | Setting | Type | Default | Description |
 |---|---|---|---|
@@ -63,7 +63,7 @@ The server advertises formatting as LSP capabilities, so all four consumers get 
 - `documentRangeFormattingProvider` — Format Selection (shares the embedded engine; Ruff widens the selection to whole logical lines).
 - `documentOnTypeFormattingProvider` — format-as-you-type (future, optional).
 
-All are attributed to the single identity **"Basilisk"** (`serverInfo.name`); VS Code shows the extension `displayName`, Zed/Neovim show the server id. There is no per-provider display name in LSP or VS Code — the Ruff engine is disclosed via [LSPFMT-PROVENANCE], never a picker label. When `basilisk.formatter` is `"none"`, none of these are advertised.
+All are attributed to the single identity **"Basilisk"** (`serverInfo.name`); VS Code shows the extension `displayName`, Zed/Neovim show the server id. There is no per-provider display name in LSP or VS Code — the Ruff engine is disclosed via [LSPFMT-PROVENANCE], never a picker label. When `basilisk.formatter` is `"none"`, none of these are advertised. Formatter *selection* is an editor session setting resolved at `initialize` — capability advertisement is per-session, deliberately outside the live-watched project configuration ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)). Formatter *style* (`[tool.ruff]`) is re-read from `pyproject.toml` on every format request, so style edits apply live.
 
 ## Native import hygiene {#LSPFMT-IMPORTS}
 

--- a/docs/specs/LSP-MASS-AUTOFIX-SPEC.md
+++ b/docs/specs/LSP-MASS-AUTOFIX-SPEC.md
@@ -119,6 +119,11 @@ reviewable operations, not one atomic command.
 ### VS Code surface {#AUTOFIX-ADOPTION-VSCODE}
 
 The server advertises Adopt File, Adopt Workspace, and Un-adopt File. The
-activity panel derives adoption state from the config files themselves.
+activity panel derives adoption state from the server's effective
+configuration — the config files remain the only source of truth, with no
+sidecar state. The panel never reads or polls config files itself: adoption
+writes land in `pyproject.toml`, the server-owned watcher picks them up, and
+the shared refresh tail's pushed updates re-render the panel
+([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)).
 Adoption is not part of the configuration-editor contract
 ([CONFIGEDITOR-ACCEPTANCE](LSP-CONFIGURATION-EDITOR-SPEC.md#CONFIGEDITOR-ACCEPTANCE)).

--- a/docs/specs/LSP-UV-INTEGRATION-SPEC.md
+++ b/docs/specs/LSP-UV-INTEGRATION-SPEC.md
@@ -57,7 +57,12 @@ site-packages to discover import roots, so unmapped multi-root distributions may
 ### Hot reload {#LSPUV-LOCK-HOT-RELOAD}
 
 Relevant file changes and successful uv commands rebuild the full registry and recheck the
-workspace. There is no package-level diff path.
+workspace. There is no package-level diff path. Observation is server-owned: the LSP's own
+watcher covers each root's `pyproject.toml`, `uv.lock`, and `.python-version`
+([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)), so hot reload works
+identically on clients with no file watchers (Zed); client `didChangeWatchedFiles` events
+are only a latency optimization, deduplicated through the shared per-source disk baseline
+so one change rebuilds exactly once.
 
 ## Target Python version {#LSPUV-PYTHON-VERSION}
 
@@ -152,5 +157,12 @@ server path. Wiring these settings is tracked by the conformance-audit plan.
 
 ## Watchers {#LSPUV-WATCHERS}
 
-The server refresh path watches changes to `uv.lock`, `pyproject.toml`, and
-`.python-version`. `.venv/pyvenv.cfg` participates in startup detection but is not watched.
+The server watches `uv.lock`, `pyproject.toml`, and `.python-version` at each workspace
+root **itself** — the server-owned poll in `configuration_editor/watch.rs`
+([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)) — and additionally registers
+client `**/uv.lock`, `**/.python-version`, and `**/pyproject.toml` watchers as a latency
+optimization that also covers nested workspace-member files. A `.python-version` change
+reloads root configs (target version); `uv.lock` and `pyproject.toml` changes rebuild the
+package registry and import search paths; every path ends in one recheck. Both observers
+share one per-source disk baseline, so a change refreshes exactly once.
+`.venv/pyvenv.cfg` participates in startup detection but is not watched.

--- a/docs/specs/NEOVIM-SPEC.md
+++ b/docs/specs/NEOVIM-SPEC.md
@@ -75,7 +75,7 @@ vim.lsp.config('basilisk', {
   root_markers = { 'pyproject.toml', 'setup.py', 'setup.cfg', '.git' },
   settings = {
     basilisk = {
-      -- All settings from LSP-ARCHITECTURE-SPEC.md "Shared Configuration Settings"
+      -- All settings from LSP-ARCHITECTURE-SPEC.md § Shared configuration [LSPARCH-CONFIG]
       python = config.python,
       analysisMode = config.analysis_mode,
       inlayHints = {
@@ -91,6 +91,16 @@ vim.lsp.config('basilisk', {
 
 vim.lsp.enable('basilisk')
 ```
+
+Only Python buffers attach — unlike the VSIX, whose `documentSelector` includes
+`**/pyproject.toml`
+([VSIX-LSP-CLIENT-CONFIGURATION](VSIX-SPEC.md#VSIX-LSP-CLIENT-CONFIGURATION)) — so the
+open-config-buffer authority path
+([CONFIGEDITOR-SOURCES-OPEN-BUFFER](LSP-CONFIGURATION-EDITOR-SPEC.md#CONFIGEDITOR-SOURCES-OPEN-BUFFER))
+does not apply in Neovim. Configuration reactivity is unaffected: the server watches the
+config sources itself and pushes refreshed diagnostics on every saved change — same
+behaviour as every other IDE, no client watcher needed
+([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)).
 
 ### Neovim API Mappings for LSP Features {#NVIM-LSP-CLIENT-CONFIGURATION-API-MAPPINGS}
 

--- a/docs/specs/VSIX-SPEC.md
+++ b/docs/specs/VSIX-SPEC.md
@@ -128,7 +128,11 @@ through the LSP snapshot/transaction API.
 Snapshot/loading/error/revision state lives in the extension's single Signals
 store (`src/store.ts`), with explicit actions; no mutable state lives in the
 panel host or hidden DOM. On reveal, the panel refetches authoritative LSP state
-instead of retaining a stale background document.
+instead of retaining a stale background document. While visible, it refreshes on
+the server's `basilisk/configurationChanged` push — the server watches every
+configuration source itself and pushes after every change (editor apply,
+open-buffer edit, external disk edit), so the panel never polls and is never
+left stale ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)).
 
 ### Hosting and visual contract {#VSIX-CONFIGURATION-EDITOR-HOST}
 

--- a/docs/specs/ZED-SPEC.md
+++ b/docs/specs/ZED-SPEC.md
@@ -23,7 +23,7 @@ Zed extensions are Rust compiled to WASM with a deliberately narrow API:
 | Custom commands | **No** | Only slash commands in AI context |
 | Status bar items | **No** | Not available |
 | Custom settings schema | **No** | Read-only access to Zed settings |
-| File watchers | **No** | Not available |
+| File watchers | **No** | Not available — config watching is server-owned ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)) |
 | Terminal control | **No** | Not available |
 
 All intelligence flows through LSP and DAP — no client-side tricks. See [LSPARCH-CMDREG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CMDREG): the server advertises all commands, clients never pre-register them.
@@ -383,7 +383,8 @@ VS Code features with no Zed equivalent:
 | "Install debugpy" button | Notification action | Not available | Error message tells user to `pip install debugpy` |
 | Webview flamegraph | WebviewPanel | Not available | Open speedscope in browser |
 | Inline profiling heat map | TextEditorDecorationType | Not available | LSP hint diagnostics |
-| Custom settings UI | contributes.configuration | Not available | Manual settings.json |
+| Custom settings UI (editor settings) | contributes.configuration | Not available | Manual settings.json |
+| Configuration editor (project rules) | Webview ([LSPARCH-CONFIG-EDITOR](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG-EDITOR)) | Not available (no webviews) | Edit `pyproject.toml` `[tool.basilisk]` directly — the server-owned watcher applies it live: recheck, republish, `basilisk/configurationChanged`, no restart ([LSPARCH-CONFIG](LSP-ARCHITECTURE-SPEC.md#LSPARCH-CONFIG)) |
 | Auto-restart on crash | Client-side logic | Not available | Zed handles LSP restart natively |
 
 The LSP produces all underlying data; only visualization differs.

--- a/scripts/gen_release_notes.py
+++ b/scripts/gen_release_notes.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Generate the release-notes component block. Implements [LSPFMT-RELEASE-NOTES].
+
+Usage: gen_release_notes.py BASILISK_BINARY RELEASE_VERSION [MANIFEST]
+
+Enumerates every shipwright.json component plus the embedded Ruff formatter
+version, read from the actual release binary — generated, never hand-typed,
+so the notes cannot claim different formatter bytes from the build
+(docs/specs/LSP-FORMATTING-SPEC.md#LSPFMT-RELEASE-NOTES).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def embedded_ruff_version(binary: str) -> str:
+    """The `Ruff formatter: X` version the binary itself reports."""
+    out = subprocess.run(
+        [binary, "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    ).stdout
+    match = re.search(r"^Ruff formatter: (\S+)$", out, re.MULTILINE)
+    if match is None:
+        msg = "binary --version did not report an embedded Ruff formatter line"
+        raise RuntimeError(msg)
+    return match.group(1)
+
+
+def component_rows(manifest: dict, release_version: str) -> list[str]:
+    """One table row per shipwright.json component."""
+    rows: list[str] = []
+    for component in manifest["components"]:
+        declared = component.get("expectedVersion", "")
+        version = (
+            release_version if declared == "${PRODUCT_VERSION}" else (declared or "—")
+        )
+        rows.append(f"| `{component['id']}` | {component['kind']} | {version} |")
+    return rows
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    binary, release_version = argv[1], argv[2]
+    manifest_path = (
+        Path(argv[3])
+        if len(argv) > 3
+        else Path(__file__).resolve().parent.parent / "shipwright.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    lines = [
+        "## Components",
+        "",
+        "| Component | Kind | Version |",
+        "|---|---|---|",
+        *component_rows(manifest, release_version),
+        "",
+        f"Embedded Ruff formatter: `{embedded_ruff_version(binary)}`",
+    ]
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/website/src/docs/formatting.md
+++ b/website/src/docs/formatting.md
@@ -1,0 +1,79 @@
+---
+layout: layouts/docs.njk
+title: "Python Formatting & Import Hygiene — Built Into Basilisk"
+description: "Basilisk embeds the Ruff formatter in the binary — format from your editor or with basilisk format, no ruff install needed — plus native import organizing."
+keywords: basilisk, python formatter, ruff formatter, format on save, organize imports, basilisk format
+date: 2026-07-16
+dateModified: 2026-07-16
+author: The Basilisk Project
+eleventyNavigation:
+  key: Formatting
+  order: 7.5
+---
+
+# Formatting & Import Hygiene
+
+Basilisk formats Python **without any external tool**. The formatter is the
+[Ruff formatter](https://docs.astral.sh/ruff/formatter/), compiled directly
+into the `basilisk` binary — no `ruff` installation, no `PATH` lookup, no
+subprocess. Output is a pure passthrough of Ruff's formatter: for the same
+input and configuration, Basilisk produces the same bytes your own
+`ruff format` would. The style is Black-compatible, with
+[Ruff's documented deviations](https://docs.astral.sh/ruff/formatter/black/).
+
+Run `basilisk --version` to see exactly which Ruff formatter version is
+embedded in your binary.
+
+## In your editor
+
+Formatting ships as standard LSP capabilities, so every editor gets it from
+the same server:
+
+- **VS Code / Cursor** — Format Document, Format Selection, and format on
+  save, with Basilisk as the formatter for Python files.
+- **Zed** — set `"formatter": "language_server"` for Python.
+- **Neovim** — `vim.lsp.buf.format()` (see `:h basilisk-formatting`).
+
+## On the command line
+
+```bash
+basilisk format             # format the current directory in place
+basilisk format src tests   # format specific paths
+basilisk format --check .   # verify only — exit 1 if anything would change
+```
+
+`--check` never writes, which makes it a drop-in CI gate. Files with syntax
+errors are refused (never rewritten), reported, and fail the run. The CLI and
+the LSP share one engine and one configuration, so their output is
+byte-identical.
+
+## Configuration
+
+Style options are read from the same `pyproject.toml` sections Ruff uses —
+see the [Ruff formatter settings](https://docs.astral.sh/ruff/settings/#format)
+for what each does:
+
+```toml
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.format]
+quote-style = "single"
+indent-style = "space"
+skip-magic-trailing-comma = false
+```
+
+To turn formatting off, set the editor setting `basilisk.formatter` to
+`"none"` — the server stops advertising formatting and `basilisk format`
+becomes a no-op.
+
+## Import hygiene
+
+Import cleanup is **Basilisk-native** — implemented on the same AST the
+checker uses, not delegated to Ruff — and is always available as code
+actions, independent of the formatter setting:
+
+- **Organize imports** — sort and group imports (isort semantics).
+- **Expand wildcard imports** — replace `from m import *` with the names you
+  actually use.
+- **Split multiple imports** — one `import` statement per line.


### PR DESCRIPTION
## TLDR
Makes configuration fully reactive — the LSP watches every root's config server-side and re-checks/republishes on any change (file edit or config-editor UI), with the in-memory root config authoritative over stale disk state — and adds `basilisk format` plus generated release-notes provenance.

## What Was Added?
- **Server-side config watcher** (`crates/basilisk-lsp/src/configuration_editor/watch.rs`): 250 ms poll of each root's `pyproject.toml`, `uv.lock`, and `.python-version` with shared per-source content baselines, so external edits are picked up even with no client file watcher. Every change runs one shared refresh tail: reload effective document → `set_root_config` (invalidates the per-directory config memo) → re-resolve imports → re-check → republish diagnostics → push `basilisk/configurationChanged`.
- **Bounded config discovery** (`basilisk_config::load_basilisk_config_below`): per-file discovery inside a root now walks only directories strictly *below* the owning root, so the root's own config file is never re-read from disk — the in-memory (applied/open-buffer) config is authoritative.
- **`basilisk format [paths] [--check]`** (`crates/basilisk-cli/src/format.rs`): the embedded Ruff formatter as a CLI command — same engine and `[tool.ruff]`/`[tool.ruff.format]` style source as LSP formatting, byte-identical output, no `ruff` executable involved.
- **Generated release-notes component block** (`scripts/gen_release_notes.py`, wired into `release.yml`): enumerates every `shipwright.json` component plus the embedded Ruff formatter version read from the actual release binary, appended to the auto-generated notes.
- Website `/docs/formatting/` page and `:h basilisk-formatting` Neovim help section.
- `basilisk.nvim/tests/lsp/client_modules_spec.lua`: 8 client-local tests (config validate/resolve branches, `tab_tracking.setup` in/out of `openFilesOnly`, version-gated `codelens.activate`) — raises enforced Lua coverage above its threshold with real assertions.

## What Was Changed or Deleted?
- `WorkspaceIndex::config_for_file` no longer merges the root's on-disk config over the in-memory root config (that silently resurrected stale state between a config-editor apply and the client's write reaching disk).
- The config-editor apply path now runs the full refresh tail *before* the apply response returns, so diagnostics and `basilisk/configurationChanged` are pushed immediately.
- Client `didChangeWatchedFiles` config events and the server-side poll dedupe through shared content baselines — no double re-checks.
- Coverage ratchets tightened: `basilisk-lsp` 83 → 84, `basilisk-config` 96 → 97 (measured 85 / 98). The nvim Lua threshold (44) is unchanged — coverage was raised to clear it, never the reverse.

## How Do The Automated Tests Prove It Works?
- `disk_config_edit_without_client_watcher_republishes_and_notifies` (ws e2e): rewrites `pyproject.toml` on disk with **no** LSP message and asserts BSK-0001 is republished at the new severity plus `basilisk/configurationChanged`. Mutation-checked: killing the watcher or the memo invalidation each makes it fail with the layer-specific assertion.
- `ui_apply_republishes_diagnostics_and_notifies` (ws e2e): full snapshot → preview → apply round trip, asserting the republish and notification arrive before/with the apply response. Born red against the pre-fix code (stale-disk resurrection), green after.
- `set_root_config_is_authoritative_over_stale_disk_config` (workspace unit test): applied in-memory config wins over conflicting on-disk content; fails if the unbounded ancestor walk is reinstated.
- `e2e_format.rs`: real-binary `basilisk format` tests run with an **empty `PATH`** — write and `--check` modes, multiple paths, parse-failure refusal, `[tool.ruff]` style options, `formatter = "none"` disablement, and byte-parity with LSP formatting.
- `e2e_release_notes_block.rs`: runs `gen_release_notes.py` against the freshly built binary and proves the block enumerates every manifest component and reports exactly the binary's embedded Ruff version.
- `basilisk.nvim` `ui_spec.lua` "format works via real LSP": `vim.lsp.buf.format` against the real binary with no external ruff.
- Full local CI parity run: lint (clippy/eslint/deslop/audit), Rust suite with coverage thresholds, conformance gate **100% / 0 false positives** via the freshly cloned upstream harness, Zed (wasm + mirror render), VS Code e2e, Neovim e2e, Shipwright version contracts, website build + Playwright smoke.

## Spec / Doc Changes
- `LSP-ARCHITECTURE-SPEC.md` `[LSPARCH-CONFIG]`: server-owned config watching is normative; the refreshed in-memory root config is **authoritative over disk**; per-file discovery never re-reads a root's own config file.
- `CHECKER-ARCHITECTURE-SPEC.md` `[CHKARCH-CONFIG-DISCOVERY]`: LSP per-file config = owning root's in-memory config merged with the chain strictly below the root; `[CHKARCH-CLI-COMMANDS]` gains `basilisk format`.
- `LSP-FORMATTING-SPEC.md` / `LSP-FORMATTING-PLAN.md`: release-notes provenance, CLI, and Neovim client wiring marked done with their test anchors.
- Editor specs (VSIX/NEOVIM/ZED/others) re-pointed at the shared architecture sections; website formatting docs page added.

## Breaking Changes
- [x] None

Note: the server-side file watcher overlaps `lspkit-live::watcher::FileWatcher` territory (see CLAUDE.md migration table) — kept in-repo for now because the debounce/baseline semantics are coupled to the config refresh tail; flagging per the migration policy.
