### PR TITLE
Fix four pre-0.38 false positives and stub-generation bugs (#182 #324 #332 #336)

### DIFF
--- a/crates/basilisk-checker/src/exports.rs
+++ b/crates/basilisk-checker/src/exports.rs
@@ -288,6 +288,36 @@ fn stub_module_exports(
         ));
     }
 
+    // Overloaded functions live in a separate map from plain functions. Omitting
+    // them dropped every `@overload` stdlib function (`math.ceil`, `ast.parse`,
+    // `hmac.new`, …) from the member set, so correct code looked undeclared and
+    // `imports_module_attribute` red a clean repo (GitHub #324). Every variant is
+    // rendered so hover shows the full overload set.
+    for (name, variants) in &stub.overloads {
+        let signature = variants
+            .iter()
+            .map(basilisk_stubs::render_stub_signature)
+            .collect::<Vec<_>>()
+            .join("\n");
+        exports.push((
+            name.clone(),
+            ExternalSymbol {
+                name: name.clone(),
+                kind: ExternalSymbolKind::Function,
+                type_annotation: variants.first().and_then(|variant| variant.return_type.clone()),
+                source_path: stub_path.to_path_buf(),
+                source_span: Span::new(0, 0),
+                signature: (!signature.is_empty()).then_some(signature),
+                docstring: None,
+                provenance,
+                methods: Vec::new(),
+                bases: Vec::new(),
+                metaclass: None,
+                metaclass_calls: Vec::new(),
+            },
+        ));
+    }
+
     exports
 }
 
@@ -751,6 +781,30 @@ fn stub_source_for(resolved_path: &Path, stub_paths: &[PathBuf]) -> StubSource {
     StubSource::StubPackage
 }
 
+/// The single top-level name a plain `import` binds an authoritative module API
+/// to, or `None` when the import binds no such API.
+///
+/// `import foo` binds `foo`; `import foo as f` — and `import a.b.c as f` — binds
+/// the alias `f` to the imported (leaf) module. But an *unaliased dotted*
+/// `import a.b.c` binds only the root package `a`, while the stub that resolved
+/// is `a.b.c`, whose members are NOT `a`'s members. Attributing them to `a` reds
+/// correct code (`a.b.c` itself, and any real `a.other`), so such imports yield
+/// no binding (GitHub #324) — the same rule the user-stub path already applies
+/// by skipping every dotted import.
+#[must_use]
+pub fn authoritative_module_binding(import: &basilisk_resolver::ImportInfo) -> Option<String> {
+    if import.kind != ImportKind::Plain {
+        return None;
+    }
+    if let Some(alias) = import.names.first() {
+        return Some(alias.clone());
+    }
+    if import.module.contains('.') {
+        return None;
+    }
+    Some(import.module.clone())
+}
+
 /// Repopulate `resolved.imported_symbols` from its resolved imports.
 ///
 /// `workspace_exports` supplies the exports of a **workspace-tracked** file
@@ -820,27 +874,21 @@ pub fn populate_imported_symbols<'a, F, E>(
                 continue;
             };
 
-        if import.kind == ImportKind::Plain && authoritative_stub {
-            let binding = import.names.first().cloned().unwrap_or_else(|| {
-                import
-                    .module
-                    .split('.')
-                    .next()
-                    .unwrap_or(&import.module)
-                    .to_owned()
-            });
-            let member_names = target_exports
-                .iter()
-                .map(|(name, _)| name.clone())
-                .collect();
-            let _ = imported_modules.insert(
-                binding,
-                ImportedModuleApi {
-                    has_getattr: target_exports.iter().any(|(name, _)| name == "__getattr__"),
-                    member_names,
-                    stub_path: resolved_path.clone(),
-                },
-            );
+        if authoritative_stub {
+            if let Some(binding) = authoritative_module_binding(import) {
+                let member_names = target_exports
+                    .iter()
+                    .map(|(name, _)| name.clone())
+                    .collect();
+                let _ = imported_modules.insert(
+                    binding,
+                    ImportedModuleApi {
+                        has_getattr: target_exports.iter().any(|(name, _)| name == "__getattr__"),
+                        member_names,
+                        stub_path: resolved_path.clone(),
+                    },
+                );
+            }
         }
 
         // Discriminate on `kind`, not `names.is_empty()`: a plain `import foo

--- a/crates/basilisk-checker/src/exports.rs
+++ b/crates/basilisk-checker/src/exports.rs
@@ -304,7 +304,9 @@ fn stub_module_exports(
             ExternalSymbol {
                 name: name.clone(),
                 kind: ExternalSymbolKind::Function,
-                type_annotation: variants.first().and_then(|variant| variant.return_type.clone()),
+                type_annotation: variants
+                    .first()
+                    .and_then(|variant| variant.return_type.clone()),
                 source_path: stub_path.to_path_buf(),
                 source_span: Span::new(0, 0),
                 signature: (!signature.is_empty()).then_some(signature),

--- a/crates/basilisk-checker/src/imports/apply.rs
+++ b/crates/basilisk-checker/src/imports/apply.rs
@@ -250,9 +250,11 @@ fn capture_active_typeshed_api(
     search_paths: &ImportSearchPaths,
     importing_file: &std::path::Path,
 ) -> Option<(String, ImportedModuleApi)> {
-    if import.kind != ImportKind::Plain {
-        return None;
-    }
+    // An unaliased dotted `import a.b.c` binds only the root `a`, whose members
+    // are not the resolved `a.b.c` stub's members — capturing them under `a`
+    // reds correct code (GitHub #324). The shared helper yields no binding for
+    // exactly those imports, mirroring the user-stub path.
+    let binding = crate::exports::authoritative_module_binding(import)?;
     let resolved_path = import.resolved_path.as_ref()?;
     let active = search_paths.typeshed_snapshot.as_ref()?;
     let (_, importer_target) = active.for_importer(Some(importing_file))?;
@@ -274,17 +276,6 @@ fn capture_active_typeshed_api(
         return None;
     }
 
-    // A plain `import foo as f` carries its alias in `names`; the alias binds
-    // the module object, so it — not the dotted module path — is the base name
-    // an attribute access is written against.
-    let binding = import.names.first().cloned().unwrap_or_else(|| {
-        import
-            .module
-            .split('.')
-            .next()
-            .unwrap_or(&import.module)
-            .to_owned()
-    });
     Some((
         binding,
         ImportedModuleApi {

--- a/crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
+++ b/crates/basilisk-checker/src/rules/assignment_compatibility/mod.rs
@@ -209,6 +209,17 @@ fn literal_collection_assignable(
     ) {
         return false;
     }
+    // Bidirectional (expected-type) inference: carry the declared element types
+    // INWARD and check each literal element against them — the exact check
+    // `returns`/`yield` already use. Without this the RHS is inferred bottom-up
+    // to e.g. `dict[LiteralString, Unknown]` (a value from a typed variable
+    // becomes `Unknown`, a string key becomes `LiteralString`) and then rejected
+    // under dict invariance, so `d: dict[str, str] = {"k": x}` fires while the
+    // identical `return {"k": x}` is clean (GitHub #332). A genuine element
+    // mismatch still yields `Some(false)` and falls through to the alias check.
+    if crate::inference::literal_collection_assignable_to(&var.rhs_kind, declared) == Some(true) {
+        return true;
+    }
     let ctx = alias_match::AliasCtx {
         union: &skip.value_aliases,
         generic: &skip.generic_aliases,

--- a/crates/basilisk-checker/src/rules/redundant_annotation.rs
+++ b/crates/basilisk-checker/src/rules/redundant_annotation.rs
@@ -269,18 +269,18 @@ fn make_diagnostic_for_var(
 /// Whether annotated assignments in this class declare *fields* rather than
 /// plain attributes (issue #110).
 ///
-/// For `pydantic.BaseModel` subclasses, `@dataclass` classes (including
-/// `dataclass_transform` factories), and attrs-style classes, the annotation is
-/// what makes the assignment a field — removing it silently deletes the field
-/// from validation/serialization or the generated `__init__`. BSK-0050 must never
-/// call such an annotation redundant.
+/// For `pydantic.BaseModel` / `pydantic_settings.BaseSettings` subclasses,
+/// `@dataclass` classes (including `dataclass_transform` factories), and
+/// attrs-style classes, the annotation is what makes the assignment a field —
+/// removing it silently deletes the field from validation/serialization or the
+/// generated `__init__`. BSK-0050 must never call such an annotation redundant.
 fn annotation_defines_field(
     class: &basilisk_resolver::ClassInfo,
     all_classes: &[basilisk_resolver::ClassInfo],
 ) -> bool {
     class.is_dataclass
         || has_attrs_class_decorator(class)
-        || transitively_inherits(class, all_classes, &is_pydantic_model_base)
+        || transitively_inherits(class, all_classes, &is_pydantic_field_base)
 }
 
 /// attrs-style class decorators (`@define`, `@frozen`, `@mutable`, `@attr.s`,
@@ -300,8 +300,19 @@ fn is_namedtuple_base(base: &str) -> bool {
     base == "NamedTuple"
 }
 
-fn is_pydantic_model_base(base: &str) -> bool {
-    base == "BaseModel" || base.ends_with(".BaseModel")
+/// A pydantic base whose annotated attributes are model *fields*.
+///
+/// `BaseModel` (pydantic) and `BaseSettings` (pydantic-settings, itself a
+/// `BaseModel` subclass) both turn `name: T = default` into a registered field;
+/// `BaseSettings` lives in a third-party package, so the resolver records only
+/// the bare base name and cannot see the inheritance — the name must be matched
+/// directly (issue #182). Dotted references (`pydantic_settings.BaseSettings`)
+/// keep their qualifier, hence the `ends_with` arm.
+fn is_pydantic_field_base(base: &str) -> bool {
+    base == "BaseModel"
+        || base.ends_with(".BaseModel")
+        || base == "BaseSettings"
+        || base.ends_with(".BaseSettings")
 }
 
 /// Check if a class transitively inherits from a base matching `is_marker_base`,

--- a/crates/basilisk-checker/tests/checker/assignment_compatibility_tests.rs
+++ b/crates/basilisk-checker/tests/checker/assignment_compatibility_tests.rs
@@ -58,6 +58,64 @@ def build_refs_dict() -> RefsDictT:
 }
 
 #[test]
+fn dict_literal_with_typed_variable_value_no_diagnostic(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Regression for issue #332: a dict display whose value comes from a typed
+    // variable must be checked contextually against the declared dict type
+    // (exactly like `return {...}`), not inferred bottom-up to
+    // `dict[LiteralString, Unknown]` and then rejected under dict invariance.
+    // The `y`/`lst` lines already pass; the `d` line was the false positive.
+    let source = r#"
+def f(x: str) -> None:
+    y: str = x
+    lst: list[str] = [x]
+    d: dict[str, str] = {"k": x}
+"#;
+    let diags = run(source)?;
+    let msgs = messages_for(&diags, "assignment_compatibility");
+    assert!(
+        msgs.is_empty(),
+        "a dict literal with a typed variable value is assignable to dict[str, str]; should not fire, got: {msgs:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn dict_literal_with_multiple_typed_variable_values_no_diagnostic(
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Real-world instance from issue #332 (docker_host.py:617): every value
+    // comes from a typed parameter.
+    let source = r#"
+def build(bind_host: str, host_port_str: str) -> None:
+    binding: dict[str, str] = {"HostIp": bind_host, "HostPort": host_port_str}
+"#;
+    let diags = run(source)?;
+    let msgs = messages_for(&diags, "assignment_compatibility");
+    assert!(
+        msgs.is_empty(),
+        "a dict of typed-variable values should not fire against dict[str, str], got: {msgs:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn dict_literal_with_wrong_value_type_still_fires() -> Result<(), Box<dyn std::error::Error>> {
+    // Guard for issue #332: contextual checking must not swallow a genuine
+    // mismatch — a str-literal value against `dict[str, int]` is still an error.
+    let source = r#"
+def f() -> None:
+    d: dict[str, int] = {"k": "not an int"}
+"#;
+    let diags = run(source)?;
+    let msgs = messages_for(&diags, "assignment_compatibility");
+    assert!(
+        !msgs.is_empty(),
+        "a str value is not assignable to dict[str, int]; should fire, got: {msgs:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn str_annotated_int_literal_fires() -> Result<(), Box<dyn std::error::Error>> {
     let source = "label: str = 42\n";
     let diags = run(source)?;

--- a/crates/basilisk-checker/tests/checker/assignment_compatibility_tests.rs
+++ b/crates/basilisk-checker/tests/checker/assignment_compatibility_tests.rs
@@ -58,8 +58,8 @@ def build_refs_dict() -> RefsDictT:
 }
 
 #[test]
-fn dict_literal_with_typed_variable_value_no_diagnostic(
-) -> Result<(), Box<dyn std::error::Error>> {
+fn dict_literal_with_typed_variable_value_no_diagnostic() -> Result<(), Box<dyn std::error::Error>>
+{
     // Regression for issue #332: a dict display whose value comes from a typed
     // variable must be checked contextually against the declared dict type
     // (exactly like `return {...}`), not inferred bottom-up to

--- a/crates/basilisk-checker/tests/checker/redundant_annotation_rule_tests.rs
+++ b/crates/basilisk-checker/tests/checker/redundant_annotation_rule_tests.rs
@@ -166,6 +166,66 @@ fn test_w0050_pydantic_basemodel_transitive_subclass_field_not_flagged() {
     );
 }
 
+// Issue #182: `pydantic_settings.BaseSettings` fields are load-bearing exactly
+// like `BaseModel` fields — the annotation is what registers the setting. When
+// BSK-0050 fires here, `basilisk fix` strips the annotation and the module then
+// raises `PydanticUserError` at import. `BaseSettings` is a `BaseModel` subclass,
+// but it lives in a third-party package so the resolver cannot see that it
+// inherits `BaseModel`; the base name itself must be recognised.
+
+#[test]
+fn test_w0050_pydantic_basesettings_field_not_flagged() {
+    let diags = run_with_config(
+        concat!(
+            "from pydantic_settings import BaseSettings\n",
+            "class Settings(BaseSettings):\n",
+            "    debug: bool = False\n",
+        ),
+        &annotation_rules_config(),
+    )
+    .unwrap();
+    assert!(
+        !diags.iter().any(|d| d.code.code == "BSK-0050"),
+        "BSK-0050 on a BaseSettings field deletes the field when autofixed (issue #182)"
+    );
+}
+
+#[test]
+fn test_w0050_pydantic_basesettings_transitive_subclass_field_not_flagged() {
+    let diags = run_with_config(
+        concat!(
+            "from pydantic_settings import BaseSettings\n",
+            "class AppSettings(BaseSettings):\n",
+            "    name: str = \"x\"\n",
+            "class DevSettings(AppSettings):\n",
+            "    debug: bool = False\n",
+        ),
+        &annotation_rules_config(),
+    )
+    .unwrap();
+    assert!(
+        !diags.iter().any(|d| d.code.code == "BSK-0050"),
+        "BSK-0050 on a transitive BaseSettings subclass field deletes the field when autofixed (issue #182)"
+    );
+}
+
+#[test]
+fn test_w0050_pydantic_basesettings_dotted_base_field_not_flagged() {
+    let diags = run_with_config(
+        concat!(
+            "import pydantic_settings\n",
+            "class Settings(pydantic_settings.BaseSettings):\n",
+            "    debug: bool = False\n",
+        ),
+        &annotation_rules_config(),
+    )
+    .unwrap();
+    assert!(
+        !diags.iter().any(|d| d.code.code == "BSK-0050"),
+        "BSK-0050 must not fire on BaseSettings fields referenced via dotted base (issue #182)"
+    );
+}
+
 #[test]
 fn test_w0050_dataclass_field_not_flagged() {
     let diags = run_with_config(

--- a/crates/basilisk-cli/src/stubs.rs
+++ b/crates/basilisk-cli/src/stubs.rs
@@ -234,6 +234,18 @@ fn cache_generation_result(
 
 /// Cache a generated stub and print the result.
 pub(super) fn cache_stub(cache_dir: &Path, package: &str, stub: &GeneratedStub) -> bool {
+    // A declaration-free stub carries no type information. Writing it would
+    // report a false "✓ Generated" success AND let the empty `.pyi` satisfy
+    // BSK-0152 as though the module were typed (GitHub #336). Surface it as a
+    // warning and write nothing — there is no stub worth caching.
+    if !stub.has_declarations() {
+        println!(
+            "{} `{package}` exposed no introspectable public API — no stub written",
+            "⚠".yellow()
+        );
+        return true;
+    }
+
     let source_hash = generate::cache::hash_source(&stub.pyi_content);
     match generate::cache::write_cache(cache_dir, package, &stub.pyi_content, source_hash) {
         Ok(path) => {

--- a/crates/basilisk-cli/tests/e2e_bundled_typeshed_config.rs
+++ b/crates/basilisk-cli/tests/e2e_bundled_typeshed_config.rs
@@ -160,6 +160,108 @@ fn cli_accepts_user_stub_reexports_from_the_custom_typeshed_stdlib() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// Regression for GitHub #324 (bug 1): `@overload` stdlib functions must be
+/// part of a module's captured member set. `stub_module_exports` looped the
+/// stub's plain functions, classes, and variables but NOT its overload groups,
+/// so every overloaded stdlib function (`math.ceil`, `hmac.new`, `ast.parse`, …)
+/// looked undeclared and `basilisk check` red a clean repo out of the box.
+#[test]
+fn cli_accepts_overloaded_stdlib_functions() {
+    let dir = unique_dir("overloaded_stdlib_functions");
+    std::fs::write(
+        dir.join("pyproject.toml"),
+        "[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk]\n",
+    )
+    .expect("write pyproject");
+    std::fs::write(
+        dir.join("app.py"),
+        "import math\nimport ast\n\nrounded = math.ceil(1.5)\ntree = ast.parse(\"x = 1\")\n",
+    )
+    .expect("write app");
+
+    let output = check_app(&dir);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stdout.contains("imports_module_attribute"),
+        "`math.ceil` and `ast.parse` are `@overload` stdlib functions and must not be flagged, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "correct stdlib code using overloaded functions must let the CLI check pass, stdout: {stdout}, stderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Regression for GitHub #324 (bug 2): an unaliased dotted `import os.path`
+/// binds only the root package `os`, but the resolved stub is `os.path` — its
+/// members are NOT `os`'s members, so attributing them to `os` red `os.path`
+/// itself ("Module `os` has no attribute `path`"). Such imports must capture no
+/// authoritative module API, mirroring the user-stub path that already skips
+/// every dotted import.
+#[test]
+fn cli_accepts_dotted_submodule_imports() {
+    let dir = unique_dir("dotted_submodule_imports");
+    std::fs::write(
+        dir.join("pyproject.toml"),
+        "[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk]\n",
+    )
+    .expect("write pyproject");
+    std::fs::write(
+        dir.join("app.py"),
+        "import os.path\nimport http.client\n\njoined = os.path.join(\"a\", \"b\")\nconn = http.client.HTTPConnection(\"localhost\")\n",
+    )
+    .expect("write app");
+
+    let output = check_app(&dir);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !stdout.contains("imports_module_attribute"),
+        "`os.path.join` and `http.client.HTTPConnection` are correct dotted-submodule access and must not be flagged, stdout: {stdout}, stderr: {stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "correct dotted-submodule imports must let the CLI check pass, stdout: {stdout}, stderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// Guard against over-skipping the GitHub #324 dotted fix: an *aliased* dotted
+/// `import X.Y as z` binds the alias `z` to the leaf module `X.Y`, so its member
+/// API is still authoritative and a genuine typo on it must still be flagged.
+#[test]
+fn cli_still_flags_missing_member_on_aliased_dotted_import() {
+    let dir = unique_dir("aliased_dotted_missing_member");
+    std::fs::write(
+        dir.join("pyproject.toml"),
+        "[project]\nname = \"x\"\nversion = \"0.1.0\"\n\n[tool.basilisk]\n",
+    )
+    .expect("write pyproject");
+    std::fs::write(
+        dir.join("app.py"),
+        "import http.client as hc\n\nvalue = hc.NoSuchMemberZzz\n",
+    )
+    .expect("write app");
+
+    let output = check_app(&dir);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stdout.contains("imports_module_attribute") && stdout.contains("NoSuchMemberZzz"),
+        "an aliased dotted import still binds the leaf module's authoritative API, so a missing member must be flagged, stdout: {stdout}, stderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// The other half of GitHub #330, and the guard against re-introducing #312:
 /// members the active Typeshed stub DOES declare — including names it
 /// re-exports rather than defines — must never be flagged. Capturing the

--- a/crates/basilisk-cli/tests/stub_cli_tests.rs
+++ b/crates/basilisk-cli/tests/stub_cli_tests.rs
@@ -164,6 +164,40 @@ fn createstub_alias_generates_the_named_package() -> Result<(), Box<dyn std::err
     Ok(())
 }
 
+/// GitHub #336: a module whose only names are private exposes no public API, so
+/// the generated stub is declaration-free. The CLI must NOT report a false
+/// "✓ Generated" success or write an empty `.pyi` (which would then satisfy
+/// BSK-0152 as though the module were typed) — it warns and writes nothing.
+#[test]
+fn generate_writes_nothing_and_warns_for_a_module_with_no_public_api(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let project = TestProject::new("no_public_api")?;
+    let _ = project.write(
+        ".venv/lib/python3.12/site-packages/hollow.py",
+        "_private = 1\ndef _helper() -> int:\n    return 2\n",
+    )?;
+    let _ = project.write("app.py", "import hollow\n")?;
+
+    let output = project.generate_all()?;
+    let details = output_text(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(output.status.success(), "{details}");
+    assert!(
+        !project.root.join(".basilisk/stubs/hollow.pyi").exists(),
+        "a declaration-free stub must not be written; {details}"
+    );
+    assert!(
+        !stdout.contains("Generated stub for `hollow`"),
+        "an empty stub must not be reported as a generation success; {details}"
+    );
+    assert!(
+        stdout.contains("no introspectable public API"),
+        "the CLI must warn that `hollow` exposed nothing to stub; {details}"
+    );
+    Ok(())
+}
+
 #[test]
 fn generate_all_with_no_untyped_imports_succeeds() -> Result<(), Box<dyn std::error::Error>> {
     let project = TestProject::new("all_empty")?;

--- a/crates/basilisk-stubs/src/generate/mod.rs
+++ b/crates/basilisk-stubs/src/generate/mod.rs
@@ -58,6 +58,35 @@ pub struct GeneratedStub {
     pub mode: StubGenMode,
 }
 
+impl GeneratedStub {
+    /// Whether this stub declares any usable type information — at least one
+    /// function, class, variable, or overload.
+    ///
+    /// A stub with none carries nothing a checker can use. Caching it would
+    /// report a false success and let the empty `.pyi` satisfy BSK-0152 as
+    /// though the module were typed (GitHub #336), so the CLI treats an
+    /// declaration-free result as "nothing generated" rather than a win. A stub
+    /// whose content fails to parse is conservatively reported as having
+    /// declarations so a genuine (if unparseable) result is never silently
+    /// dropped.
+    #[must_use]
+    pub fn has_declarations(&self) -> bool {
+        crate::pyi_parser::parse_pyi_source(
+            &self.pyi_content,
+            Path::new("<generated>"),
+            &self.module_name,
+            crate::types::StubSource::UserStub,
+            crate::types::StubTier::Tier3,
+        )
+        .map_or(true, |module| {
+            !module.functions.is_empty()
+                || !module.classes.is_empty()
+                || !module.variables.is_empty()
+                || !module.overloads.is_empty()
+        })
+    }
+}
+
 /// Generate stubs for a module using the specified mode.
 ///
 /// # Errors
@@ -76,5 +105,38 @@ pub fn generate_stubs(
         StubGenMode::Runtime => runtime::generate_runtime_stubs(module_name, python_path),
         StubGenMode::Ast => ast::generate_ast_stubs(module_name, source_path),
         StubGenMode::Hybrid => hybrid::generate_hybrid_stubs(module_name, source_path, python_path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stub(pyi_content: &str) -> GeneratedStub {
+        GeneratedStub {
+            module_name: "m".to_owned(),
+            pyi_content: pyi_content.to_owned(),
+            mode: StubGenMode::Runtime,
+        }
+    }
+
+    /// GitHub #336: a stub that declares nothing must be recognised as empty so
+    /// the CLI never caches it or reports a false success.
+    #[test]
+    fn has_declarations_reports_a_header_only_stub_as_empty() {
+        let empty = stub(
+            "# Auto-generated stub for `m` (runtime introspection)\n\nfrom typing import Any\n",
+        );
+        assert!(
+            !empty.has_declarations(),
+            "a header-only stub declares no usable type information"
+        );
+    }
+
+    #[test]
+    fn has_declarations_reports_a_populated_stub_as_non_empty() {
+        assert!(stub("def f() -> int: ...\n").has_declarations(), "function");
+        assert!(stub("class C: ...\n").has_declarations(), "class");
+        assert!(stub("VERSION: str\n").has_declarations(), "variable");
     }
 }

--- a/crates/basilisk-stubs/src/generate/runtime.rs
+++ b/crates/basilisk-stubs/src/generate/runtime.rs
@@ -53,11 +53,15 @@ struct BoundedOutput {
 /// {"name": "Session", "kind": "class", "methods": [...]}
 /// ```
 const INTROSPECT_SCRIPT: &str = r#"
-import sys, json, inspect, types
+import sys, json, inspect, types, importlib
 
 module_name = sys.argv[1]
 try:
-    module = __import__(module_name)
+    # `importlib.import_module` returns the named (sub)module itself; the bare
+    # `__import__(name)` returns the TOP-LEVEL package for a dotted name, so
+    # `import_module("pkg.sub")` was introspecting `pkg` — producing an empty or
+    # wrong-module stub (GitHub #336). This mirrors FIND_PACKAGE_SOURCE_SCRIPT.
+    module = importlib.import_module(module_name)
 except Exception as e:
     print(json.dumps({"error": str(e)}))
     sys.exit(1)
@@ -451,7 +455,8 @@ pub const fn default_timeout() -> Duration {
 #[cfg(test)]
 #[expect(
     clippy::unwrap_used,
-    reason = "test-only: unwrap acceptable in unit tests"
+    clippy::expect_used,
+    reason = "test-only: unwrap/expect acceptable in unit tests"
 )]
 mod tests {
     use super::*;
@@ -610,6 +615,24 @@ exit 7",
         assert!(
             stub.pyi_content.contains("VERSION: str"),
             "{}",
+            stub.pyi_content
+        );
+    }
+
+    /// GitHub #336 (bugs 1 & 2): runtime introspection must import the named
+    /// (sub)module itself, not its top-level package. `__import__("a.b.c")`
+    /// returns `a`, whose only members are submodules — an empty/wrong stub.
+    /// This runs the REAL introspection script against a real interpreter, so
+    /// it depends on `python3` being on PATH (as it is in CI's Rust job).
+    #[test]
+    fn runtime_introspection_targets_the_dotted_submodule_not_its_root() {
+        let python = std::path::PathBuf::from("python3");
+        let stub = generate_runtime_stubs("concurrent.futures", &python)
+            .expect("python3 must introspect a dotted stdlib submodule");
+        assert!(
+            stub.pyi_content.contains("ThreadPoolExecutor"),
+            "the dotted submodule's own members must be introspected (not the \
+             root package's), got:\n{}",
             stub.pyi_content
         );
     }

--- a/crates/basilisk-stubs/src/pyi_parser.rs
+++ b/crates/basilisk-stubs/src/pyi_parser.rs
@@ -294,11 +294,7 @@ impl StubExtractor {
                 &alternative.functions,
                 same_stub_function,
             );
-            retain_matching_entries(
-                &mut intersection.overloads,
-                &alternative.overloads,
-                |left, right| same_stub_functions(left, right),
-            );
+            union_common_overloads(&mut intersection.overloads, &alternative.overloads);
             retain_matching_entries(
                 &mut intersection.classes,
                 &alternative.classes,
@@ -522,6 +518,37 @@ pub(super) fn same_stub_function(left: &StubFunction, right: &StubFunction) -> b
         && left.is_async == right.is_async
         && left.decorators == right.decorators
         && left.class_name == right.class_name
+}
+
+/// Intersect overload groups by NAME across feasible branches, unioning the
+/// variants of a name that appears in every branch.
+///
+/// A plain [`retain_matching_entries`] keyed on `same_stub_functions` drops an
+/// overload whose variant list differs across a version gate — but a function
+/// like `ast.parse`, declared under BOTH arms of `if sys.version_info >= (3,
+/// 15)`, exists regardless of the (unknown) target version. Dropping it reported
+/// `ast.parse` as a missing attribute (GitHub #324). Keeping the name and
+/// unioning the per-branch variants preserves membership without inventing a
+/// declaration no branch made. A name present in only SOME branches is still
+/// intersected away — it may genuinely not exist on the resolved version.
+fn union_common_overloads(
+    left: &mut HashMap<String, Vec<StubFunction>>,
+    right: &HashMap<String, Vec<StubFunction>>,
+) {
+    left.retain(|name, variants| match right.get(name) {
+        Some(other) => {
+            for variant in other {
+                if !variants
+                    .iter()
+                    .any(|existing| same_stub_function(existing, variant))
+                {
+                    variants.push(variant.clone());
+                }
+            }
+            true
+        }
+        None => false,
+    });
 }
 
 fn same_stub_functions(left: &[StubFunction], right: &[StubFunction]) -> bool {


### PR DESCRIPTION
## TLDR
Fixes four open bugs blocking the 0.38 line — three real-world false positives (#182, #324, #332) and the `stubs generate` empty/wrong-stub bug (#336) — each proven test-first (red → green) with conformance held at 100% / 0-FP.

## What Was Added
- `exports::authoritative_module_binding` — the single source of truth for the top-level name a plain `import` binds an authoritative module API to; returns `None` for an unaliased dotted `import a.b.c` (binds only root `a`, whose members are not the resolved `a.b.c` stub's). Used by both the CLI capture path and the cross-module `populate_imported_symbols`.
- `pyi_parser::union_common_overloads` — intersecting version-gated stub branches now keeps an overload **name** present in every branch (unioning its variants) instead of dropping it when signatures differ.
- `GeneratedStub::has_declarations()` — true iff the generated stub declares any function/class/variable/overload.
- New tests (see below).

## What Was Changed/Deleted
- **#182** `redundant_annotation.rs`: `is_pydantic_model_base` → `is_pydantic_field_base`, now also matches `BaseSettings` / `*.BaseSettings`. BSK-0050 no longer flags (and `basilisk fix` no longer strips) load-bearing `pydantic_settings.BaseSettings` field annotations.
- **#324** `exports.rs`: `stub_module_exports` now emits `stub.overloads` (previously dropped every `@overload` stdlib fn — `math.ceil`, `hmac.new`, `ast.parse`). `pyi_parser.rs`: version-gated overloads survive branch intersection. `exports.rs` + `imports/apply.rs`: unaliased dotted imports capture no authoritative API (removes `Module os has no attribute path` etc.). Aliased dotted imports still capture their leaf module's API.
- **#332** `assignment_compatibility/mod.rs`: `literal_collection_assignable` now tries the contextual `inference::literal_collection_assignable_to(&rhs_kind, declared)` first — the same bidirectional check `returns` uses — so `d: dict[str, str] = {"k": x}` type-checks like `return {"k": x}` instead of being inferred bottom-up to `dict[LiteralString, Unknown]` and rejected under invariance.
- **#336** `generate/runtime.rs`: introspection script uses `importlib.import_module` (returns the real submodule) instead of `__import__` (returns the top package). `cli/stubs.rs`: `cache_stub` warns and writes nothing for a declaration-free stub instead of printing `✓ Generated` and leaving an empty `.pyi` that satisfies BSK-0152.

## How Tests Prove It Works
Every fix was demonstrated failing on the old code first, then passing:
- #182: `test_w0050_pydantic_basesettings_{field,transitive_subclass_field,dotted_base}_not_flagged` (`redundant_annotation_rule_tests.rs`).
- #324: `cli_accepts_overloaded_stdlib_functions`, `cli_accepts_dotted_submodule_imports`, `cli_still_flags_missing_member_on_aliased_dotted_import` (`e2e_bundled_typeshed_config.rs`) — run against the real bundled typeshed; the reporter's exact FPs (`math.ceil`, `ast.parse`, `os.path.join`, `http.client.HTTPConnection`) reproduced then cleared.
- #332: `dict_literal_with_typed_variable_value_no_diagnostic`, `dict_literal_with_multiple_typed_variable_values_no_diagnostic`, `dict_literal_with_wrong_value_type_still_fires` (`assignment_compatibility_tests.rs`).
- #336: `runtime_introspection_targets_the_dotted_submodule_not_its_root` (real Python: `__import__("concurrent.futures")` proven to yield zero members), `has_declarations_reports_a_header_only_stub_as_empty` / `..._populated_stub_as_non_empty`, `generate_writes_nothing_and_warns_for_a_module_with_no_public_api`.

Local verification: `cargo fmt --check` ✓, `cargo clippy --release --all-targets` ✓, checker/stubs/cli/lsp test suites ✓, and the real `python/typing@main` conformance harness at **100% / 0-FP with the committed `conformance_status.csv` byte-identical** (no regression from the stub-parsing/import-resolution changes).

## Spec/Doc Changes
None — behaviour-only fixes within existing spec anchors ([STUBRES-ENGINE], [CHKARCH-DIAG-STUB-MEMBER], [TYPEINF-VARS-ANNOTATED], BSK-0050/BSK-0152).

## Breaking Changes
No. All four narrow the set of diagnostics/behaviours toward correctness (fewer false positives; more accurate stub generation); no valid code that passed before now fails.

Refs #182 #324 #332 #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)