### PR TITLE
Extract linux-x64 archive by exact name in release-notes step (unblocks v0.37 release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tar -xzf artifacts/basilisk-*-linux-x64.tar.gz basilisk
+          # The linux-x64 archive from the build matrix, by its exact name —
+          # the archives are named by target triple, and a glob that matches
+          # nothing fails only at release time (first hit: v0.37.1).
+          tar -xzf artifacts/basilisk-x86_64-unknown-linux-gnu.tar.gz basilisk
           chmod +x basilisk
           python3 scripts/gen_release_notes.py ./basilisk "$GITHUB_REF_NAME" > release-notes-block.md
 


### PR DESCRIPTION
## TLDR
Fixes the last blocker in the v0.37.1 release run: the release-notes step extracted the linux-x64 archive with a glob (`basilisk-*-linux-x64.tar.gz`) that never matches the build matrix's target-triple archive name (`basilisk-x86_64-unknown-linux-gnu.tar.gz`).

## What Was Changed or Deleted?
One line in `.github/workflows/release.yml` ("Generate release-notes component block", added in #314): extract `artifacts/basilisk-x86_64-unknown-linux-gnu.tar.gz` by its exact name, matching every other archive reference in the workflow. The step had never executed before — the v0.36.0/v0.37.0 runs died earlier (fixed in #344) — so v0.37.1 was its first run, and it failed with "Cannot open: No such file or directory". All build, attribution, and both conformance-gate jobs in the v0.37.1 run passed; only this publish step failed.

## How Do The Automated Tests Prove It Works?
- The archive name is the literal `archive:` value for linux-x64 in this same workflow's build matrix, and the identical exact-name convention the Homebrew/Scoop jobs already use for the same files.
- `python3 scripts/gen_release_notes.py ./target/release/basilisk v0.37.1` runs clean locally against a release-built binary, so the step's remaining commands are sound (the notes block itself is drift-tested by `crates/basilisk-cli/tests/e2e_release_notes_block.rs`).
- Workflow-file changes can only be fully proven by the next tagged release run.

## Breaking Changes
- [x] None
