### PR TITLE
Judge built-in method arguments by type, not syntax: fix 4 str.join false positives and 1 missed error (#356)

### DIFF
--- a/crates/basilisk-checker/src/rules/calls_argument_type/arg_types.rs
+++ b/crates/basilisk-checker/src/rules/calls_argument_type/arg_types.rs
@@ -1,0 +1,302 @@
+//! Implements [CHKARCH-DIAG-TYPESAFETY]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-DIAG-TYPESAFETY
+//! Type-directed argument resolution for bound built-in method calls.
+//!
+//! The resolver classifies a call argument by the *syntactic shape* of its
+//! expression ([`RhsKind`]): a name is `Other` whatever it was declared to be,
+//! and a display element is `Other` even when its declared type is known. A
+//! rule that matches on those shapes cannot tell a valid `[*p]` (`p: list[str]`)
+//! from an invalid `[1]`, so it must either reject both or accept both
+//! (GitHub #356).
+//!
+//! This module answers the question the shape cannot: the *type* of the
+//! argument expression, resolved through the declared types visible at that
+//! point in the module. Anything it cannot resolve is [`InferredType::Unknown`],
+//! which every compatibility predicate here accepts — an unresolved expression
+//! never manufactures a diagnostic ([CHKARCH-CONFORMANCE-MODE]).
+
+use std::collections::HashMap;
+
+use basilisk_resolver::{iter_all_params, ResolvedModule, RhsKind, Span};
+use ruff_python_ast::visitor::{walk_body, walk_expr, walk_stmt, Visitor};
+use ruff_python_ast::{Expr, Stmt, StmtAnnAssign, StmtFunctionDef};
+use ruff_text_size::Ranged;
+
+use crate::inference::infer_rhs;
+use crate::rules::shared::{ann_str, parse_module};
+use crate::types::{InferredType, LiteralValue};
+
+/// Declared types of names, grouped by the source range of the scope that
+/// declares them.
+///
+/// A lookup is scope-aware: the *innermost* enclosing scope that declares the
+/// name wins, so a parameter of one function never supplies the type for a
+/// same-named parameter of another.
+pub(crate) struct ScopedTypes<'a> {
+    scopes: Vec<Scope>,
+    /// Every expression in the module, keyed by its exact source range — the
+    /// same range the resolver records for a call argument.
+    expressions: HashMap<(u32, u32), &'a Expr>,
+}
+
+/// One lexical scope: the range it spans and the types it declares.
+struct Scope {
+    range: Span,
+    names: HashMap<String, InferredType>,
+}
+
+impl<'a> ScopedTypes<'a> {
+    /// Collect every declared type and expression in `module`.
+    ///
+    /// Yields an empty table when the module does not parse; the parse error is
+    /// reported separately, and every lookup then answers `Unknown`.
+    pub(crate) fn from_module(module: &'a ResolvedModule) -> Self {
+        let module_range = Span::new(0, u32::try_from(module.source.len()).unwrap_or(u32::MAX));
+        let mut collector = Collector {
+            scopes: vec![Scope {
+                range: module_range,
+                names: HashMap::new(),
+            }],
+            expressions: HashMap::new(),
+            current: 0,
+        };
+        if let Some(parsed) = parse_module(module) {
+            walk_body(&mut collector, &parsed.ast.body);
+        }
+        Self {
+            scopes: collector.scopes,
+            expressions: collector.expressions,
+        }
+    }
+
+    /// The type of the argument expression occupying `span`.
+    ///
+    /// Falls back to the resolver's shape-derived inference when the span names
+    /// no expression (an unparsed module), which keeps the judgement gradual
+    /// rather than absent.
+    pub(crate) fn argument_type(&self, span: Span, rhs: &RhsKind) -> InferredType {
+        self.expressions
+            .get(&(span.start, span.end))
+            .map_or_else(|| infer_rhs(rhs), |expr| self.expr_type(expr))
+    }
+
+    /// The declared type of `name` as seen from `offset`, innermost scope first.
+    fn lookup(&self, name: &str, offset: u32) -> Option<&InferredType> {
+        self.scopes
+            .iter()
+            .filter(|scope| scope.range.contains_offset(offset))
+            .filter_map(|scope| {
+                let width = scope.range.end.saturating_sub(scope.range.start);
+                scope.names.get(name).map(|ty| (width, ty))
+            })
+            .min_by_key(|(width, _)| *width)
+            .map(|(_, ty)| ty)
+    }
+
+    /// The type of an arbitrary expression; `Unknown` when unresolvable.
+    fn expr_type(&self, expr: &Expr) -> InferredType {
+        match expr {
+            Expr::StringLiteral(_) => InferredType::LiteralString,
+            // An f-string is a `str` but never a `LiteralString` (PEP 675:
+            // interpolations may carry runtime data). A t-string is neither —
+            // it builds a `Template`, so it stays unresolved below.
+            Expr::FString(_) => InferredType::Str,
+            Expr::BytesLiteral(_) => InferredType::Bytes,
+            Expr::BooleanLiteral(_) => InferredType::Bool,
+            Expr::NoneLiteral(_) => InferredType::None_,
+            Expr::NumberLiteral(number) => number_type(&number.value),
+            Expr::Name(name) => self
+                .lookup(name.id.as_str(), name.range.start().to_u32())
+                .cloned()
+                .unwrap_or(InferredType::Unknown),
+            Expr::List(list) => InferredType::List(Box::new(self.element_type(&list.elts))),
+            Expr::Set(set) => InferredType::Set(Box::new(self.element_type(&set.elts))),
+            Expr::Tuple(tuple) => InferredType::Tuple(
+                tuple
+                    .elts
+                    .iter()
+                    .map(|element| self.unpacked_type(element))
+                    .collect(),
+            ),
+            _ => InferredType::Unknown,
+        }
+    }
+
+    /// The union of the element types of a list/set display.
+    fn element_type(&self, elements: &[Expr]) -> InferredType {
+        elements
+            .iter()
+            .map(|element| self.unpacked_type(element))
+            .fold(InferredType::Never, InferredType::union)
+    }
+
+    /// The type an element contributes to its display: its own type, or the
+    /// type it yields when it is unpacked (`*values`).
+    fn unpacked_type(&self, element: &Expr) -> InferredType {
+        match element {
+            Expr::Starred(starred) => iterated_type(&self.expr_type(&starred.value)),
+            other => self.expr_type(other),
+        }
+    }
+}
+
+/// The type produced by iterating `container`; `Unknown` when unknowable.
+fn iterated_type(container: &InferredType) -> InferredType {
+    match container {
+        InferredType::List(element) | InferredType::Set(element) => element.as_ref().clone(),
+        InferredType::Dict(key, _) => key.as_ref().clone(),
+        InferredType::Tuple(elements) => elements
+            .iter()
+            .cloned()
+            .fold(InferredType::Never, InferredType::union),
+        InferredType::Str | InferredType::LiteralString => InferredType::Str,
+        InferredType::Generator(yielded, _, _) => yielded.as_ref().clone(),
+        _ => InferredType::Unknown,
+    }
+}
+
+/// The type of a numeric literal.
+fn number_type(number: &ruff_python_ast::Number) -> InferredType {
+    match number {
+        ruff_python_ast::Number::Int(_) => InferredType::Int,
+        ruff_python_ast::Number::Float(_) => InferredType::Float,
+        ruff_python_ast::Number::Complex { .. } => InferredType::Named("complex".to_owned()),
+    }
+}
+
+/// Does `argument` satisfy an `Iterable[str]` / `Iterable[LiteralString]`
+/// parameter such as `str.join`'s?
+///
+/// `str` itself qualifies — iterating a string yields strings. Everything this
+/// module could not resolve qualifies too; only a positively-known mismatch is
+/// rejected.
+pub(crate) fn satisfies_str_iterable(argument: &InferredType) -> bool {
+    match argument {
+        InferredType::Literal(value) => matches!(value, LiteralValue::Str(_)),
+        InferredType::Int
+        | InferredType::Float
+        | InferredType::Bool
+        | InferredType::Bytes
+        | InferredType::None_ => false,
+        InferredType::List(element) | InferredType::Set(element) => may_be_str(element),
+        InferredType::Dict(key, _) => may_be_str(key),
+        InferredType::Tuple(elements) => elements.iter().all(may_be_str),
+        InferredType::Generator(yielded, _, _) => may_be_str(yielded),
+        // A union member that qualifies is enough: this check sees declared
+        // types, not narrowed ones, so `list[str] | None` inside an
+        // `if values is not None:` guard must not be rejected.
+        InferredType::Union(members) => members.iter().any(satisfies_str_iterable),
+        InferredType::Optional(inner) => satisfies_str_iterable(inner),
+        // `str`/`LiteralString` iterate as `Iterable[str]`; everything else
+        // reaching here is unresolved (`Unknown`, `Any`, a named class) and is
+        // accepted rather than guessed at.
+        _ => true,
+    }
+}
+
+/// Could a value of this type be a `str`? `true` unless it is positively known
+/// to be something else.
+fn may_be_str(element: &InferredType) -> bool {
+    match element {
+        InferredType::Int
+        | InferredType::Float
+        | InferredType::Bool
+        | InferredType::Bytes
+        | InferredType::None_
+        | InferredType::List(_)
+        | InferredType::Set(_)
+        | InferredType::Dict(_, _)
+        | InferredType::Tuple(_) => false,
+        InferredType::Literal(value) => matches!(value, LiteralValue::Str(_)),
+        InferredType::Union(members) => members.iter().all(may_be_str),
+        InferredType::Optional(inner) => may_be_str(inner),
+        _ => true,
+    }
+}
+
+/// Walks the module AST once, recording declared types per scope and indexing
+/// every expression by its source range.
+struct Collector<'a> {
+    scopes: Vec<Scope>,
+    expressions: HashMap<(u32, u32), &'a Expr>,
+    /// Index into `scopes` of the scope currently being filled.
+    current: usize,
+}
+
+impl<'a> Collector<'a> {
+    /// Open a scope for `function`, seeded with its annotated parameters, and
+    /// walk the whole definition inside it.
+    fn enter_function(&mut self, stmt: &'a Stmt, function: &'a StmtFunctionDef) {
+        self.scopes.push(Scope {
+            range: Span::from(function.range),
+            names: parameter_types(function),
+        });
+        let outer = std::mem::replace(&mut self.current, self.scopes.len() - 1);
+        walk_stmt(self, stmt);
+        self.current = outer;
+    }
+
+    /// Index a class body: its nested definitions are walked, but a class-level
+    /// `x: T` binds an attribute, not a name its methods can read, so the
+    /// annotation is only indexed — never recorded as a scope type.
+    fn enter_class_body(&mut self, body: &'a [Stmt]) {
+        for nested in body {
+            match nested {
+                Stmt::AnnAssign(assign) => self.index_annotation(assign),
+                other => self.visit_stmt(other),
+            }
+        }
+    }
+
+    /// Index every expression of `x: T = value` without recording the type.
+    fn index_annotation(&mut self, assign: &'a StmtAnnAssign) {
+        self.visit_expr(&assign.target);
+        self.visit_expr(&assign.annotation);
+        if let Some(value) = assign.value.as_ref() {
+            self.visit_expr(value);
+        }
+    }
+
+    /// Record `x: T` in the current scope when the target is a plain name.
+    fn record_annotation(&mut self, assign: &'a StmtAnnAssign) {
+        self.index_annotation(assign);
+        let Expr::Name(target) = assign.target.as_ref() else {
+            return;
+        };
+        let declared = InferredType::from_annotation(&ann_str(&assign.annotation));
+        if let Some(scope) = self.scopes.get_mut(self.current) {
+            let _ = scope.names.insert(target.id.to_string(), declared);
+        }
+    }
+}
+
+impl<'a> Visitor<'a> for Collector<'a> {
+    fn visit_stmt(&mut self, stmt: &'a Stmt) {
+        match stmt {
+            Stmt::FunctionDef(function) => self.enter_function(stmt, function),
+            Stmt::ClassDef(class) => self.enter_class_body(&class.body),
+            Stmt::AnnAssign(assign) => self.record_annotation(assign),
+            other => walk_stmt(self, other),
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        let range = expr.range();
+        let _ = self
+            .expressions
+            .insert((range.start().to_u32(), range.end().to_u32()), expr);
+        walk_expr(self, expr);
+    }
+}
+
+/// Parameter name → declared type for one function's annotated parameters.
+fn parameter_types(function: &StmtFunctionDef) -> HashMap<String, InferredType> {
+    iter_all_params(&function.parameters)
+        .filter_map(|param| {
+            let annotation = param.parameter.annotation.as_ref()?;
+            Some((
+                param.parameter.name.to_string(),
+                InferredType::from_annotation(&ann_str(annotation)),
+            ))
+        })
+        .collect()
+}

--- a/crates/basilisk-checker/src/rules/calls_argument_type/builtin_methods.rs
+++ b/crates/basilisk-checker/src/rules/calls_argument_type/builtin_methods.rs
@@ -1,0 +1,156 @@
+//! Implements [`calls_argument_type`] for bound built-in methods, from
+//! [CHKARCH-DIAG-TYPESAFETY]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-DIAG-TYPESAFETY
+//!
+//! A `receiver.method(...)` call whose receiver has a statically-known built-in
+//! type is checked against every applicable overload of the active
+//! `builtins.pyi` declaration ([STUBRES-PYI] #288) — never against a hand table.
+
+use basilisk_resolver::{CallSite, ResolvedModule, RhsKind};
+use basilisk_stubs::StubFunction;
+
+use crate::diagnostic::Diagnostic;
+use crate::types::InferredType;
+
+use super::arg_types::{satisfies_str_iterable, ScopedTypes};
+use super::{arg_rhs_mismatch, make_diagnostic};
+
+/// Validate arguments to bound built-in methods against all applicable
+/// overloads from the active `builtins.pyi` declaration ([STUBRES-PYI] #288).
+///
+/// Arguments are judged by their resolved *type* ([`ScopedTypes`]), not by the
+/// syntactic shape of the expression, so a display of `str`-typed elements is
+/// accepted and a `list[int]` name is rejected (GitHub #356).
+pub(super) fn check_builtin_method_argument_types(
+    module: &ResolvedModule,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Built once, and only for a module that actually calls a built-in method.
+    let mut scoped: Option<ScopedTypes<'_>> = None;
+    for call in &module.calls {
+        let declarations: Vec<_> = module
+            .builtin_methods_for_call(call)
+            .into_iter()
+            .filter(|declaration| {
+                crate::rules::calls_argument_count::stub_arity_accepts(declaration, call.args.len())
+            })
+            .collect();
+        if declarations.is_empty() {
+            continue;
+        }
+        let types = scoped.get_or_insert_with(|| ScopedTypes::from_module(module));
+        let argument_types: Vec<InferredType> = call
+            .args
+            .iter()
+            .map(|(rhs, span)| types.argument_type(*span, rhs))
+            .collect();
+        diagnostics.extend(incompatible_argument(
+            call,
+            &declarations,
+            &argument_types,
+            &module.path,
+        ));
+    }
+}
+
+/// The diagnostic for the first argument that no applicable overload accepts,
+/// or `None` when some overload accepts the whole call.
+fn incompatible_argument(
+    call: &CallSite,
+    declarations: &[&StubFunction],
+    argument_types: &[InferredType],
+    path: &str,
+) -> Option<Diagnostic> {
+    if declarations
+        .iter()
+        .any(|declaration| stub_accepts_call(declaration, call, argument_types))
+    {
+        return None;
+    }
+    let (index, ((_, span), argument)) = call.args.iter().zip(argument_types).enumerate().find(
+        |(index, ((rhs, _), argument))| {
+            declarations.iter().all(|declaration| {
+                stub_parameter_annotation(declaration, *index)
+                    .is_some_and(|annotation| !stub_argument_compatible(annotation, rhs, argument))
+            })
+        },
+    )?;
+    let expected = expected_annotations(declarations, index);
+    let description = describe_argument(argument, &expected);
+    Some(make_diagnostic(
+        &call.callee,
+        declarations
+            .first()
+            .and_then(|declaration| declaration.params.get(index))
+            .map_or("argument", |parameter| parameter.name.as_str()),
+        &expected,
+        &description,
+        *span,
+        path,
+    ))
+}
+
+/// Does this overload accept every argument at the call site?
+fn stub_accepts_call(
+    declaration: &StubFunction,
+    call: &CallSite,
+    argument_types: &[InferredType],
+) -> bool {
+    call.args
+        .iter()
+        .zip(argument_types)
+        .enumerate()
+        .all(|(index, ((rhs, _), argument))| {
+            stub_parameter_annotation(declaration, index)
+                .is_none_or(|annotation| stub_argument_compatible(annotation, rhs, argument))
+        })
+}
+
+/// The declared annotation of an overload's parameter at `index`.
+fn stub_parameter_annotation(declaration: &StubFunction, index: usize) -> Option<&str> {
+    declaration
+        .params
+        .get(index)
+        .and_then(|parameter| parameter.annotation.as_deref())
+}
+
+/// Every distinct annotation the applicable overloads declare at `index`,
+/// rendered as the union a caller must satisfy.
+fn expected_annotations(declarations: &[&StubFunction], index: usize) -> String {
+    declarations
+        .iter()
+        .filter_map(|declaration| stub_parameter_annotation(declaration, index))
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+/// Render the rejected argument as the Python type it resolved to — never as a
+/// dump of the resolver's internal expression-kind enum (GitHub #356).
+fn describe_argument(argument: &InferredType, expected: &str) -> String {
+    match argument {
+        InferredType::Unknown => format!("an argument incompatible with `{expected}`"),
+        resolved => format!("`{resolved}`"),
+    }
+}
+
+/// Is one argument compatible with the annotation an overload declares for it?
+///
+/// `argument` is the resolved type of the expression; `rhs` its syntactic shape,
+/// still consulted by the literal-kind comparison in [`arg_rhs_mismatch`].
+fn stub_argument_compatible(annotation: &str, rhs: &RhsKind, argument: &InferredType) -> bool {
+    let normalized = annotation.replace(' ', "");
+    if normalized == "Any" || normalized == "object" {
+        return true;
+    }
+    if normalized.contains("Iterable[str]") || normalized.contains("Iterable[LiteralString]") {
+        return satisfies_str_iterable(argument);
+    }
+    if normalized.contains("LiteralString") {
+        return matches!(
+            rhs,
+            RhsKind::StrLiteral | RhsKind::Other | RhsKind::CallExpr
+        );
+    }
+    arg_rhs_mismatch(annotation, rhs, None).is_none()
+}

--- a/crates/basilisk-checker/src/rules/calls_argument_type/mod.rs
+++ b/crates/basilisk-checker/src/rules/calls_argument_type/mod.rs
@@ -13,6 +13,9 @@
 //! result: int = add("hello", "world")   # str literals for int params → E0012
 //! ```
 
+mod arg_types;
+mod builtin_methods;
+
 use std::collections::HashMap;
 
 use basilisk_resolver::{FunctionInfo, ResolvedModule, RhsKind, Span, TypeVarCallInfo};
@@ -106,94 +109,8 @@ impl Rule for ArgumentTypeMismatch {
                 }
             }
         }
-        check_builtin_method_argument_types(module, diagnostics);
+        builtin_methods::check_builtin_method_argument_types(module, diagnostics);
     }
-}
-
-/// Validate literal arguments to bound built-in methods against all applicable
-/// overloads from the active `builtins.pyi` declaration ([STUBRES-PYI] #288).
-fn check_builtin_method_argument_types(module: &ResolvedModule, diagnostics: &mut Vec<Diagnostic>) {
-    for call in &module.calls {
-        let declarations: Vec<_> = module
-            .builtin_methods_for_call(call)
-            .into_iter()
-            .filter(|declaration| {
-                super::calls_argument_count::stub_arity_accepts(declaration, call.args.len())
-            })
-            .collect();
-        if declarations.is_empty() {
-            continue;
-        }
-        if declarations.iter().any(|declaration| {
-            call.args.iter().enumerate().all(|(index, (rhs, _))| {
-                declaration
-                    .params
-                    .get(index)
-                    .and_then(|parameter| parameter.annotation.as_deref())
-                    .is_none_or(|annotation| stub_argument_compatible(annotation, rhs))
-            })
-        }) {
-            continue;
-        }
-        let Some((index, (rhs, span))) = call.args.iter().enumerate().find(|(index, (rhs, _))| {
-            declarations.iter().all(|declaration| {
-                declaration
-                    .params
-                    .get(*index)
-                    .and_then(|parameter| parameter.annotation.as_deref())
-                    .is_some_and(|annotation| !stub_argument_compatible(annotation, rhs))
-            })
-        }) else {
-            continue;
-        };
-        let expected = declarations
-            .iter()
-            .filter_map(|declaration| declaration.params.get(index))
-            .filter_map(|parameter| parameter.annotation.as_deref())
-            .collect::<std::collections::BTreeSet<_>>()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .join(" | ");
-        let description = format!("an argument incompatible with `{expected}` ({rhs:?})");
-        diagnostics.push(make_diagnostic(
-            &call.callee,
-            declarations
-                .first()
-                .and_then(|declaration| declaration.params.get(index))
-                .map_or("argument", |parameter| parameter.name.as_str()),
-            &expected,
-            &description,
-            *span,
-            &module.path,
-        ));
-    }
-}
-
-fn stub_argument_compatible(annotation: &str, rhs: &RhsKind) -> bool {
-    let normalized = annotation.replace(' ', "");
-    if normalized == "Any" || normalized == "object" {
-        return true;
-    }
-    if normalized.contains("Iterable[str]") || normalized.contains("Iterable[LiteralString]") {
-        return match rhs {
-            RhsKind::StrLiteral
-            | RhsKind::EmptyList
-            | RhsKind::Other
-            | RhsKind::CallExpr
-            | RhsKind::KnownCall(_) => true,
-            RhsKind::List(items) | RhsKind::Tuple(items) | RhsKind::Set(items) => {
-                items.iter().all(|item| matches!(item, RhsKind::StrLiteral))
-            }
-            _ => false,
-        };
-    }
-    if normalized.contains("LiteralString") {
-        return matches!(
-            rhs,
-            RhsKind::StrLiteral | RhsKind::Other | RhsKind::CallExpr
-        );
-    }
-    arg_rhs_mismatch(annotation, rhs, None).is_none()
 }
 
 /// For an overloaded function, determine which function signature to check
@@ -271,7 +188,7 @@ fn is_overload_stub(func: &FunctionInfo, _module: &ResolvedModule) -> bool {
 ///
 /// `arg_source` is the raw source text of the argument expression, used to
 /// disambiguate `CallExpr` arguments (e.g. detecting `type(None)` vs other calls).
-fn arg_rhs_mismatch(
+pub(super) fn arg_rhs_mismatch(
     annotation: &str,
     rhs: &RhsKind,
     arg_source: Option<&str>,
@@ -411,7 +328,7 @@ fn is_type_call(arg_source: Option<&str>) -> bool {
     src.starts_with("type(") && src.ends_with(')')
 }
 
-fn make_diagnostic(
+pub(super) fn make_diagnostic(
     callee: &str,
     param_name: &str,
     annotation: &str,

--- a/crates/basilisk-checker/tests/checker/calls_argument_type_tests.rs
+++ b/crates/basilisk-checker/tests/checker/calls_argument_type_tests.rs
@@ -168,6 +168,204 @@ result: str = parse("hello")
     Ok(())
 }
 
+/// GitHub #356: `str.join` arguments are judged by the *type* of the argument
+/// expression, not by the syntactic shape of the display. A list/tuple whose
+/// elements are typed `str` — through a parameter annotation, an unpacked
+/// `list[str]`, or a `str` method call — is a valid `Iterable[str]`.
+#[test]
+fn str_join_accepts_typed_str_elements() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def f(p: list[str], s: str) -> None:
+    " ".join(["a", *p])
+    " ".join(["a", s])
+    " ".join([s.upper()])
+    " ".join(("a", s))
+    " ".join(p)
+    " ".join(["a", "b"])
+    " ".join([f"{s}!"])
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        messages_for(&diags, "calls_argument_type"),
+        Vec::<&str>::new(),
+        "list/tuple displays of `str`-typed elements are valid `Iterable[str]` arguments"
+    );
+    Ok(())
+}
+
+/// GitHub #356: the same type-directed check catches the genuine error a
+/// syntactic check missed — a bare name whose declared type is `list[int]`.
+#[test]
+fn str_join_rejects_list_int_argument() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def g(nums: list[int]) -> None:
+    " ".join(nums)
+"#;
+    let diags = run(source)?;
+    let messages = messages_for(&diags, "calls_argument_type");
+    assert_eq!(
+        messages.len(),
+        1,
+        "`list[int]` does not satisfy either `join` overload, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}
+
+/// GitHub #356: the received type renders as Python source, never as a `Debug`
+/// dump of the resolver's internal expression-kind enum.
+#[test]
+fn str_join_mismatch_message_renders_python_type() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def g(nums: list[int]) -> None:
+    " ".join(nums)
+"#;
+    let diags = run(source)?;
+    let messages = messages_for(&diags, "calls_argument_type");
+    let message = messages
+        .first()
+        .ok_or("`join` on a `list[int]` must be reported")?;
+    assert!(
+        message.contains("`list[int]`"),
+        "the message must name the argument's Python type, got: {message}"
+    );
+    assert!(
+        !message.contains("StrLiteral")
+            && !message.contains("IntLiteral")
+            && !message.contains("Other"),
+        "internal `RhsKind` variants must never reach the user, got: {message}"
+    );
+    Ok(())
+}
+
+/// GitHub #356 negative control: a non-`str` element literal is still rejected.
+#[test]
+fn str_join_rejects_int_element_literals() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def h() -> None:
+    " ".join([1, 2])
+"#;
+    let diags = run(source)?;
+    assert!(
+        codes(&diags).contains(&"calls_argument_type"),
+        "`list[int]` display must still violate both `join` overloads, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}
+
+/// GitHub #356: iterating a `dict` yields its keys, and iterating a `str`
+/// yields strings — both are valid `join` arguments when the element is a `str`.
+#[test]
+fn str_join_judges_iterated_element_type() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def f(mapping: dict[str, int], s: str, values: set[str]) -> None:
+    " ".join(mapping)
+    " ".join(s)
+    " ".join(values)
+    " ".join({s, "a"})
+    " ".join([])
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        messages_for(&diags, "calls_argument_type"),
+        Vec::<&str>::new(),
+        "`dict[str, _]`, `str` and `set[str]` all iterate as `Iterable[str]`"
+    );
+    Ok(())
+}
+
+/// GitHub #356: a `dict` whose keys are not `str` fails the same check that
+/// lets a `dict[str, int]` through.
+#[test]
+fn str_join_rejects_non_str_dict_keys() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def f(mapping: dict[int, str]) -> None:
+    " ".join(mapping)
+"#;
+    let diags = run(source)?;
+    assert!(
+        codes(&diags).contains(&"calls_argument_type"),
+        "iterating `dict[int, str]` yields `int` keys, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}
+
+/// GitHub #356: a module-level annotated variable supplies the argument type
+/// just as a parameter annotation does.
+#[test]
+fn str_join_resolves_module_level_annotation() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+counts: list[int] = []
+joined = " ".join(counts)
+"#;
+    let diags = run(source)?;
+    assert!(
+        codes(&diags).contains(&"calls_argument_type"),
+        "the module-level `list[int]` annotation must reach the call, got: {:?}",
+        codes(&diags)
+    );
+    Ok(())
+}
+
+/// GitHub #356: a class-level annotation binds an attribute, not a name a
+/// method body can read, so it must never type a bare name inside the method.
+#[test]
+fn str_join_ignores_class_level_annotations() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+class Report:
+    rows: list[int] = []
+
+    def render(self, rows: list[str]) -> None:
+        " ".join(rows)
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        messages_for(&diags, "calls_argument_type"),
+        Vec::<&str>::new(),
+        "`rows` in the method body is the `list[str]` parameter, not the class attribute"
+    );
+    Ok(())
+}
+
+/// GitHub #356: an inner function's parameter shadows the outer one.
+#[test]
+fn str_join_prefers_the_innermost_declaration() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def outer(values: list[int]) -> None:
+    def inner(values: list[str]) -> None:
+        " ".join(values)
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        messages_for(&diags, "calls_argument_type"),
+        Vec::<&str>::new(),
+        "the inner `list[str]` parameter shadows the outer `list[int]` one"
+    );
+    Ok(())
+}
+
+/// GitHub #356: name resolution is scope-aware — a parameter of an unrelated
+/// function must never supply the type for a same-named parameter here.
+#[test]
+fn str_join_resolves_names_in_their_own_scope() -> Result<(), Box<dyn std::error::Error>> {
+    let source = r#"
+def first(values: list[int]) -> None:
+    pass
+
+def second(values: list[str]) -> None:
+    " ".join(values)
+"#;
+    let diags = run(source)?;
+    assert_eq!(
+        messages_for(&diags, "calls_argument_type"),
+        Vec::<&str>::new(),
+        "`values` must resolve to the enclosing function's `list[str]` parameter"
+    );
+    Ok(())
+}
+
 #[test]
 fn multiple_params_mixed_mismatch() -> Result<(), Box<dyn std::error::Error>> {
     let source = r"


### PR DESCRIPTION
## TLDR

`calls_argument_type` now judges bound built-in method arguments by their resolved **type** instead of the syntactic shape of the expression, closing 4 false positives and 1 missed error on `str.join` (Refs #356).

## What Was Added?

- `crates/basilisk-checker/src/rules/calls_argument_type/arg_types.rs` — type-directed argument resolution:
  - `ScopedTypes` walks the module AST once, recording declared types per lexical scope (parameters, annotated locals, module-level annotations) and indexing every expression by its exact source range — the same range the resolver records for a call argument.
  - Lookups are scope-aware: the innermost enclosing scope that declares a name wins, so one function's parameter never types another's. Class-level annotations bind attributes, not names a method body can read, so they are indexed but never recorded as scope types.
  - Display elements resolve individually, including the element type behind a `*values` unpack; `dict` iterates as its keys, `str` as `str`.
  - Anything unresolvable stays `InferredType::Unknown` and is accepted — an unresolved expression can never manufacture a diagnostic ([CHKARCH-CONFORMANCE-MODE]).
- `crates/basilisk-checker/src/rules/calls_argument_type/builtin_methods.rs` — the stub-driven bound-method half of the rule, split out of the rule file (which was heading past the 500-LOC ceiling) and rewritten to thread resolved argument types through overload matching.

## What Was Changed or Deleted?

- `calls_argument_type.rs` became `calls_argument_type/mod.rs`; the built-in-method pass moved to `builtin_methods.rs` (mod.rs 438 → 355 LOC).
- The `Iterable[str] | Iterable[LiteralString]` branch no longer matches on `RhsKind`. It previously accepted `Other`/`CallExpr` at the top level while rejecting those same kinds one level down as elements, which is exactly why a valid `[*p]` and an invalid `[1]` were indistinguishable and a `list[int]` name sailed through.
- Diagnostic text renders the argument's Python type — `` `list[int]` `` — where it used to print a `Debug` dump of an internal enum, `(List([StrLiteral, Other]))`.

Behaviour on the four reported false positives (all valid Python, all previously flagged) and the missed error:

```python
def f(p: list[str], s: str) -> None:
    " ".join(["a", *p])       # was error → now clean
    " ".join(["a", s])        # was error → now clean
    " ".join([s.upper()])     # was error → now clean
    " ".join(("a", s))        # was error → now clean

def g(nums: list[int]) -> None:
    " ".join(nums)            # was silent → now: expects `Iterable[LiteralString] | Iterable[str]` but received `list[int]`
```

## How Do The Automated Tests Prove It Works?

Ten new tests in `crates/basilisk-checker/tests/checker/calls_argument_type_tests.rs`, all written and confirmed failing against the old code first:

- `str_join_accepts_typed_str_elements` — the four reported false-positive forms plus the three that already worked; asserts an empty `calls_argument_type` message list. Failed before the fix with all four messages present.
- `str_join_rejects_list_int_argument` — `" ".join(nums)` with `nums: list[int]` must report exactly one diagnostic. Failed before (0 reported).
- `str_join_mismatch_message_renders_python_type` — the message contains `` `list[int]` `` and none of `StrLiteral`/`IntLiteral`/`Other`.
- `str_join_rejects_int_element_literals` — negative control: `[1, 2]` still errors.
- `str_join_judges_iterated_element_type` — `dict[str, int]`, `str`, `set[str]`, a set display and `[]` all pass.
- `str_join_rejects_non_str_dict_keys` — `dict[int, str]` iterates as `int` and is reported.
- `str_join_resolves_module_level_annotation` — a module-level `counts: list[int]` reaches the call.
- `str_join_ignores_class_level_annotations` / `str_join_prefers_the_innermost_declaration` / `str_join_resolves_names_in_their_own_scope` — scope guards: a class attribute never types a method-body name, an inner parameter shadows the outer one, and a same-named parameter of an unrelated function is never consulted.

Existing coverage held: `real_bundled_str_join_drives_call_checking` (only the `[1]` iterable violates both real typeshed overloads) and `pyi_mutation_flows_through_no_hand_table` still pass unchanged.

Full local CI: conformance **141/141 = 100%, 0 false positives, 0 missed** against a fresh `python/typing@39164cd` clone scored by the suite's own harness; coverage `basilisk-checker: 94% ≥ 93%` with every crate threshold met; mutation gate unchanged at 144 mutants / 137 caught / 0 missed / 100% kill rate; lint, deslop, docs-drift, Zed, VS Code (93% ≥ 92%), Neovim (45% ≥ 44%), Shipwright and website e2e all green.

## Breaking Changes

- [x] None
