### PR TITLE
Fix v0.36/v0.37 release failures: CRLF-proof byte-verified typeshed index + native linux-arm64 wheel build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,3 +24,10 @@ vscode-extension/LICENSE.txt -text
 # The embedded Typeshed snapshot is verified by SHA-256 against its sidecar
 # manifest; any conversion would break the hash.
 crates/basilisk-stubs/data/typeshed/stdlib.zip binary
+
+# Derived typeshed indexes are likewise SHA-256-pinned by the manifest's
+# derived_indexes sidecar ([STUBRES-TYPESHED-LICENSE]); a CRLF checkout on
+# windows-latest changes their bytes and failed the v0.36.0/v0.37.0 releases.
+# verify_release_attribution.py now refuses any byte-verified file that is not
+# pinned here, so new derived indexes fail PR CI instead of the release.
+crates/basilisk-stubs/data/typeshed_stub_distributions.tsv -text

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -871,9 +871,16 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             manylinux: auto
+          # Native ARM runner, not cross-compilation: the typeshed download
+          # runtime ([STUBRES-TYPESHED]) pulls in `ring`, whose pregenerated
+          # aarch64 assembly does not build under the old cross-gcc in
+          # maturin-action's manylinux cross container ("#error ARM assembler
+          # must define __ARM_ARCH" — failed the v0.36.0/v0.37.0 releases).
+          # The native manylinux aarch64 image carries a modern toolchain and
+          # keeps the widest manylinux2014 wheel tag.
           - platform: linux-arm64
             target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             manylinux: auto
           - platform: darwin-arm64
             target: aarch64-apple-darwin

--- a/scripts/verify_release_attribution.py
+++ b/scripts/verify_release_attribution.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import subprocess
 import tarfile
 import tomllib
 import zipfile
@@ -73,6 +74,49 @@ def _normalized_section(text: str, start: str, end: str) -> str:
     if not separator:
         raise ValueError(f"THIRD-PARTY-LICENSES section {start} has no end marker")
     return "".join(section.split())
+
+
+def _byte_exact_repo_paths(repo_root: Path) -> tuple[str, ...]:
+    """Working-tree files whose exact bytes this script asserts."""
+    crate_root = PurePosixPath("crates/basilisk-stubs")
+    manifest = json.loads(
+        (repo_root / crate_root / "data" / "typeshed" / "manifest.json").read_text()
+    )
+    derived = tuple(
+        str(crate_root / index["path"])
+        for index in manifest["derived_indexes"].values()
+    )
+    return (
+        *LEGAL_FILES,
+        str(crate_root / "data" / "typeshed" / "stdlib.zip"),
+        *derived,
+    )
+
+
+def _verify_checkout_byte_stability(repo_root: Path) -> None:
+    """Every byte-verified file must be pinned against checkout rewriting.
+
+    Git-for-Windows defaults to core.autocrlf=true, so a byte-verified file
+    left eligible for text conversion checks out with CRLF endings on the
+    windows-latest runners and its bytes no longer match the recorded
+    sidecar/notice (the v0.36.0/v0.37.0 release failures). `text` must
+    resolve to `unset` for these paths (`-text` or `binary` in .gitattributes).
+    """
+    paths = _byte_exact_repo_paths(repo_root)
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "check-attr", "text", "--", *paths],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    attributes = dict(line.rsplit(": text: ", 1) for line in result.stdout.splitlines())
+    for path in paths:
+        if attributes.get(path) != "unset":
+            raise ValueError(
+                f"{path} is byte-verified but not pinned '-text' in .gitattributes "
+                f"(text={attributes.get(path)!r}); a core.autocrlf=true checkout "
+                "would rewrite its bytes and break attribution verification"
+            )
 
 
 def _verify_typeshed_policy_metadata(repo_root: Path) -> None:
@@ -332,6 +376,7 @@ def main() -> None:
         "--repo-root", type=Path, default=Path(__file__).resolve().parents[1]
     )
     args = parser.parse_args()
+    _verify_checkout_byte_stability(args.repo_root)
     _verify_typeshed_policy_metadata(args.repo_root)
     _verify_release_package_metadata(args.repo_root)
     if args.policy_only:


### PR DESCRIPTION
## TLDR
Fixes the two defects that failed the v0.36.0 and v0.37.0 release pipelines (no release has shipped since v0.35.0): CRLF checkout corruption of the byte-verified typeshed derived index on Windows runners, and a `ring` cross-compilation failure in the linux-arm64 PyPI wheel job — plus a PR-CI guard so the CRLF failure class can never again reach a release before being caught.

## What Was Added?
- `_verify_checkout_byte_stability` in `scripts/verify_release_attribution.py`: every working-tree file the script verifies byte-exact (the four legal files, the embedded typeshed `stdlib.zip`, and every `derived_indexes` path from the typeshed manifest) must have `text` resolving to `unset` via `.gitattributes` (`-text`/`binary`). A file left eligible for text conversion now fails the existing `--policy-only` check that CI already runs on every PR — on Linux, long before any Windows runner or release tag is involved.
- `.gitattributes` pin for `crates/basilisk-stubs/data/typeshed_stub_distributions.tsv` (`-text`), matching the existing pins for the legal files and `stdlib.zip`.

## What Was Changed or Deleted?
- `release.yml` `pypi-wheels` matrix: the `linux-arm64` wheel now builds on the native `ubuntu-24.04-arm` runner instead of cross-compiling from `ubuntu-latest`. The typeshed acquisition runtime ([STUBRES-TYPESHED]) pulled `ring` into the dependency tree in v0.36; `ring`'s pregenerated aarch64 assembly does not build under the old cross-gcc in maturin-action's manylinux cross container (`#error "ARM assembler must define __ARM_ARCH"`). The native manylinux aarch64 image carries a modern toolchain and keeps the widest `manylinux2014` wheel tag (`manylinux: auto` unchanged). The release-archive binary job is untouched — its Ubuntu cross-gcc is modern and already builds `ring` fine.

Why the releases failed, for the record:
- All four Windows release jobs (binary + wheel, x64 + arm64) died in "Verify … attribution" with `derived index …typeshed_stub_distributions.tsv differs from its sidecar`. Git-for-Windows defaults to `core.autocrlf=true`, so the checkout rewrote the TSV to CRLF and its SHA-256 no longer matched the manifest pin. The repo already pinned every other byte-verified file for exactly this reason (see the existing `.gitattributes` comment); the TSV introduced in the store-backed-pins work was missed.
- The `linux-arm64` wheel job died in `maturin`'s docker build on `ring` as described above.

## How Do The Automated Tests Prove It Works?
- Guard proven test-first: before the `.gitattributes` fix, `python3 scripts/verify_release_attribution.py --policy-only` fails with `crates/basilisk-stubs/data/typeshed_stub_distributions.tsv is byte-verified but not pinned '-text' in .gitattributes (text='unspecified')`; after the pin it passes. CI runs this exact command on every PR (`ci.yml` "policy-only" step), so the guard is exercised on this PR itself.
- Windows behaviour simulated end-to-end: a fresh clone with `core.autocrlf=true` containing the new `.gitattributes` checks the TSV out with 0 CRLF sequences and SHA-256 `dc995d15…` — exactly the manifest sidecar value the release gate compares against.
- The linux-arm64 wheel fix is proven by the release workflow itself on the next tag; it cannot be exercised in PR CI (wheels are only built in `release.yml`).
- Local `make ci`: lint, the full Rust suite, nvim, zed, and `make build` all pass. The VSIX e2e suite showed pre-existing, nondeterministic local-only failures unrelated to this diff (a `cancelPreview` webview race and one debugpy timeout — each test passes in other runs, and the suite is green on CI for main). Flagged separately for a deterministic fix rather than touched here.

## Breaking Changes
- [x] None
