### PR TITLE
Fix LSP CPU pinning on py.typed workspaces; tolerate version-less uv.lock packages; fix Literal comma panic

### DIFF
--- a/crates/basilisk-checker/src/exports.rs
+++ b/crates/basilisk-checker/src/exports.rs
@@ -9,7 +9,7 @@
 //! a single implementation of "what does a module export" and "which of those
 //! exports does an import bind".
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use basilisk_resolver::scope::{ExternalMethod, ExternalSymbol, ExternalSymbolKind, ImportKind};
@@ -191,27 +191,109 @@ pub fn extract_stub_exports(
     exports
 }
 
-/// Extract exported symbols from an external `.py` package that ships inline
-/// PEP 561 types (a `py.typed` marker).
+/// A parsed external (non-workspace) type-bearing module: its exports plus
+/// the re-export edges the `py.typed` chase follows.
 ///
-/// Parses and resolves the file, then reuses [`extract_exports`]. Callers MUST
-/// gate this on [`basilisk_stubs::has_py_typed_marker`] — a package without the
-/// marker has not opted in to inline type distribution, so its annotations must
-/// not be trusted. Returns an empty vec if the file cannot be read or parsed.
-/// Implements [ANALYSIS-CROSSLSP].
+/// Built by [`load_external_module`] from **one** read+parse of the on-disk
+/// file, and memoized per path by the salsa layer
+/// ([`crate::incremental::external_module`]) so a workspace scan parses each
+/// external module once — not once per workspace file per imported name,
+/// which pinned a CPU core for hours on large workspaces (GitHub #304).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ExternalModule {
+    /// The module's exported symbols.
+    pub exports: Vec<(String, ExternalSymbol)>,
+    /// Module-level `from … import` edges into sibling module files, for the
+    /// `py.typed` re-export chase. Empty for `.pyi` stubs (no chase).
+    pub reexports: Vec<ReexportEdge>,
+}
+
+/// One `from … import` edge of a `py.typed` module, pre-resolved to the
+/// sibling file it points at.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReexportEdge {
+    /// The binding names the edge re-exports, or `None` for `import *`.
+    pub names: Option<Vec<String>>,
+    /// The sibling module file the edge resolves to.
+    pub target: PathBuf,
+}
+
+/// What to load from an external import target's on-disk file.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ExternalModuleRequest {
+    /// An inline-typed (PEP 561 `py.typed`) package module. Callers MUST gate
+    /// this on [`basilisk_stubs::has_py_typed_marker`] — a package without the
+    /// marker has not opted in to inline type distribution.
+    PyTyped,
+    /// A `.pyi` stub, with the importing module name and stub provenance.
+    Stub {
+        /// The module name the import refers to (drives stub parsing).
+        module_name: String,
+        /// Where the stub came from, for honest hover provenance.
+        source: StubSource,
+    },
+}
+
+/// A shared handle to an external module's parsed view.
+pub type SharedExternalModule = std::sync::Arc<ExternalModule>;
+
+/// Load one external module's exports and re-export edges from disk.
+///
+/// This is the **uncached** producer: one read + parse + resolve per call. The
+/// salsa layer memoizes it per `(path, request)`
+/// ([`crate::incremental::external_module`]) so consumers share the work;
+/// callers outside the engine (tests) may use it directly as the
+/// `external_module` argument of [`populate_imported_symbols`]. A file that
+/// cannot be read, parsed, or resolved yields an empty module. Implements
+/// [ANALYSIS-CROSSLSP].
 #[must_use]
-pub fn extract_py_typed_exports(py_path: &Path) -> Vec<(String, ExternalSymbol)> {
+pub fn load_external_module(path: &Path, request: &ExternalModuleRequest) -> SharedExternalModule {
+    match request {
+        ExternalModuleRequest::Stub {
+            module_name,
+            source,
+        } => std::sync::Arc::new(ExternalModule {
+            exports: extract_stub_exports(path, module_name, *source),
+            reexports: Vec::new(),
+        }),
+        ExternalModuleRequest::PyTyped => std::sync::Arc::new(load_py_typed_module(path)),
+    }
+}
+
+/// Load a `py.typed` module: exports plus chase edges, from one parse.
+fn load_py_typed_module(py_path: &Path) -> ExternalModule {
     let Ok(text) = std::fs::read_to_string(py_path) else {
-        return Vec::new();
+        return ExternalModule::default();
     };
     let path_str = py_path.to_string_lossy().into_owned();
     let Ok(parsed) = basilisk_parser::parse_source(text, path_str) else {
-        return Vec::new();
+        return ExternalModule::default();
     };
     let Ok(resolved) = basilisk_resolver::resolve(&parsed) else {
-        return Vec::new();
+        return ExternalModule::default();
     };
-    extract_exports(&resolved, py_path)
+    let reexports = py_path
+        .parent()
+        .map(|dir| {
+            resolved
+                .imports
+                .iter()
+                .filter_map(|import| {
+                    let names = match import.kind {
+                        ImportKind::From => Some(Some(import.names.clone())),
+                        ImportKind::Star => Some(None),
+                        ImportKind::Plain => None,
+                    }?;
+                    let target = sibling_module_file(dir, &import.module)?;
+                    Some(ReexportEdge { names, target })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    ExternalModule {
+        exports: extract_exports(&resolved, py_path),
+        reexports,
+    }
 }
 
 /// Resolve `name` through the re-export chain of a `py.typed` module.
@@ -219,41 +301,40 @@ pub fn extract_py_typed_exports(py_path: &Path) -> Vec<(String, ExternalSymbol)>
 /// A package `__init__.py` often defines nothing itself and re-exports its
 /// public names from submodules — pydantic v2 exposes `BaseModel` only via
 /// `if TYPE_CHECKING: from .main import *` (runtime uses a lazy module
-/// `__getattr__`). When the resolved file's own definitions miss `name`,
-/// follow its module-level `from … import name` and `from … import *`
-/// statements into the sibling module file and take the symbol — with its
-/// methods — from there (GitHub #287). `visited` breaks import cycles.
-fn chase_py_typed_reexport(
+/// `__getattr__`). When the module's own exports miss `name`, follow its
+/// `from … import name` and `from … import *` edges into the sibling module
+/// and take the symbol — with its methods — from there (GitHub #287).
+/// `visited` breaks import cycles. Every module is fetched through the shared
+/// `external_module` lookup, so the chase never re-parses a file (GitHub #304).
+fn chase_py_typed_reexport<E>(
     py_path: &Path,
     name: &str,
-    external_cache: &mut HashMap<PathBuf, Vec<(String, ExternalSymbol)>>,
+    external_module: &mut E,
     visited: &mut HashSet<PathBuf>,
-) -> Option<ExternalSymbol> {
+) -> Option<ExternalSymbol>
+where
+    E: FnMut(&Path, &ExternalModuleRequest) -> SharedExternalModule,
+{
     if !visited.insert(py_path.to_path_buf()) {
         return None;
     }
-    let text = std::fs::read_to_string(py_path).ok()?;
-    let parsed =
-        basilisk_parser::parse_source(text, py_path.to_string_lossy().into_owned()).ok()?;
-    let resolved = basilisk_resolver::resolve(&parsed).ok()?;
-    let dir = py_path.parent()?;
-    resolved
-        .imports
+    let module = external_module(py_path, &ExternalModuleRequest::PyTyped);
+    module
+        .reexports
         .iter()
-        .filter(|import| match import.kind {
-            ImportKind::From => import.names.iter().any(|n| n == name),
-            ImportKind::Star => true,
-            ImportKind::Plain => false,
+        .filter(|edge| {
+            edge.names
+                .as_ref()
+                .is_none_or(|names| names.iter().any(|n| n == name))
         })
-        .filter_map(|import| sibling_module_file(dir, &import.module))
-        .find_map(|target| {
-            let direct = external_cache
-                .entry(target.clone())
-                .or_insert_with(|| extract_py_typed_exports(&target))
+        .find_map(|edge| {
+            let direct = external_module(&edge.target, &ExternalModuleRequest::PyTyped)
+                .exports
                 .iter()
                 .find(|(export_name, _)| export_name == name)
                 .map(|(_, symbol)| symbol.clone());
-            direct.or_else(|| chase_py_typed_reexport(&target, name, external_cache, visited))
+            direct
+                .or_else(|| chase_py_typed_reexport(&edge.target, name, external_module, visited))
         })
 }
 
@@ -350,9 +431,13 @@ fn stub_source_for(resolved_path: &Path, custom_typeshed: Option<&Path>) -> Stub
 /// `workspace_exports` supplies the exports of a **workspace-tracked** file
 /// (the caller decides the lookup — the salsa query resolves through the
 /// memoized [`crate::incremental::module_exports`]); imports outside the
-/// workspace fall back to on-demand parsing of external `.pyi` stubs and
-/// PEP 561 `py.typed` packages from disk. Non-`py.typed` `.py` packages are
-/// skipped — their annotations must not be trusted (PEP 561 opt-in).
+/// workspace fall back to `external_module`, the caller-supplied lookup for
+/// external `.pyi` stubs and PEP 561 `py.typed` packages. The salsa engine
+/// supplies the memoized [`crate::incremental::external_module`] query there,
+/// so external modules are parsed once per workspace — not once per importing
+/// file per name, which pinned a CPU core for hours on large workspaces
+/// (GitHub #304). Non-`py.typed` `.py` packages are skipped — their
+/// annotations must not be trusted (PEP 561 opt-in).
 ///
 /// Stale entries are cleared first so a renamed or removed export disappears
 /// from importers — without this the old name lingers and keeps suppressing its
@@ -364,17 +449,15 @@ fn stub_source_for(resolved_path: &Path, custom_typeshed: Option<&Path>) -> Stub
 /// [`StubSource::CustomTypeshed`] so hover reads `(custom typeshed)` and a
 /// `MicroPython` signature is never reported as the bundled `CPython` one
 /// ([STUBRES-CUSTOM-TYPESHED]). Pass `None` for the default bundled typeshed.
-pub fn populate_imported_symbols<'a, F>(
+pub fn populate_imported_symbols<'a, F, E>(
     resolved: &mut basilisk_resolver::ResolvedModule,
     mut workspace_exports: F,
+    mut external_module: E,
     custom_typeshed: Option<&Path>,
 ) where
     F: FnMut(&Path) -> Option<&'a [(String, ExternalSymbol)]>,
+    E: FnMut(&Path, &ExternalModuleRequest) -> SharedExternalModule,
 {
-    // External type sources (`.pyi` stubs, `py.typed` packages) are parsed on
-    // demand and cached per path so multiple imports of one module parse once.
-    let mut external_cache: HashMap<PathBuf, Vec<(String, ExternalSymbol)>> = HashMap::new();
-
     let imports = &resolved.imports;
     let imported_symbols = &mut resolved.imported_symbols;
     imported_symbols.clear();
@@ -384,9 +467,11 @@ pub fn populate_imported_symbols<'a, F>(
             continue;
         };
 
-        // Prefer workspace exports; otherwise parse an external `.pyi` stub
-        // or an inline-typed `py.typed` package (PEP 561 opt-in only).
+        // Prefer workspace exports; otherwise load the external `.pyi` stub
+        // or inline-typed `py.typed` package (PEP 561 opt-in only) through the
+        // shared lookup.
         let mut py_typed_source = false;
+        let external;
         let target_exports: &[(String, ExternalSymbol)] = if let Some(exports) =
             workspace_exports(resolved_path)
         {
@@ -395,17 +480,18 @@ pub fn populate_imported_symbols<'a, F>(
             // Classify the stub's provenance: a `.pyi` under the configured
             // custom typeshed's `stdlib/` is CustomTypeshed
             // ([STUBRES-CUSTOM-TYPESHED]); every other stub is StubPackage/Tier1.
-            let stub_source = stub_source_for(resolved_path, custom_typeshed);
-            external_cache
-                .entry(resolved_path.clone())
-                .or_insert_with(|| extract_stub_exports(resolved_path, &import.module, stub_source))
+            let request = ExternalModuleRequest::Stub {
+                module_name: import.module.clone(),
+                source: stub_source_for(resolved_path, custom_typeshed),
+            };
+            external = external_module(resolved_path, &request);
+            &external.exports
         } else if resolved_path.extension().is_some_and(|ext| ext == "py")
             && basilisk_stubs::has_py_typed_marker(resolved_path)
         {
             py_typed_source = true;
-            external_cache
-                .entry(resolved_path.clone())
-                .or_insert_with(|| extract_py_typed_exports(resolved_path))
+            external = external_module(resolved_path, &ExternalModuleRequest::PyTyped);
+            &external.exports
         } else {
             continue;
         };
@@ -415,18 +501,11 @@ pub fn populate_imported_symbols<'a, F>(
         // object — it is not a member to look up in `foo`'s exports.
         if import.kind == ImportKind::From {
             // `from foo import bar, baz` — only import the named symbols.
-            let direct: Vec<(String, Option<ExternalSymbol>)> = import
-                .names
-                .iter()
-                .map(|import_name| {
-                    let symbol = target_exports
-                        .iter()
-                        .find(|(name, _)| name == import_name)
-                        .map(|(_, symbol)| symbol.clone());
-                    (import_name.clone(), symbol)
-                })
-                .collect();
-            for (import_name, symbol) in direct {
+            for import_name in &import.names {
+                let symbol = target_exports
+                    .iter()
+                    .find(|(name, _)| name == import_name)
+                    .map(|(_, symbol)| symbol.clone());
                 // A `py.typed` package `__init__.py` may only *re-export* the
                 // name from a submodule (pydantic v2) — chase it (GitHub #287).
                 let symbol = symbol.or_else(|| {
@@ -434,15 +513,15 @@ pub fn populate_imported_symbols<'a, F>(
                         .then(|| {
                             chase_py_typed_reexport(
                                 resolved_path,
-                                &import_name,
-                                &mut external_cache,
+                                import_name,
+                                &mut external_module,
                                 &mut HashSet::new(),
                             )
                         })
                         .flatten()
                 });
                 if let Some(symbol) = symbol {
-                    let _ = imported_symbols.insert(import_name, symbol);
+                    let _ = imported_symbols.insert(import_name.clone(), symbol);
                 }
             }
         } else {

--- a/crates/basilisk-checker/src/exports.rs
+++ b/crates/basilisk-checker/src/exports.rs
@@ -333,8 +333,7 @@ where
                 .iter()
                 .find(|(export_name, _)| export_name == name)
                 .map(|(_, symbol)| symbol.clone());
-            direct
-                .or_else(|| chase_py_typed_reexport(&edge.target, name, external_module, visited))
+            direct.or_else(|| chase_py_typed_reexport(&edge.target, name, external_module, visited))
         })
 }
 
@@ -472,29 +471,28 @@ pub fn populate_imported_symbols<'a, F, E>(
         // shared lookup.
         let mut py_typed_source = false;
         let external;
-        let target_exports: &[(String, ExternalSymbol)] = if let Some(exports) =
-            workspace_exports(resolved_path)
-        {
-            exports
-        } else if resolved_path.extension().is_some_and(|ext| ext == "pyi") {
-            // Classify the stub's provenance: a `.pyi` under the configured
-            // custom typeshed's `stdlib/` is CustomTypeshed
-            // ([STUBRES-CUSTOM-TYPESHED]); every other stub is StubPackage/Tier1.
-            let request = ExternalModuleRequest::Stub {
-                module_name: import.module.clone(),
-                source: stub_source_for(resolved_path, custom_typeshed),
+        let target_exports: &[(String, ExternalSymbol)] =
+            if let Some(exports) = workspace_exports(resolved_path) {
+                exports
+            } else if resolved_path.extension().is_some_and(|ext| ext == "pyi") {
+                // Classify the stub's provenance: a `.pyi` under the configured
+                // custom typeshed's `stdlib/` is CustomTypeshed
+                // ([STUBRES-CUSTOM-TYPESHED]); every other stub is StubPackage/Tier1.
+                let request = ExternalModuleRequest::Stub {
+                    module_name: import.module.clone(),
+                    source: stub_source_for(resolved_path, custom_typeshed),
+                };
+                external = external_module(resolved_path, &request);
+                &external.exports
+            } else if resolved_path.extension().is_some_and(|ext| ext == "py")
+                && basilisk_stubs::has_py_typed_marker(resolved_path)
+            {
+                py_typed_source = true;
+                external = external_module(resolved_path, &ExternalModuleRequest::PyTyped);
+                &external.exports
+            } else {
+                continue;
             };
-            external = external_module(resolved_path, &request);
-            &external.exports
-        } else if resolved_path.extension().is_some_and(|ext| ext == "py")
-            && basilisk_stubs::has_py_typed_marker(resolved_path)
-        {
-            py_typed_source = true;
-            external = external_module(resolved_path, &ExternalModuleRequest::PyTyped);
-            &external.exports
-        } else {
-            continue;
-        };
 
         // Discriminate on `kind`, not `names.is_empty()`: a plain `import foo
         // as f` carries its alias in `names`, but the alias binds the module

--- a/crates/basilisk-checker/src/imports/apply.rs
+++ b/crates/basilisk-checker/src/imports/apply.rs
@@ -208,6 +208,6 @@ fn enrich_package_metadata(
         basilisk_uv::DepKind::Dev => PackageDepKind::Dev,
         basilisk_uv::DepKind::Transitive => PackageDepKind::Transitive,
     });
-    import.package_version = Some(info.version.clone());
+    import.package_version = info.version.clone();
     import.package_name = Some(info.name.clone());
 }

--- a/crates/basilisk-checker/src/incremental.rs
+++ b/crates/basilisk-checker/src/incremental.rs
@@ -325,11 +325,8 @@ pub fn cross_resolved_module(
                 .map(|imported| module_exports(db, *imported).0.as_slice())
         },
         |path, request| {
-            let key = ExternalModuleKey::new(
-                db,
-                path.to_string_lossy().into_owned(),
-                request.clone(),
-            );
+            let key =
+                ExternalModuleKey::new(db, path.to_string_lossy().into_owned(), request.clone());
             std::sync::Arc::clone(external_module(db, key, search_paths))
         },
         custom_typeshed,

--- a/crates/basilisk-checker/src/incremental.rs
+++ b/crates/basilisk-checker/src/incremental.rs
@@ -324,9 +324,50 @@ pub fn cross_resolved_module(
                 .get(path)
                 .map(|imported| module_exports(db, *imported).0.as_slice())
         },
+        |path, request| {
+            let key = ExternalModuleKey::new(
+                db,
+                path.to_string_lossy().into_owned(),
+                request.clone(),
+            );
+            std::sync::Arc::clone(external_module(db, key, search_paths))
+        },
         custom_typeshed,
     );
     ResolvedFile::Resolved(std::sync::Arc::new(resolved))
+}
+
+/// Interned key for one external (non-workspace) type-bearing module file:
+/// its absolute path plus what to load from it.
+#[salsa::interned(debug)]
+pub struct ExternalModuleKey<'db> {
+    /// Absolute path of the external module file.
+    #[returns(ref)]
+    pub path: String,
+    /// What to load: `py.typed` module or `.pyi` stub (with provenance).
+    #[returns(ref)]
+    pub request: crate::exports::ExternalModuleRequest,
+}
+
+/// Tracked query: the parsed view of one **external** module — its exports
+/// plus `py.typed` re-export edges — memoized per `(path, request)`.
+///
+/// This is the sharing layer that fixes GitHub #304: every importer in the
+/// workspace reads the same memo instead of re-parsing the external file, so
+/// a scan's external work is bounded by the number of external modules, not
+/// `files × imported names × package closure`. The read is untracked disk
+/// I/O, mirroring the [CHKCACHE-LIMITS](CHECKER-CACHE-SPEC.md#CHKCACHE-LIMITS)
+/// boundary; reading `search_paths.value(db)` registers the input edge, so a
+/// re-set `SearchPathsInput` (venv sync, `uv.lock` edit, config change)
+/// refreshes the memo from disk.
+#[salsa::tracked(returns(ref))]
+pub fn external_module<'db>(
+    db: &'db dyn Db,
+    key: ExternalModuleKey<'db>,
+    search_paths: SearchPathsInput,
+) -> crate::exports::SharedExternalModule {
+    let _ = search_paths.value(db);
+    crate::exports::load_external_module(std::path::Path::new(key.path(db)), key.request(db))
 }
 
 /// Tracked query: the **cross-module** diagnostics for one file — a thin

--- a/crates/basilisk-checker/src/rules/shared.rs
+++ b/crates/basilisk-checker/src/rules/shared.rs
@@ -240,7 +240,9 @@ pub(crate) fn typevar_tuple_names(typevar_calls: &[TypeVarCallInfo]) -> HashSet<
 // String splitting
 // ---------------------------------------------------------------------------
 
-/// Split `s` at every top-level comma, respecting bracket nesting.
+/// Split `s` at every top-level comma, respecting bracket nesting and string
+/// literals — a comma inside quotes (`Literal[',']`) is part of the literal
+/// value, not a separator (issue #316).
 ///
 /// Returns slices into the original string (no allocation for the parts
 /// themselves). Callers that need trimmed/owned values can chain
@@ -248,16 +250,25 @@ pub(crate) fn typevar_tuple_names(typevar_calls: &[TypeVarCallInfo]) -> HashSet<
 pub(crate) fn split_top_level_commas(s: &str) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut depth: usize = 0;
+    let mut in_string: Option<char> = None;
     let mut start = 0;
     for (idx, ch) in s.char_indices() {
-        match ch {
-            '[' | '(' | '{' => depth += 1,
-            ']' | ')' | '}' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                parts.push(&s[start..idx]);
-                start = idx + 1;
+        match in_string {
+            Some(quote) => {
+                if ch == quote {
+                    in_string = None;
+                }
             }
-            _ => {}
+            None => match ch {
+                '\'' | '"' => in_string = Some(ch),
+                '[' | '(' | '{' => depth += 1,
+                ']' | ')' | '}' => depth = depth.saturating_sub(1),
+                ',' if depth == 0 => {
+                    parts.push(&s[start..idx]);
+                    start = idx + 1;
+                }
+                _ => {}
+            },
         }
     }
     parts.push(&s[start..]);

--- a/crates/basilisk-checker/src/types_parsing.rs
+++ b/crates/basilisk-checker/src/types_parsing.rs
@@ -234,14 +234,18 @@ fn parse_single_literal(val: &str) -> InferredType {
         }
     }
 
-    if (val.starts_with('"') && val.ends_with('"'))
-        || (val.starts_with('\'') && val.ends_with('\''))
+    // Length guards keep the slices in range: a lone `'` both starts AND ends
+    // with a quote (same byte), and `val[1..0]` panics (issue #316).
+    if val.len() >= 2
+        && ((val.starts_with('"') && val.ends_with('"'))
+            || (val.starts_with('\'') && val.ends_with('\'')))
     {
         let content = &val[1..val.len() - 1];
         return InferredType::Literal(LiteralValue::Str(content.to_owned()));
     }
 
-    if (val.starts_with("b\"") || val.starts_with("b'"))
+    if val.len() >= 3
+        && (val.starts_with("b\"") || val.starts_with("b'"))
         && (val.ends_with('"') || val.ends_with('\''))
     {
         let content = &val[2..val.len() - 1];
@@ -264,20 +268,31 @@ pub(super) fn parse_key_value_args(inner: &str) -> Option<(InferredType, Inferre
     Some((key, value))
 }
 
-/// Split type parameters by top-level commas, respecting bracket nesting.
+/// Split type parameters by top-level commas, respecting bracket nesting and
+/// string literals — a comma inside quotes (`Literal[',']`) is part of the
+/// literal value, not a separator (issue #316).
 pub(super) fn split_type_params(inner: &str) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut depth = 0u32;
+    let mut in_string: Option<char> = None;
     let mut start = 0;
     for (idx, ch) in inner.char_indices() {
-        match ch {
-            '[' | '(' | '{' => depth = depth.saturating_add(1),
-            ']' | ')' | '}' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                parts.push(&inner[start..idx]);
-                start = idx + 1;
+        match in_string {
+            Some(quote) => {
+                if ch == quote {
+                    in_string = None;
+                }
             }
-            _ => {}
+            None => match ch {
+                '\'' | '"' => in_string = Some(ch),
+                '[' | '(' | '{' => depth = depth.saturating_add(1),
+                ']' | ')' | '}' => depth = depth.saturating_sub(1),
+                ',' if depth == 0 => {
+                    parts.push(&inner[start..idx]);
+                    start = idx + 1;
+                }
+                _ => {}
+            },
         }
     }
     let remainder = &inner[start..];

--- a/crates/basilisk-checker/tests/checker/types_tests.rs
+++ b/crates/basilisk-checker/tests/checker/types_tests.rs
@@ -182,6 +182,24 @@ def func(x: Literal[None]) -> None:
     Ok(())
 }
 
+// A string literal containing a comma is ONE literal value, not two:
+// `split_type_params` must not split inside quotes, and the lone `'` it
+// produced made `parse_single_literal` panic on `val[1..0]` (issue #316).
+#[test]
+fn literal_string_containing_comma_does_not_panic() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import Literal
+
+comma: Literal[','] = ','
+"#;
+    let diags = run(source)?;
+    assert!(
+        diags.is_empty(),
+        "assigning ',' to Literal[','] is valid and must produce no diagnostics, got: {diags:?}"
+    );
+    Ok(())
+}
+
 #[test]
 fn literal_bytes() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"

--- a/crates/basilisk-checker/tests/import_apply_tests.rs
+++ b/crates/basilisk-checker/tests/import_apply_tests.rs
@@ -41,7 +41,7 @@ fn make_registry() -> Arc<PackageRegistry> {
     };
     let registry_pkg = |name: &str, ver: &str, deps: Vec<LockDependency>| LockPackage {
         name: name.to_owned(),
-        version: ver.to_owned(),
+        version: Some(ver.to_owned()),
         source: Some(LockSource {
             registry: Some("https://pypi.org/simple".to_owned()),
             editable: None,
@@ -53,7 +53,7 @@ fn make_registry() -> Arc<PackageRegistry> {
     };
     let root = LockPackage {
         name: "my-project".to_owned(),
-        version: "0.1.0".to_owned(),
+        version: Some("0.1.0".to_owned()),
         source: Some(LockSource {
             registry: None,
             editable: None,

--- a/crates/basilisk-checker/tests/import_apply_tests.rs
+++ b/crates/basilisk-checker/tests/import_apply_tests.rs
@@ -411,7 +411,12 @@ fn custom_typeshed_stub_exports_carry_custom_provenance() {
 
     // WITH the custom typeshed: the stub's `uname` export is CustomTypeshed.
     let mut with_custom = resolved.clone();
-    populate_imported_symbols(&mut with_custom, no_workspace, Some(&typeshed));
+    populate_imported_symbols(
+        &mut with_custom,
+        no_workspace,
+        basilisk_checker::exports::load_external_module,
+        Some(&typeshed),
+    );
     let uname = with_custom
         .imported_symbols
         .get("uname")
@@ -426,7 +431,12 @@ fn custom_typeshed_stub_exports_carry_custom_provenance() {
     // WITHOUT the custom typeshed argument (same file on disk): a plain Tier-1
     // stub. Only the `custom_typeshed` argument decides provenance.
     let mut without_custom = resolved.clone();
-    populate_imported_symbols(&mut without_custom, no_workspace, None);
+    populate_imported_symbols(
+        &mut without_custom,
+        no_workspace,
+        basilisk_checker::exports::load_external_module,
+        None,
+    );
     assert_eq!(
         without_custom
             .imported_symbols
@@ -483,7 +493,12 @@ fn custom_typeshed_does_not_taint_user_stubs_outside_its_stdlib() {
     // Even WITH the custom typeshed configured, a stub outside its stdlib/ is a
     // plain Tier-1 stub: provenance tracks the on-disk source, not merely whether
     // a custom typeshed exists.
-    populate_imported_symbols(&mut resolved, no_workspace, Some(&typeshed));
+    populate_imported_symbols(
+        &mut resolved,
+        no_workspace,
+        basilisk_checker::exports::load_external_module,
+        Some(&typeshed),
+    );
     assert_eq!(
         resolved.imported_symbols.get("tux").unwrap().provenance,
         Some(TypeProvenance::StubTier1),

--- a/crates/basilisk-lsp/src/hover/tests.rs
+++ b/crates/basilisk-lsp/src/hover/tests.rs
@@ -112,7 +112,12 @@ fn test_hover_on_method_inherited_from_external_stub_base_shows_signature() {
         import.resolution = ImportResolution::StubPyi;
         import.resolved_path = Some(stub_path);
     }
-    basilisk_checker::exports::populate_imported_symbols(&mut resolved, |_| None, None);
+    basilisk_checker::exports::populate_imported_symbols(
+        &mut resolved,
+        |_| None,
+        basilisk_checker::exports::load_external_module,
+        None,
+    );
     assert!(
         resolved.imported_symbols.contains_key("BaseModel"),
         "precondition: the stub base class resolved"
@@ -169,7 +174,12 @@ fn test_hover_on_method_reexported_through_py_typed_package_init() {
         import.resolution = ImportResolution::SourcePy;
         import.resolved_path = Some(pkg.join("__init__.py"));
     }
-    basilisk_checker::exports::populate_imported_symbols(&mut resolved, |_| None, None);
+    basilisk_checker::exports::populate_imported_symbols(
+        &mut resolved,
+        |_| None,
+        basilisk_checker::exports::load_external_module,
+        None,
+    );
     assert!(
         resolved.imported_symbols.contains_key("BaseModel"),
         "the TYPE_CHECKING re-export in the package __init__ must surface \

--- a/crates/basilisk-lsp/tests/workspace_scan_enrichment_perf_tests.rs
+++ b/crates/basilisk-lsp/tests/workspace_scan_enrichment_perf_tests.rs
@@ -1,0 +1,164 @@
+//! Regression coverage for GitHub #304 ([ANALYSIS-INCR-IMPORTS]).
+//!
+//! The workspace scan re-parsed external `py.typed` package modules **once per
+//! workspace file per imported name**: `populate_imported_symbols`
+//! (`crates/basilisk-checker/src/exports.rs`) keeps its external-module cache
+//! local to each call, and `chase_py_typed_reexport` restarts with a fresh
+//! `visited` set per imported name while re-parsing every module it walks.
+//! On a workspace importing large PEP 561 packages (sqlalchemy, pydantic —
+//! the dify/api reproduction in the issue) the scan burns
+//! `files × names × package-closure` parses and pins a CPU core for hours,
+//! while `basilisk check` finishes the same tree in seconds.
+//!
+//! The test measures the same scan over the same external package with 2 and
+//! then 20 workspace files. External-package work must be shared across
+//! workspace files, so the 10× file count must NOT cost ~10× the time.
+
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used, missing_docs)]
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use basilisk_lsp::config::AnalysisMode;
+use basilisk_lsp::workspace::WorkspaceIndex;
+
+static TEST_CTR: AtomicU64 = AtomicU64::new(0);
+
+/// Modules in the package's star-re-export chain (`__init__ -> mod_000 ->
+/// … -> mod_039`, targets defined only in the last module).
+const CHAIN_LEN: usize = 40;
+/// Names each workspace file imports from the package.
+const IMPORTED_NAMES: usize = 10;
+/// Filler functions per chain module, so each parse has realistic cost.
+const FILLER_FUNCS: usize = 150;
+
+fn unique_tmp(prefix: &str) -> PathBuf {
+    let sequence = TEST_CTR.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("{prefix}_{sequence}_{}", std::process::id()))
+}
+
+/// Write a PEP 561 (`py.typed`) package whose public names are only reachable
+/// by chasing a chain of `from .mod_NNN import *` re-exports — the pydantic /
+/// sqlalchemy shape that triggers the GitHub #304 blow-up.
+fn write_py_typed_package(site_packages: &Path) {
+    let pkg = site_packages.join("bigpkg");
+    std::fs::create_dir_all(&pkg).unwrap();
+    std::fs::write(pkg.join("py.typed"), "").unwrap();
+    std::fs::write(pkg.join("__init__.py"), "from .mod_000 import *\n").unwrap();
+
+    for module_idx in 0..CHAIN_LEN {
+        let mut text = String::new();
+        if module_idx + 1 < CHAIN_LEN {
+            let _ = writeln!(text, "from .mod_{:03} import *", module_idx + 1);
+        } else {
+            // Only the last chain module defines the imported names.
+            for name_idx in 0..IMPORTED_NAMES {
+                let _ = writeln!(
+                    text,
+                    "def target_{name_idx}(value: int) -> int:\n    return value\n"
+                );
+            }
+        }
+        for filler_idx in 0..FILLER_FUNCS {
+            let _ = writeln!(
+                text,
+                "def filler_{module_idx}_{filler_idx}(left: int, right: str) -> int:\n    \
+                 total = left + len(right)\n    return total\n"
+            );
+        }
+        std::fs::write(pkg.join(format!("mod_{module_idx:03}.py")), text).unwrap();
+    }
+}
+
+/// Write `file_count` workspace files that each import the chased names.
+fn write_workspace_files(root: &Path, file_count: usize) {
+    let names: Vec<String> = (0..IMPORTED_NAMES)
+        .map(|name_idx| format!("target_{name_idx}"))
+        .collect();
+    let import_line = format!("from bigpkg import {}\n", names.join(", "));
+    let mut uses = String::new();
+    for (name_idx, name) in names.iter().enumerate() {
+        let _ = writeln!(uses, "value_{name_idx} = {name}(1)");
+    }
+    for file_idx in 0..file_count {
+        std::fs::write(
+            root.join(format!("app_{file_idx:03}.py")),
+            format!("{import_line}{uses}"),
+        )
+        .unwrap();
+    }
+}
+
+/// Build a workspace with `file_count` files importing from the shared
+/// `py.typed` package fixture, run the startup scan, and return its duration.
+fn timed_scan(prefix: &str, file_count: usize) -> (Duration, WorkspaceIndex, PathBuf) {
+    let root = unique_tmp(prefix);
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("pyproject.toml"), "[tool.basilisk]\n").unwrap();
+    let site_packages = root.join("site-packages");
+    write_py_typed_package(&site_packages);
+    write_workspace_files(&root, file_count);
+
+    let roots = vec![root.clone()];
+    let config = basilisk_lsp::config::load_config(&root);
+    let index = WorkspaceIndex::new(
+        roots.clone(),
+        AnalysisMode::WholeModule,
+        basilisk_config::BasiliskConfig::default(),
+    );
+    let mut search_paths =
+        basilisk_lsp::import_resolver::search_paths_from_config(&roots, &config, None);
+    search_paths.site_packages = Some(site_packages);
+    index.set_search_paths(search_paths);
+
+    let started = Instant::now();
+    let (_diagnostics, scanned_count, _errors) = index.scan();
+    let elapsed = started.elapsed();
+    assert_eq!(
+        scanned_count, file_count,
+        "scan must analyse exactly the workspace files"
+    );
+    (elapsed, index, root)
+}
+
+/// GitHub #304: the startup scan must share external `py.typed` package
+/// parsing across workspace files instead of re-chasing the package's
+/// re-export closure per file per imported name.
+#[test]
+fn scan_shares_py_typed_package_parses_across_workspace_files_github_304() {
+    let (small_elapsed, small_index, small_root) = timed_scan("bsk_scan_304_small", 2);
+    let (big_elapsed, big_index, big_root) = timed_scan("bsk_scan_304_big", 20);
+
+    // Guard: the enrichment path actually ran — the chased re-export resolved.
+    for (index, root) in [(&small_index, &small_root), (&big_index, &big_root)] {
+        let entry = index.files.get(&root.join("app_000.py")).unwrap();
+        let resolved = entry
+            .resolved
+            .as_ref()
+            .expect("scan must store the resolved module");
+        assert!(
+            resolved.imported_symbols.contains_key("target_0"),
+            "py.typed re-export chase must populate imported_symbols \
+             (otherwise this test is not exercising the #304 code path)"
+        );
+    }
+
+    // External-package work must be shared across workspace files: 10× the
+    // workspace files must not cost ~10× the scan time. The bound is deliberately
+    // loose (4× + a 2-second absolute floor) so machine speed and build profile
+    // don't matter; the unfixed code multiplies external parsing per file and
+    // lands near 10×.
+    let allowed = std::cmp::max(small_elapsed * 4, Duration::from_secs(2));
+    assert!(
+        big_elapsed < allowed,
+        "workspace scan re-does external py.typed package parsing per workspace \
+         file (GitHub #304): 2 files took {small_elapsed:?}, 20 files took \
+         {big_elapsed:?} (allowed: {allowed:?}). External module parses must be \
+         shared across files."
+    );
+
+    let _ = std::fs::remove_dir_all(small_root);
+    let _ = std::fs::remove_dir_all(big_root);
+}

--- a/crates/basilisk-uv/src/lockfile.rs
+++ b/crates/basilisk-uv/src/lockfile.rs
@@ -46,7 +46,11 @@ pub struct LockPackage {
     pub name: String,
 
     /// Resolved version string.
-    pub version: String,
+    ///
+    /// Lockfile revision 3 omits this for editable workspace members with
+    /// dynamic versioning (e.g. Airflow's `apache-airflow-ctl`).
+    #[serde(default)]
+    pub version: Option<String>,
 
     /// Source information (registry, editable path, etc.).
     #[serde(default)]
@@ -279,6 +283,39 @@ source = { editable = "../my-editable" }
         assert_eq!(lock.version, 1);
         assert!(lock.requires_python.is_none());
         assert!(lock.packages.is_empty());
+    }
+
+    // [LSPUV-LOCK-EXTRACT]: lockfile revision 3 omits `version` for editable
+    // workspace members with dynamic versioning (e.g. apache-airflow-ctl in
+    // Airflow's uv.lock). Parsing must tolerate the absent field instead of
+    // rejecting the whole lock file (issue #320).
+    #[test]
+    fn parses_revision3_package_without_version() {
+        let content = r#"
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "apache-airflow-ctl"
+source = { editable = "airflow-ctl" }
+dependencies = [
+    { name = "argcomplete" },
+]
+
+[[package]]
+name = "argcomplete"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+"#;
+        let lock = toml::from_str::<LockFile>(content).unwrap();
+
+        assert_eq!(lock.packages.len(), 2);
+        let member = pkg(&lock, "apache-airflow-ctl");
+        assert_eq!(
+            member.source.as_ref().unwrap().editable.as_deref(),
+            Some("airflow-ctl")
+        );
     }
 
     #[test]

--- a/crates/basilisk-uv/src/registry.rs
+++ b/crates/basilisk-uv/src/registry.rs
@@ -26,8 +26,8 @@ pub enum DepKind {
 pub struct PackageInfo {
     /// Normalised `PyPI` package name.
     pub name: String,
-    /// Resolved version string.
-    pub version: String,
+    /// Resolved version string; absent for dynamic-version workspace members.
+    pub version: Option<String>,
     /// Python import name (may differ from package name).
     pub import_name: String,
     /// How this package relates to the project.
@@ -176,7 +176,7 @@ mod tests {
     ) -> LockPackage {
         LockPackage {
             name: name.to_owned(),
-            version: version.to_owned(),
+            version: Some(version.to_owned()),
             source,
             dependencies: deps,
             dev_dependencies: dev_deps,


### PR DESCRIPTION
## TLDR

Fixes the LSP pinning a CPU core indefinitely on workspaces that import large `py.typed` packages (Refs #304) by memoizing external-module extraction in salsa, and fixes two parsing crashes: version-less packages in revision-3 `uv.lock` files (Refs #320) and a panic on `Literal` annotations containing quoted commas (Refs #316).

## What Was Added?

- `ExternalModule` / `ReexportEdge` / `ExternalModuleRequest` in `crates/basilisk-checker/src/exports.rs`: the parsed view of one external (non-workspace) module — its exports plus pre-resolved `py.typed` re-export edges — built from a **single** read+parse via `load_external_module`.
- A salsa-tracked `external_module` query keyed on an interned `ExternalModuleKey` (`crates/basilisk-checker/src/incremental.rs`): every importer in the workspace shares one memo per external module, and reading `SearchPathsInput` keeps the documented [CHKCACHE-LIMITS] refresh contract (venv sync / `uv.lock` edit / config change re-reads from disk).
- Regression test `scan_shares_py_typed_package_parses_across_workspace_files_github_304` (`crates/basilisk-lsp/tests/workspace_scan_enrichment_perf_tests.rs`): scans 2 vs 20 workspace files over a star-import re-export-chained `py.typed` fixture and asserts external work does not multiply with workspace size.
- Test `parses_revision3_package_without_version` (`crates/basilisk-uv/src/lockfile.rs`) for the version-less lock entry.
- Test `literal_string_containing_comma_does_not_panic` (`crates/basilisk-checker/tests/checker/types_tests.rs`).

## What Was Changed or Deleted?

- `populate_imported_symbols` now takes a caller-supplied `external_module` lookup instead of building a call-local cache; `chase_py_typed_reexport` walks the memoized modules through that lookup and never re-parses a file at any recursion depth. Previously every workspace file re-parsed the same site-packages modules once per imported name (work grew as *files × names × package re-export closure*), which is what pinned the CPU on large projects.
- `LockPackage.version` is now `Option<String>` (`#[serde(default)]`): lockfile revision 3 omits `version` for editable workspace members with dynamic versioning, and parsing previously rejected the whole lock file. The package registry threads the optional version through.
- `split_top_level_commas` (`crates/basilisk-checker/src/rules/shared.rs`) is now string-literal-aware — a comma inside quotes (`Literal[',']`) is part of the value, not a separator — and `parse_single_literal` (`types_parsing.rs`) length-guards its quote slicing so a lone quote no longer panics.
- CLI behaviour is unchanged: the CLI pipeline never runs the external-symbol enrichment, and non-cross paths keep byte-for-byte parity.

## How Do The Automated Tests Prove It Works?

- `scan_shares_py_typed_package_parses_across_workspace_files_github_304` failed on the previous code with `2 files took 1.2s, 20 files took 11.5s` (external parsing repeated per file, ~9.5× for 10× files) and now passes with the whole test completing in ~0.2s. Reproducing the exact report from #304 (`langgenius/dify` `api/`, 3,337 files, 518-package venv): the workspace scan previously never completed at 100% CPU; it now logs `workspace scan complete — 3337 files` in ~10s and idles at 0% CPU.
- `parses_revision3_package_without_version` feeds a revision-3 lock entry with no `version` and asserts the file parses and the package is registered — previously `parse_lock_file` returned an error for the entire lock file.
- `literal_string_containing_comma_does_not_panic` checks `Literal[',']`-style annotations that previously sliced out of range.
- Existing enrichment behaviour is pinned by the untouched assertions in `hover/tests.rs` (re-export chase through a `py.typed` `__init__.py`, GitHub #287) and `import_apply_tests.rs` (custom-typeshed stub provenance), now driven through the shared lookup.
- Full local run: workspace test suite green, per-crate coverage thresholds met (`scripts/test-rust.sh`), and the conformance gate scored 141/141 (100%) with 0 false positives against a fresh `python/typing` clone.

## Breaking Changes

- [x] None user-facing. (Internal API: `populate_imported_symbols` gained an `external_module` parameter and `basilisk_uv::LockPackage.version` became `Option<String>` — both crate-internal consumers updated in this PR.)
