### PR TITLE
Fix Windows VSIX jobs: shell-spawn npm and CRLF-pin the VSIX legal files (unblocks v0.37 release)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,14 @@ basilisk-zed/LICENSE     -text
 basilisk.nvim/LICENSE    -text
 vscode-extension/LICENSE.txt -text
 
+# The VSIX legal pipeline is byte-exact too: update-dependency-licenses.mjs
+# --check requires the committed carrier + manifest to equal the regenerated
+# LF bytes, and VSCODE-DISTRIBUTION-LICENSE ships verbatim into the VSIX as
+# LICENSE.txt. All three ran CRLF-converted on the windows-latest VSIX jobs.
+VSCODE-DISTRIBUTION-LICENSE  -text
+VSCODE-DEPENDENCY-LICENSES   -text
+vscode-license-manifest.json -text
+
 # The embedded Typeshed snapshot is verified by SHA-256 against its sidecar
 # manifest; any conversion would break the hash.
 crates/basilisk-stubs/data/typeshed/stdlib.zip binary

--- a/scripts/verify_release_attribution.py
+++ b/scripts/verify_release_attribution.py
@@ -76,8 +76,19 @@ def _normalized_section(text: str, start: str, end: str) -> str:
     return "".join(section.split())
 
 
+# Byte-compared by the VSIX pipeline: vscode-extension/scripts/
+# update-dependency-licenses.mjs --check regenerates the carrier + manifest and
+# requires the committed bytes to match exactly, and the release workflow packs
+# VSCODE-DISTRIBUTION-LICENSE verbatim into the VSIX as LICENSE.txt.
+VSIX_LEGAL_FILES = (
+    "VSCODE-DISTRIBUTION-LICENSE",
+    "VSCODE-DEPENDENCY-LICENSES",
+    "vscode-license-manifest.json",
+)
+
+
 def _byte_exact_repo_paths(repo_root: Path) -> tuple[str, ...]:
-    """Working-tree files whose exact bytes this script asserts."""
+    """Working-tree files whose exact bytes the release pipeline asserts."""
     crate_root = PurePosixPath("crates/basilisk-stubs")
     manifest = json.loads(
         (repo_root / crate_root / "data" / "typeshed" / "manifest.json").read_text()
@@ -88,6 +99,7 @@ def _byte_exact_repo_paths(repo_root: Path) -> tuple[str, ...]:
     )
     return (
         *LEGAL_FILES,
+        *VSIX_LEGAL_FILES,
         str(crate_root / "data" / "typeshed" / "stdlib.zip"),
         *derived,
     )

--- a/vscode-extension/scripts/update-dependency-licenses.mjs
+++ b/vscode-extension/scripts/update-dependency-licenses.mjs
@@ -17,9 +17,14 @@ function sha256(value) {
 }
 
 function productionPackageDirs() {
-  return execFileSync("npm", ["ls", "--omit=dev", "--parseable", "--all"], {
+  // On Windows npm is npm.cmd, which Node can only spawn through a shell
+  // (spawning it directly fails ENOENT/EINVAL). The arguments are static, so
+  // the shell path takes no untrusted input.
+  const windows = process.platform === "win32";
+  return execFileSync(windows ? "npm.cmd" : "npm", ["ls", "--omit=dev", "--parseable", "--all"], {
     cwd: extensionRoot,
     encoding: "utf8",
+    shell: windows,
   })
     .split("\n")
     .map((entry) => entry.trim())


### PR DESCRIPTION
## TLDR
Fixes the failure that stopped the v0.37.2 release at the Windows VSIX jobs — `licenses:check` spawning `npm` in a way Windows cannot execute — and defuses the CRLF checkout landmine sitting directly behind it in the same jobs.

## What Was Added?
- `VSIX_LEGAL_FILES` in `scripts/verify_release_attribution.py`: `VSCODE-DISTRIBUTION-LICENSE`, `VSCODE-DEPENDENCY-LICENSES`, and `vscode-license-manifest.json` join the checkout byte-stability guard added in #344, since the VSIX pipeline byte-compares/ships them (`update-dependency-licenses.mjs --check` requires the committed carrier + manifest to equal regenerated LF bytes; the distribution license is packed verbatim into the VSIX as `LICENSE.txt`).
- `.gitattributes` `-text` pins for those three files.

## What Was Changed or Deleted?
`vscode-extension/scripts/update-dependency-licenses.mjs` spawns `npm.cmd` through a shell on Windows (static arguments only). On win32 npm is a `.cmd`, which Node cannot spawn directly — `execFileSync("npm", …)` failed with `spawnSync npm ENOENT`, killing both win32 VSIX jobs in the v0.37.2 release run (first-ever execution of this check on Windows; it was added after v0.35.0 with the VSIX license carrier work).

## How Do The Automated Tests Prove It Works?
- Guard proven test-first: with only the guard extension applied, `python3 scripts/verify_release_attribution.py --policy-only` fails with `VSCODE-DISTRIBUTION-LICENSE is byte-verified but not pinned '-text' in .gitattributes`; with the pins it passes. CI runs that exact command on every PR.
- `npm run licenses:check` still reports `VS Code production dependency licenses are exact` on POSIX after the spawn change, and eslint passes.
- The Windows spawn path itself is proven by the next tagged release run (the win32 VSIX jobs only exist in `release.yml`).

## Breaking Changes
- [x] None
