### PR TITLE
Accept string forward references in directives_cast

### DIFF
--- a/crates/basilisk-checker/src/rules/directives_cast.rs
+++ b/crates/basilisk-checker/src/rules/directives_cast.rs
@@ -2,10 +2,16 @@
 //! `directives_cast`: Invalid `cast()` call.
 //!
 //! `typing.cast(typ, val)` must be called with exactly two positional arguments,
-//! and the first argument must be a type expression, not a value literal.
+//! and the first argument must be a type expression, not a value literal. A
+//! *quoted* first argument (`cast("Widget", x)`) is NOT a value literal — it is
+//! the standard PEP 484 forward-reference spelling, which typeshed admits
+//! directly (`cast(typ: type[_T] | str | Any, val)`) and which ruff's `TC006`
+//! actively requires — so only genuine non-string value literals are rejected
+//! (issue #335).
 //!
 //! - `cast()` — too few arguments
-//! - `cast(1, x)` — first argument is a literal, not a type
+//! - `cast(1, x)` — first argument is a value literal, not a type
+//! - `cast("Widget", x)` — OK: string forward reference
 //! - `cast(int, x, y)` — too many arguments
 
 use basilisk_resolver::{ResolvedModule, RhsKind};
@@ -32,7 +38,11 @@ impl Rule for InvalidCastCall {
         for call in module.calls.iter().filter(|c| c.callee == "cast") {
             let arg_count = call.args.len();
             if arg_count == 2 {
-                // Exactly 2 args: check that first arg is not a plain value literal.
+                // Exactly 2 args: reject a first argument that is a genuine value
+                // literal (number, bool, bytes, or None). A string is deliberately
+                // NOT in this set — `cast("Widget", x)` is a forward reference, the
+                // spelling typeshed admits (`type[_T] | str | Any`) and ruff `TC006`
+                // requires, so flagging it would be a false positive (issue #335).
                 let Some((first_kind, first_span)) = call.args.first() else {
                     continue;
                 };
@@ -40,7 +50,6 @@ impl Rule for InvalidCastCall {
                     first_kind,
                     RhsKind::IntLiteral
                         | RhsKind::FloatLiteral
-                        | RhsKind::StrLiteral
                         | RhsKind::BoolLiteral
                         | RhsKind::BytesLiteral
                         | RhsKind::NoneValue

--- a/crates/basilisk-checker/tests/checker/directives_cast_tests.rs
+++ b/crates/basilisk-checker/tests/checker/directives_cast_tests.rs
@@ -48,3 +48,32 @@ y = cast(str, x)
     );
     Ok(())
 }
+
+/// A quoted string is a legal first argument to `cast()`: it is the standard
+/// forward-reference spelling, and typeshed admits it directly
+/// (`cast(typ: type[_T] | str | Any, val)`). Flagging it as a "value literal"
+/// is a false positive — and, because ruff's `TC006` actively *requires* the
+/// quotes, it puts Basilisk in unsatisfiable conflict with ruff (issue #335).
+#[test]
+fn cast_string_forward_reference_no_diagnostic() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+from typing import cast
+from uuid import UUID
+
+
+class Local: ...
+
+
+a = cast("UUID", object())
+b = cast("Local", object())
+c = cast("int", 1)
+d = cast("dict[str, str]", {})
+"#;
+    let diags = run(source)?;
+    assert!(
+        !codes(&diags).contains(&"directives_cast"),
+        "quoted forward-reference casts are legal (PEP 484 / typeshed / ruff TC006) and must not fire directives_cast, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}

--- a/website/src/_data/rules.json
+++ b/website/src/_data/rules.json
@@ -2251,11 +2251,11 @@
     "body": [
       {
         "type": "text",
-        "html": "<code>typing.cast(typ, val)</code> must be called with exactly two positional arguments, and the first argument must be a type expression, not a value literal."
+        "html": "<code>typing.cast(typ, val)</code> must be called with exactly two positional arguments, and the first argument must be a type expression, not a value literal. A <em>quoted</em> first argument (<code>cast(&quot;Widget&quot;, x)</code>) is NOT a value literal \u2014 it is the standard <a href=\"https://peps.python.org/pep-0484/\">PEP 484</a> forward-reference spelling, which typeshed admits directly (<code>cast(typ: type_T | str | Any, val)</code>) and which ruff&#x27;s <code>TC006</code> actively requires \u2014 so only genuine non-string value literals are rejected (issue #335)."
       },
       {
         "type": "text",
-        "html": "- <code>cast()</code> \u2014 too few arguments - <code>cast(1, x)</code> \u2014 first argument is a literal, not a type - <code>cast(int, x, y)</code> \u2014 too many arguments"
+        "html": "- <code>cast()</code> \u2014 too few arguments - <code>cast(1, x)</code> \u2014 first argument is a value literal, not a type - <code>cast(&quot;Widget&quot;, x)</code> \u2014 OK: string forward reference - <code>cast(int, x, y)</code> \u2014 too many arguments"
       }
     ],
     "group": "Type System",


### PR DESCRIPTION
## TLDR
`directives_cast` no longer flags a quoted forward reference (`cast("Widget", x)`) as an invalid "value literal" — a critical, unsuppressable false positive that put Basilisk in unsatisfiable conflict with ruff's `TC006`.

## What Was Added?
- A regression test — `cast_string_forward_reference_no_diagnostic` (`crates/basilisk-checker/tests/checker/directives_cast_tests.rs`) — asserting that quoted `cast()` first arguments do **not** fire `directives_cast`, covering a `str`-imported class (`UUID`), a locally-defined class, a builtin (`int`), and a subscripted generic (`dict[str, str]`).

## What Was Changed or Deleted?
- `crates/basilisk-checker/src/rules/directives_cast.rs`: removed `RhsKind::StrLiteral` from the rule's value-literal reject set. `typing.cast()`'s first argument may be a quoted forward reference — typeshed types the parameter `type[_T] | str | Any`, and ruff's `TC006` (in ruff's `ALL` set) actively *requires* the quotes. Treating a string as a value literal therefore produced a false positive that no project running both tools could satisfy (quote → fail Basilisk; unquote → fail ruff). Genuine value literals (`int`/`float`/`bool`/`bytes`/`None`) and wrong argument counts still fire; the module doc comment now documents the forward-reference case.
- `website/src/_data/rules.json`: regenerated from the updated rule doc comment (`python3 scripts/gen_rules_reference.py --data`) so the generated `/errors/directives_cast` page and rules reference stay in sync ([WEBSITE-ERROR-PAGES-DRIFT]).

## How Do The Automated Tests Prove It Works?
- New `cast_string_forward_reference_no_diagnostic` was confirmed to **fail before the fix** (all four quoted casts each emitted `directives_cast`) and **passes after it**.
- The existing `cast_literal_first_arg_fires` (uses `cast(1, x)`) and `cast_too_few_args_fires` still pass — genuine value-literal and arity detection is preserved, not weakened.
- Full `basilisk-checker` suite green (3779 tests) and CLI e2e `invalid_cast` still passes.
- End-to-end against a freshly built binary: the issue's full a–g repro now reports "All checked. No issues found.", while `cast(1, …)`/`cast(1.5, …)`/`cast(True, …)`/`cast(None, …)` still emit `directives_cast`.

## Spec / Doc Changes
- Rule doc comment in `directives_cast.rs` updated to state that a quoted first argument is a legal forward reference (with the typeshed signature and the ruff `TC006` interaction); `rules.json` regenerated accordingly. No spec-ID or configuration-surface changes.

## Breaking Changes
- [x] None

Refs #335.

Scope note: this closes the critical false-positive half of #335 (Problem 1). The issue's second, lower-severity defect — the rule only inspects calls in assignment-RHS position, so a genuine value-literal `cast(1, x)` in a call-argument or `return` position is currently *missed* (a false negative) — is rooted in the resolver's `module.calls` collection, affects every call-iterating rule, and is intentionally left out of this minimal fix. Hence `Refs`, not a close keyword.
