### PR TITLE
Add `imports_missing_name` rule; make generated and empty stubs honest

### DIFF
--- a/crates/basilisk-checker/src/imports/resolve.rs
+++ b/crates/basilisk-checker/src/imports/resolve.rs
@@ -88,7 +88,15 @@ fn resolve_module_cached_with_importer(
     //    (`.pyi` before `.py`).
     for stub_dir in &search_paths.stub_paths {
         if let Some(resolved) = try_resolve_stub_only(module_name, stub_dir, fs) {
-            return Some(resolved);
+            // A stub that fails to parse — or a module stub that declares
+            // nothing — carries no type information. Treat it as absent so
+            // resolution falls through to the remaining steps and BSK-0152
+            // still reports the package as untyped, instead of a contentless
+            // `.pyi` silencing the very rule it was generated to satisfy
+            // (GitHub #336).
+            if stub_provides_type_info(&resolved.path, module_name) {
+                return Some(resolved);
+            }
         }
     }
     for dir in &search_paths.extra_paths {
@@ -192,6 +200,45 @@ pub(crate) fn resolve_module_with_importer_cached(
         importing_file.and_then(Path::parent),
         fs,
     )
+}
+
+/// Whether a step-1 user stub actually provides type information: it parses,
+/// and (for a module stub) declares or re-exports at least one name. An empty
+/// but parseable `__init__.pyi` remains valid — it is the conventional package
+/// marker of a partial stub tree. Implements the GitHub #336 fix: an empty or
+/// unparseable stub is treated as absent rather than as type coverage.
+fn stub_provides_type_info(stub_path: &Path, module_name: &str) -> bool {
+    let Ok(content) = basilisk_common::fs::read_tracked(stub_path) else {
+        return false;
+    };
+    let tier = basilisk_stubs::user_stub_tier(&content);
+    let Ok(stub) = basilisk_stubs::parse_pyi_source(
+        &content,
+        stub_path,
+        module_name,
+        basilisk_stubs::StubSource::UserStub,
+        tier,
+    ) else {
+        return false;
+    };
+    stub_path
+        .file_name()
+        .is_some_and(|name| name == "__init__.pyi")
+        || stub_declares_names(&stub)
+}
+
+/// Whether a parsed stub declares or re-exports at least one name.
+fn stub_declares_names(stub: &basilisk_stubs::StubModule) -> bool {
+    !stub.functions.is_empty()
+        || !stub.overloads.is_empty()
+        || !stub.classes.is_empty()
+        || !stub.variables.is_empty()
+        || !stub.reexported_names.is_empty()
+        || !stub.star_reexports.is_empty()
+        || stub
+            .dunder_all
+            .as_ref()
+            .is_some_and(|names| !names.is_empty())
 }
 
 /// Try resolving a module in a stub-only directory (only `.pyi` files).

--- a/crates/basilisk-checker/src/imports/resolve_tests.rs
+++ b/crates/basilisk-checker/src/imports/resolve_tests.rs
@@ -356,3 +356,84 @@ fn importer_directory_is_user_code_before_site_packages() {
             .expect("importer-local user code resolves");
     assert_eq!(resolved.path, expected);
 }
+
+/// GitHub #336 (bug 3): a `stub-paths` stub that declares nothing must be
+/// treated as absent. Resolution falls through to the installed `.py` source,
+/// so BSK-0152 still reports the package as untyped — an empty stub must not
+/// turn the gate green while providing no type information.
+#[test]
+fn stub_path_stub_declaring_nothing_is_treated_as_absent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let stubs = temp.path().join("stubs");
+    std::fs::create_dir_all(&stubs).expect("create stubs dir");
+    std::fs::write(
+        stubs.join("foopkg.pyi"),
+        "# Auto-generated stub\n\nfrom typing import Any\n",
+    )
+    .expect("write empty stub");
+    let site_packages = temp.path().join("site-packages");
+    let expected = write_module(&site_packages, "foopkg", "py");
+    let mut paths = search_paths(&site_packages);
+    paths.stub_paths.push(stubs);
+
+    let resolved = resolve_module("foopkg", &paths)
+        .expect("resolution must fall through to the installed source");
+    assert_eq!(
+        resolved.path, expected,
+        "a declaration-less stub must not shadow the installed source"
+    );
+    assert_eq!(
+        resolved.resolution,
+        basilisk_resolver::scope::ImportResolution::SourcePy,
+        "the fall-through resolution must be SourcePy so BSK-0152 can fire"
+    );
+}
+
+/// GitHub #336 follow-up: a `stub-paths` stub that fails to parse (e.g. the
+/// generator's former `-> <class 'str'>` output) must likewise be treated as
+/// absent instead of silently counting as type information.
+#[test]
+fn stub_path_stub_that_fails_to_parse_is_treated_as_absent() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let stubs = temp.path().join("stubs");
+    std::fs::create_dir_all(&stubs).expect("create stubs dir");
+    std::fs::write(
+        stubs.join("foopkg.pyi"),
+        "from typing import Any\n\ndef get_host(self) -> <class 'str'>: ...\n",
+    )
+    .expect("write broken stub");
+    let site_packages = temp.path().join("site-packages");
+    let expected = write_module(&site_packages, "foopkg", "py");
+    let mut paths = search_paths(&site_packages);
+    paths.stub_paths.push(stubs);
+
+    let resolved = resolve_module("foopkg", &paths)
+        .expect("resolution must fall through to the installed source");
+    assert_eq!(
+        resolved.path, expected,
+        "an unparseable stub must not shadow the installed source"
+    );
+    assert_eq!(
+        resolved.resolution,
+        basilisk_resolver::scope::ImportResolution::SourcePy,
+        "the fall-through resolution must be SourcePy so BSK-0152 can fire"
+    );
+}
+
+/// Guard: a `stub-paths` stub with real declarations keeps winning step 1 —
+/// treating empty stubs as absent must not disturb valid manual stubs.
+#[test]
+fn stub_path_stub_with_declarations_still_wins_step_one() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let stubs = temp.path().join("stubs");
+    std::fs::create_dir_all(&stubs).expect("create stubs dir");
+    let expected = stubs.join("foopkg.pyi");
+    std::fs::write(&expected, "class Widget: ...\n").expect("write real stub");
+    let site_packages = temp.path().join("site-packages");
+    let _shadow = write_module(&site_packages, "foopkg", "py");
+    let mut paths = search_paths(&site_packages);
+    paths.stub_paths.push(stubs);
+
+    let resolved = resolve_module("foopkg", &paths).expect("manual stub must resolve");
+    assert_eq!(resolved.path, expected);
+}

--- a/crates/basilisk-checker/src/rules/imports_missing_name.rs
+++ b/crates/basilisk-checker/src/rules/imports_missing_name.rs
@@ -1,0 +1,431 @@
+//! Implements [CHKARCH-DIAG-IMPORT-MEMBER]. See docs/specs/CHECKER-ARCHITECTURE-SPEC.md#CHKARCH-DIAG-IMPORT-MEMBER
+//! `imports_missing_name`: Importing a name the resolved module does not define.
+//!
+//! `from M import name` only proves that the module path `M` resolves to a
+//! file; it says nothing about `name`. When `M` is a workspace `.py` source
+//! Basilisk can see every module-level binding, so importing a name that is
+//! neither bound in `M`, nor an existing submodule of the package, is an
+//! `ImportError` waiting for runtime (GitHub #55).
+//!
+//! ```python
+//! from demo.late_module import provide_value  # late_module.py defines nothing
+//! ```
+//!
+//! The rule is deliberately conservative — silence over guessing:
+//!
+//! - Every module-level binding form counts as defined: `def`/`class`,
+//!   every assignment form, `import`/`from` re-exports, `for`/`with`/`match`/
+//!   `except` targets, walrus expressions, and `type` alias statements.
+//! - A module-level `__getattr__` (PEP 562) permits any name.
+//! - A target containing `from x import *` has an unknowable member set and
+//!   suppresses the rule for that module.
+//! - `from pkg import mod` is satisfied by an existing `pkg/mod.py`,
+//!   `pkg/mod.pyi`, or `pkg/mod/` submodule.
+//!
+//! Scope: `from`-imports resolved to workspace `.py` sources. Stub-backed
+//! imports are covered by `imports_module_attribute`; site-packages sources
+//! stay with `missing_type_stubs` (PEP 561 draws the trust boundary there).
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
+
+use basilisk_resolver::{ImportInfo, ImportResolution, ResolvedModule, Span};
+use ruff_python_ast::visitor::{walk_expr, walk_stmt, Visitor};
+use ruff_python_ast::{self as ast, Expr, Stmt};
+use ruff_text_size::Ranged as _;
+
+use crate::diagnostic::{error_diagnostic_owned, Diagnostic, ErrorCode};
+
+use super::Rule;
+
+const CODE: ErrorCode = ErrorCode {
+    code: "imports_missing_name",
+    docs_url: "https://www.basilisk-python.dev/errors/imports_missing_name",
+};
+
+/// Emits `imports_missing_name` for `from M import name` where the resolved
+/// workspace module `M` defines no `name` (GitHub #55).
+pub(crate) struct MissingImportedName;
+
+impl Rule for MissingImportedName {
+    fn check(
+        &self,
+        module: &ResolvedModule,
+        _ctx: &super::CheckContext,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        let candidates: Vec<&ImportInfo> = module
+            .imports
+            .iter()
+            .filter(|import| is_checkable_from_import(import))
+            .collect();
+        if candidates.is_empty() {
+            return;
+        }
+        let Some(parsed) = super::shared::parse_module(module) else {
+            return;
+        };
+        let from_stmts = collect_from_imports(&parsed.ast.body);
+        for import in candidates {
+            let Some(stmt) = from_stmts.get(&(import.span.start, import.span.end)) else {
+                continue;
+            };
+            check_from_import(import, stmt, module, diagnostics);
+        }
+    }
+}
+
+/// A `from`-import is checkable when it resolved to a workspace `.py` source.
+///
+/// Site-packages sources are excluded: untyped third-party code is
+/// `missing_type_stubs`' domain, and PEP 561 says its contents must not be
+/// trusted either way.
+fn is_checkable_from_import(import: &ImportInfo) -> bool {
+    if import.kind != basilisk_resolver::scope::ImportKind::From
+        || import.resolution != ImportResolution::SourcePy
+    {
+        return false;
+    }
+    import.resolved_path.as_deref().is_some_and(|path| {
+        path.extension().is_some_and(|ext| ext == "py")
+            && !path.to_string_lossy().contains("site-packages")
+    })
+}
+
+/// Index every `from`-import statement in the AST by its byte span, so each
+/// resolved [`ImportInfo`] can be matched back to its alias list.
+fn collect_from_imports(body: &[Stmt]) -> HashMap<(u32, u32), &ast::StmtImportFrom> {
+    struct FromImportVisitor<'a> {
+        found: HashMap<(u32, u32), &'a ast::StmtImportFrom>,
+    }
+    impl<'a> Visitor<'a> for FromImportVisitor<'a> {
+        fn visit_stmt(&mut self, stmt: &'a Stmt) {
+            if let Stmt::ImportFrom(import_from) = stmt {
+                let range = import_from.range();
+                let _previous = self
+                    .found
+                    .insert((range.start().to_u32(), range.end().to_u32()), import_from);
+            }
+            walk_stmt(self, stmt);
+        }
+    }
+    let mut visitor = FromImportVisitor {
+        found: HashMap::new(),
+    };
+    for stmt in body {
+        visitor.visit_stmt(stmt);
+    }
+    visitor.found
+}
+
+/// Check one resolved `from`-import's aliases against the target module.
+fn check_from_import(
+    import: &ImportInfo,
+    stmt: &ast::StmtImportFrom,
+    module: &ResolvedModule,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(target_path) = import.resolved_path.as_deref() else {
+        return;
+    };
+    let Some(bindings) = target_bindings(target_path) else {
+        return; // unreadable or unparseable target: silence over guessing
+    };
+    if bindings.has_getattr || bindings.has_star_import {
+        return;
+    }
+    let is_package_init = target_path
+        .file_name()
+        .is_some_and(|name| name == "__init__.py");
+    for alias in &stmt.names {
+        let imported = alias.name.as_str();
+        if bindings.names.contains(imported) {
+            continue;
+        }
+        if is_package_init && submodule_exists(target_path, imported) {
+            continue;
+        }
+        // Cross-module mode resolves imports against live buffer content; if
+        // it found the bound name, the on-disk view is stale — trust it.
+        let bound = alias.asname.as_ref().map_or(imported, |name| name.as_str());
+        if module.imported_symbols.contains_key(bound) {
+            continue;
+        }
+        let range = alias.name.range();
+        diagnostics.push(error_diagnostic_owned(
+            CODE,
+            format!(
+                "Cannot import name `{imported}` from `{}` — the module defines no such name",
+                import.module
+            ),
+            Span::new(range.start().to_u32(), range.end().to_u32()),
+            &module.path,
+            Some(format!(
+                "define `{imported}` in `{}`, or fix the typo. A module-level \
+                 `def __getattr__(name: str) -> Any: ...` makes the module dynamic \
+                 and permits any name (PEP 562).",
+                target_path.display()
+            )),
+            Some(
+                "`from M import X` requires `X` to be an attribute of `M` or one of its \
+                 submodules; otherwise it raises `ImportError` at runtime. \
+                 https://docs.python.org/3/reference/import.html#submodules"
+                    .to_owned(),
+            ),
+        ));
+    }
+}
+
+/// Whether the package directory owning `init_path` contains a submodule
+/// (`name.py`, `name.pyi`, or a `name/` package) — `from pkg import name`
+/// imports the submodule when the `__init__` binds no such attribute.
+fn submodule_exists(init_path: &std::path::Path, name: &str) -> bool {
+    let Some(package_dir) = init_path.parent() else {
+        return false;
+    };
+    package_dir.join(format!("{name}.py")).is_file()
+        || package_dir.join(format!("{name}.pyi")).is_file()
+        || package_dir.join(name).is_dir()
+}
+
+// ---------------------------------------------------------------------------
+// Target-module binding collection
+// ---------------------------------------------------------------------------
+
+/// The importable surface of one target module, as visible statically.
+struct TargetBindings {
+    /// Every module-level bound name, across all binding statement forms.
+    names: HashSet<String>,
+    /// `__getattr__` present (PEP 562) — any name is importable.
+    has_getattr: bool,
+    /// The module star-imports another — its member set is unknowable.
+    has_star_import: bool,
+}
+
+/// Memo key: target path plus its content hash, so an edited file re-parses.
+type BindingsKey = (String, u64);
+/// The memo table shared by every checked file in the process.
+type BindingsMemo = HashMap<BindingsKey, std::sync::Arc<TargetBindings>>;
+
+/// Per-process cache of parsed target bindings, keyed by path and content
+/// hash. The content is re-read (and read-set-tracked) on every check so the
+/// CLI result cache still records the dependency edge; only the parse and
+/// AST walk are amortised.
+fn bindings_memo() -> &'static Mutex<BindingsMemo> {
+    static MEMO: OnceLock<Mutex<BindingsMemo>> = OnceLock::new();
+    MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Read, parse, and index the target module's bindings. `None` when the file
+/// is unreadable or does not parse — the rule stays silent rather than guess.
+fn target_bindings(path: &std::path::Path) -> Option<std::sync::Arc<TargetBindings>> {
+    let source = basilisk_common::fs::read_tracked(path).ok()?;
+    let key = (
+        path.to_string_lossy().into_owned(),
+        basilisk_common::fs::content_hash(&source),
+    );
+    if let Some(cached) = bindings_memo().lock().ok()?.get(&key) {
+        return Some(std::sync::Arc::clone(cached));
+    }
+    let parsed = basilisk_parser::parse_source(source, key.0.clone()).ok()?;
+    let bindings = std::sync::Arc::new(collect_bindings(&parsed.ast.body));
+    if let Ok(mut memo) = bindings_memo().lock() {
+        let _previous = memo.insert(key, std::sync::Arc::clone(&bindings));
+    }
+    Some(bindings)
+}
+
+/// Collect every module-level binding in `body`, recursing through control
+/// flow (`if`/`for`/`while`/`with`/`try`/`match`) but not into function or
+/// class bodies — those bind their own scopes, not the module.
+fn collect_bindings(body: &[Stmt]) -> TargetBindings {
+    let mut bindings = TargetBindings {
+        names: HashSet::new(),
+        has_getattr: false,
+        has_star_import: false,
+    };
+    collect_from_statements(body, &mut bindings);
+    // Walrus targets bind the enclosing scope from arbitrary expression
+    // positions; collect them from the whole tree. Over-inclusive on purpose
+    // (a function-local walrus also lands here) — silence over guessing.
+    let mut walrus = WalrusVisitor {
+        names: &mut bindings.names,
+    };
+    for stmt in body {
+        walrus.visit_stmt(stmt);
+    }
+    bindings.has_getattr = bindings.names.contains("__getattr__");
+    bindings
+}
+
+fn collect_from_statements(body: &[Stmt], bindings: &mut TargetBindings) {
+    for stmt in body {
+        match stmt {
+            Stmt::FunctionDef(def) => {
+                let _new = bindings.names.insert(def.name.to_string());
+            }
+            Stmt::ClassDef(def) => {
+                let _new = bindings.names.insert(def.name.to_string());
+            }
+            Stmt::Assign(assign) => {
+                for target in &assign.targets {
+                    collect_target(target, &mut bindings.names);
+                }
+            }
+            Stmt::AnnAssign(assign) => collect_target(&assign.target, &mut bindings.names),
+            Stmt::AugAssign(assign) => collect_target(&assign.target, &mut bindings.names),
+            Stmt::TypeAlias(alias) => collect_target(&alias.name, &mut bindings.names),
+            Stmt::Import(import) => {
+                for alias in &import.names {
+                    let bound = alias.asname.as_ref().map_or_else(
+                        // Plain `import a.b` binds the top-level `a`.
+                        || {
+                            alias
+                                .name
+                                .split('.')
+                                .next()
+                                .unwrap_or(alias.name.as_str())
+                                .to_owned()
+                        },
+                        ToString::to_string,
+                    );
+                    let _new = bindings.names.insert(bound);
+                }
+            }
+            Stmt::ImportFrom(import) => {
+                for alias in &import.names {
+                    if alias.name.as_str() == "*" {
+                        bindings.has_star_import = true;
+                    } else {
+                        let bound = alias.asname.as_ref().unwrap_or(&alias.name);
+                        let _new = bindings.names.insert(bound.to_string());
+                    }
+                }
+            }
+            Stmt::For(for_stmt) => {
+                collect_target(&for_stmt.target, &mut bindings.names);
+                collect_from_statements(&for_stmt.body, bindings);
+                collect_from_statements(&for_stmt.orelse, bindings);
+            }
+            Stmt::While(while_stmt) => {
+                collect_from_statements(&while_stmt.body, bindings);
+                collect_from_statements(&while_stmt.orelse, bindings);
+            }
+            Stmt::If(if_stmt) => {
+                collect_from_statements(&if_stmt.body, bindings);
+                for clause in &if_stmt.elif_else_clauses {
+                    collect_from_statements(&clause.body, bindings);
+                }
+            }
+            Stmt::With(with_stmt) => {
+                for item in &with_stmt.items {
+                    if let Some(vars) = &item.optional_vars {
+                        collect_target(vars, &mut bindings.names);
+                    }
+                }
+                collect_from_statements(&with_stmt.body, bindings);
+            }
+            Stmt::Try(try_stmt) => {
+                collect_from_statements(&try_stmt.body, bindings);
+                for handler in &try_stmt.handlers {
+                    let ast::ExceptHandler::ExceptHandler(handler) = handler;
+                    if let Some(name) = &handler.name {
+                        let _new = bindings.names.insert(name.to_string());
+                    }
+                    collect_from_statements(&handler.body, bindings);
+                }
+                collect_from_statements(&try_stmt.orelse, bindings);
+                collect_from_statements(&try_stmt.finalbody, bindings);
+            }
+            Stmt::Match(match_stmt) => {
+                for case in &match_stmt.cases {
+                    collect_pattern(&case.pattern, &mut bindings.names);
+                    collect_from_statements(&case.body, bindings);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Bind every name in an assignment-target expression (`a`, `a, b`, `[a, *b]`).
+fn collect_target(target: &Expr, names: &mut HashSet<String>) {
+    match target {
+        Expr::Name(name) => {
+            let _new = names.insert(name.id.to_string());
+        }
+        Expr::Tuple(tuple) => {
+            for element in &tuple.elts {
+                collect_target(element, names);
+            }
+        }
+        Expr::List(list) => {
+            for element in &list.elts {
+                collect_target(element, names);
+            }
+        }
+        Expr::Starred(starred) => collect_target(&starred.value, names),
+        // Attribute/subscript targets mutate existing objects, binding nothing.
+        _ => {}
+    }
+}
+
+/// Bind every capture name in a `match` pattern.
+fn collect_pattern(pattern: &ast::Pattern, names: &mut HashSet<String>) {
+    match pattern {
+        ast::Pattern::MatchAs(as_pattern) => {
+            if let Some(name) = &as_pattern.name {
+                let _new = names.insert(name.to_string());
+            }
+            if let Some(inner) = &as_pattern.pattern {
+                collect_pattern(inner, names);
+            }
+        }
+        ast::Pattern::MatchStar(star) => {
+            if let Some(name) = &star.name {
+                let _new = names.insert(name.to_string());
+            }
+        }
+        ast::Pattern::MatchSequence(sequence) => {
+            for inner in &sequence.patterns {
+                collect_pattern(inner, names);
+            }
+        }
+        ast::Pattern::MatchMapping(mapping) => {
+            for inner in &mapping.patterns {
+                collect_pattern(inner, names);
+            }
+            if let Some(rest) = &mapping.rest {
+                let _new = names.insert(rest.to_string());
+            }
+        }
+        ast::Pattern::MatchClass(class) => {
+            for inner in &class.arguments.patterns {
+                collect_pattern(inner, names);
+            }
+            for keyword in &class.arguments.keywords {
+                collect_pattern(&keyword.pattern, names);
+            }
+        }
+        ast::Pattern::MatchOr(or_pattern) => {
+            for inner in &or_pattern.patterns {
+                collect_pattern(inner, names);
+            }
+        }
+        ast::Pattern::MatchValue(_) | ast::Pattern::MatchSingleton(_) => {}
+    }
+}
+
+/// Records walrus (`:=`) targets from every expression in the tree.
+struct WalrusVisitor<'names> {
+    names: &'names mut HashSet<String>,
+}
+
+impl Visitor<'_> for WalrusVisitor<'_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        if let Expr::Named(named) = expr {
+            collect_target(&named.target, self.names);
+        }
+        walk_expr(self, expr);
+    }
+}

--- a/crates/basilisk-checker/src/rules/mod.rs
+++ b/crates/basilisk-checker/src/rules/mod.rs
@@ -97,6 +97,7 @@ pub(crate) mod generics_variance;
 pub(crate) mod generics_variance_inference;
 pub(crate) mod guards;
 pub(crate) mod historical_positional;
+pub(crate) mod imports_missing_name;
 pub(crate) mod imports_module_attribute;
 pub(crate) mod imports_unresolved;
 pub(crate) mod lambda_missing_annotations;
@@ -219,6 +220,7 @@ fn all_rules() -> &'static [&'static dyn Rule] {
         &missing_vararg_annotation::MissingVarArgAnnotation,
         &missing_attribute_annotation::MissingAttributeAnnotation,
         &imports_unresolved::ImportFromUntypedModule,
+        &imports_missing_name::MissingImportedName,
         &returns_compatibility::ReturnTypeMismatch,
         &calls_argument_type::ArgumentTypeMismatch,
         &returns_compatibility_2::ReturnTypeMismatch,

--- a/crates/basilisk-checker/tests/imports_missing_name_tests.rs
+++ b/crates/basilisk-checker/tests/imports_missing_name_tests.rs
@@ -1,0 +1,280 @@
+//! Tests for [CHKARCH-DIAG-IMPORT-MEMBER] (`imports_missing_name`, GitHub #55).
+//! `from M import name` where the resolved workspace module defines no `name`
+//! must produce a diagnostic — module-path resolution alone is not enough.
+#![allow(
+    clippy::allow_attributes,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    missing_docs
+)]
+
+use std::fs;
+use std::path::Path;
+
+use basilisk_checker::imports::resolve_module_imports;
+
+mod import_support;
+use import_support::{make_search_paths, make_tmp_dir};
+
+/// Parse + resolve `source` as `<root>/consumer.py`, resolve its imports
+/// against `root`, and run the full default-config rule set over it.
+fn check_consumer(root: &Path, source: &str) -> Vec<basilisk_checker::Diagnostic> {
+    let consumer = root.join("consumer.py");
+    fs::write(&consumer, source).unwrap();
+    let parsed =
+        basilisk_parser::parse_source(source.to_owned(), consumer.to_string_lossy().into_owned())
+            .unwrap();
+    let mut resolved = basilisk_resolver::resolve(&parsed).unwrap();
+    let paths = make_search_paths(vec![root.to_path_buf()]);
+    resolve_module_imports(&mut resolved, &paths);
+    basilisk_checker::check_with_config(&resolved, &basilisk_config::BasiliskConfig::default())
+}
+
+fn codes(diagnostics: &[basilisk_checker::Diagnostic]) -> Vec<&str> {
+    diagnostics.iter().map(|d| d.code.code).collect()
+}
+
+/// GitHub #55, the exact filed repro: the target module resolves but is empty,
+/// so the imported name cannot exist — a diagnostic is required.
+#[test]
+fn from_import_of_name_missing_from_resolved_module_is_flagged() {
+    let root = make_tmp_dir("missing_name_empty_module");
+    fs::create_dir_all(root.join("demo")).unwrap();
+    fs::write(root.join("demo/__init__.py"), "").unwrap();
+    fs::write(root.join("demo/late_module.py"), "").unwrap();
+
+    let diagnostics = check_consumer(
+        &root,
+        "from demo.late_module import provide_value\n\n\
+         def use() -> int:\n    return provide_value()\n",
+    );
+
+    let missing: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code.code == "imports_missing_name")
+        .collect();
+    assert_eq!(
+        missing.len(),
+        1,
+        "importing `provide_value` from an empty module must be flagged \
+         (GitHub #55); got diagnostics: {:?}",
+        codes(&diagnostics)
+    );
+    assert!(
+        missing[0].message.contains("provide_value")
+            && missing[0].message.contains("demo.late_module"),
+        "the diagnostic must name both the missing symbol and the module: {}",
+        missing[0].message
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// The gap is not an empty-file special case: a module that defines OTHER
+/// names still draws the diagnostic for the one it doesn't define — and no
+/// diagnostic for the one it does.
+#[test]
+fn from_import_flags_only_the_undefined_name_in_a_nonempty_module() {
+    let root = make_tmp_dir("missing_name_nonempty_module");
+    fs::create_dir_all(root.join("demo")).unwrap();
+    fs::write(root.join("demo/__init__.py"), "").unwrap();
+    fs::write(root.join("demo/other.py"), "DEFINED_NAME: int = 1\n").unwrap();
+
+    let diagnostics = check_consumer(&root, "from demo.other import DEFINED_NAME, missing_name\n");
+
+    let missing: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code.code == "imports_missing_name")
+        .collect();
+    assert_eq!(
+        missing.len(),
+        1,
+        "exactly `missing_name` must be flagged, never `DEFINED_NAME`; got: {:?}",
+        codes(&diagnostics)
+    );
+    assert!(missing[0].message.contains("missing_name"));
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// `from m import real as alias` checks the IMPORTED name (`real`), not the
+/// local alias — aliasing an existing name is fine.
+#[test]
+fn aliased_from_import_checks_the_imported_name_not_the_alias() {
+    let root = make_tmp_dir("missing_name_alias");
+    fs::write(root.join("target.py"), "value = 1\n").unwrap();
+
+    let diagnostics = check_consumer(&root, "from target import value as v\n");
+    assert!(
+        !codes(&diagnostics).contains(&"imports_missing_name"),
+        "aliasing an existing name must not be flagged; got: {:?}",
+        codes(&diagnostics)
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// `from pkg import mod` where `pkg/mod.py` exists is a SUBMODULE import — the
+/// package `__init__.py` need not bind the name. Must never be flagged.
+#[test]
+fn from_package_import_of_existing_submodule_is_not_flagged() {
+    let root = make_tmp_dir("missing_name_submodule");
+    fs::create_dir_all(root.join("pkg")).unwrap();
+    fs::write(root.join("pkg/__init__.py"), "").unwrap();
+    fs::write(root.join("pkg/mod.py"), "x = 1\n").unwrap();
+
+    let diagnostics = check_consumer(&root, "from pkg import mod\n");
+    assert!(
+        !codes(&diagnostics).contains(&"imports_missing_name"),
+        "an existing submodule satisfies `from pkg import mod`; got: {:?}",
+        codes(&diagnostics)
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// A module-level `__getattr__` (PEP 562) makes every attribute importable —
+/// the rule must stand down entirely for such modules.
+#[test]
+fn module_level_getattr_suppresses_the_rule() {
+    let root = make_tmp_dir("missing_name_getattr");
+    fs::write(
+        root.join("dynamic.py"),
+        "def __getattr__(name: str) -> object: ...\n",
+    )
+    .unwrap();
+
+    let diagnostics = check_consumer(&root, "from dynamic import anything_at_all\n");
+    assert!(
+        !codes(&diagnostics).contains(&"imports_missing_name"),
+        "PEP 562 `__getattr__` permits any name; got: {:?}",
+        codes(&diagnostics)
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// A target module containing `from x import *` has a statically unknowable
+/// member set — the rule must stay silent rather than guess.
+#[test]
+fn target_module_with_star_import_suppresses_the_rule() {
+    let root = make_tmp_dir("missing_name_star_target");
+    fs::write(root.join("base.py"), "hidden = 1\n").unwrap();
+    fs::write(root.join("reexporter.py"), "from base import *\n").unwrap();
+
+    let diagnostics = check_consumer(&root, "from reexporter import hidden\n");
+    assert!(
+        !codes(&diagnostics).contains(&"imports_missing_name"),
+        "a star-importing target has an unknowable member set; got: {:?}",
+        codes(&diagnostics)
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// Names bound by non-def statements — imports (re-exports), `for` targets,
+/// walrus, `with ... as`, try/except fallbacks — are all legitimate exports.
+#[test]
+fn names_bound_by_any_module_level_statement_count_as_defined() {
+    let root = make_tmp_dir("missing_name_binding_forms");
+    fs::write(root.join("helper.py"), "thing = 1\n").unwrap();
+    fs::write(
+        root.join("bindings.py"),
+        "from helper import thing\n\
+         import helper as helper_alias\n\
+         for loop_var in range(3):\n    pass\n\
+         if (walrus := 1):\n    pass\n\
+         try:\n    fallback = 1\nexcept ValueError:\n    fallback = 2\n",
+    )
+    .unwrap();
+
+    let diagnostics = check_consumer(
+        &root,
+        "from bindings import thing, helper_alias, loop_var, walrus, fallback\n",
+    );
+    assert!(
+        !codes(&diagnostics).contains(&"imports_missing_name"),
+        "every module-level binding form must count as defined; got: {:?}",
+        codes(&diagnostics)
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// The remaining binding statement forms — `while`/`with`/`match` bodies,
+/// `except ... as`, `type` aliases, augmented assignment, unpacking — all
+/// count as defined, and a genuinely missing name still surfaces beside them.
+#[test]
+fn structured_binding_forms_count_as_defined_without_masking_real_misses() {
+    let root = make_tmp_dir("missing_name_structured_forms");
+    fs::write(
+        root.join("forms.py"),
+        "type Alias = int\n\
+         total = 0\n\
+         total += 1\n\
+         first, *rest = [1, 2, 3]\n\
+         while False:\n    inside_while = 1\n\
+         with open(__file__) as handle:\n    pass\n\
+         try:\n    pass\nexcept ValueError as caught:\n    pass\n\
+         match [1]:\n    case [head, *tail]:\n        pass\n    case {**mapping_rest}:\n        pass\n    case str() as bound:\n        pass\n",
+    )
+    .unwrap();
+
+    let diagnostics = check_consumer(
+        &root,
+        "from forms import Alias, total, first, rest, inside_while, handle, \
+         caught, head, tail, mapping_rest, bound, definitely_missing\n",
+    );
+
+    let missing: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code.code == "imports_missing_name")
+        .collect();
+    assert_eq!(
+        missing.len(),
+        1,
+        "only `definitely_missing` may be flagged; got: {:?}",
+        missing.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+    assert!(missing[0].message.contains("definitely_missing"));
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// A target that does not parse has an unknowable surface — the rule must stay
+/// silent (the target's own check reports the syntax error).
+#[test]
+fn unparseable_target_module_suppresses_the_rule() {
+    let root = make_tmp_dir("missing_name_unparseable_target");
+    fs::write(root.join("broken.py"), "def broken(:\n").unwrap();
+
+    let diagnostics = check_consumer(&root, "from broken import anything\n");
+    assert!(
+        !codes(&diagnostics).contains(&"imports_missing_name"),
+        "an unparseable target must suppress the rule; got: {:?}",
+        codes(&diagnostics)
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}
+
+/// Submodules satisfy the import as `.pyi` stubs and as package directories,
+/// not only as `.py` files.
+#[test]
+fn pyi_and_directory_submodules_satisfy_a_package_import() {
+    let root = make_tmp_dir("missing_name_submodule_kinds");
+    fs::create_dir_all(root.join("pkg/subpkg")).unwrap();
+    fs::write(root.join("pkg/__init__.py"), "").unwrap();
+    fs::write(root.join("pkg/stubbed.pyi"), "x: int\n").unwrap();
+    fs::write(root.join("pkg/subpkg/__init__.py"), "").unwrap();
+
+    let diagnostics = check_consumer(&root, "from pkg import stubbed, subpkg\n");
+    assert!(
+        !codes(&diagnostics).contains(&"imports_missing_name"),
+        "`.pyi` and directory submodules must satisfy the import; got: {:?}",
+        codes(&diagnostics)
+    );
+
+    fs::remove_dir_all(&root).unwrap();
+}

--- a/crates/basilisk-stubs/src/generate/runtime.rs
+++ b/crates/basilisk-stubs/src/generate/runtime.rs
@@ -76,7 +76,11 @@ def encode_signature(entry, obj):
     for pname, param in sig.parameters.items():
         p = {"name": pname}
         if param.annotation is not inspect.Parameter.empty:
-            p["annotation"] = str(param.annotation)
+            # formatannotation renders a class object as a type expression
+            # (`datetime.datetime`), where str() would produce the repr
+            # (`<class 'datetime.datetime'>`) — not valid stub source
+            # (GitHub #336).
+            p["annotation"] = inspect.formatannotation(param.annotation)
         if param.default is not inspect.Parameter.empty:
             p["has_default"] = True
         if param.kind == inspect.Parameter.VAR_POSITIONAL:
@@ -91,7 +95,7 @@ def encode_signature(entry, obj):
     entry["params"] = params
     ret = sig.return_annotation
     if ret is not inspect.Parameter.empty:
-        entry["return"] = str(ret)
+        entry["return"] = inspect.formatannotation(ret)
 
 def encode_class_methods(entry, cls):
     methods = []
@@ -173,6 +177,16 @@ pub fn generate_runtime_stubs(
     }
 
     let pyi_content = entries_to_pyi(module_name, &entries);
+
+    // A stub Basilisk's own parser rejects must never be reported as a
+    // success — fail loudly instead of writing a contentless lie (GitHub #336).
+    if let Err(err) =
+        basilisk_parser::parse_source(pyi_content.clone(), format!("{module_name}.pyi"))
+    {
+        return Err(StubGenError::Subprocess(format!(
+            "generated stub for `{module_name}` does not parse: {err}"
+        )));
+    }
 
     Ok(GeneratedStub {
         module_name: module_name.to_owned(),
@@ -366,6 +380,13 @@ fn entries_to_pyi(module_name: &str, entries: &[serde_json::Value]) -> String {
     lines.push("# Tier 3: best-effort, may be inaccurate".to_owned());
     lines.push(String::new());
     lines.push("from typing import Any".to_owned());
+    // A dotted annotation (`datetime.datetime`) references a module the stub
+    // must import to be self-consistent (GitHub #336).
+    lines.extend(
+        collect_annotation_imports(entries)
+            .into_iter()
+            .map(|module| format!("import {module}")),
+    );
     lines.push(String::new());
 
     for entry in entries {
@@ -426,13 +447,10 @@ fn format_function_stub(name: &str, entry: &serde_json::Value) -> String {
             let formatted = match kind {
                 Some("vararg") => format!("*{pname}"),
                 Some("kwarg") => format!("**{pname}"),
-                _ => {
-                    if let Some(a) = ann {
-                        format!("{pname}: {a}")
-                    } else {
-                        pname.to_owned()
-                    }
-                }
+                _ => match ann.map(sanitized_annotation) {
+                    Some(annotation) => format!("{pname}: {annotation}"),
+                    None => pname.to_owned(),
+                },
             };
             params.push(formatted);
         }
@@ -441,9 +459,77 @@ fn format_function_stub(name: &str, entry: &serde_json::Value) -> String {
     let ret = entry
         .get("return")
         .and_then(|v| v.as_str())
-        .unwrap_or("Any");
+        .map_or_else(|| "Any".to_owned(), sanitized_annotation);
 
     format!("def {name}({}) -> {ret}: ...", params.join(", "))
+}
+
+/// An introspected annotation, degraded to `Any` unless it is usable stub
+/// source: a single-line string that parses as the annotation of one
+/// `_x: <annotation>` statement. Guards against non-expressions such as the
+/// `repr()` of a runtime class object — `<class 'str'>` (GitHub #336).
+fn sanitized_annotation(raw: &str) -> String {
+    let trimmed = raw.trim();
+    let single_line = !trimmed.is_empty() && !trimmed.contains(['\n', '\r', ';', '#']);
+    if single_line
+        && basilisk_parser::parse_source(format!("_x: {trimmed}"), "annotation.pyi".to_owned())
+            .is_ok()
+    {
+        trimmed.to_owned()
+    } else {
+        "Any".to_owned()
+    }
+}
+
+/// The modules referenced by dotted annotations across all entries, in stable
+/// (sorted) order. Best-effort: only a plain dotted-name chain counts, and the
+/// module is everything up to the final segment (`datetime.datetime` →
+/// `datetime`).
+fn collect_annotation_imports(entries: &[serde_json::Value]) -> std::collections::BTreeSet<String> {
+    let mut imports = std::collections::BTreeSet::new();
+    for entry in entries {
+        collect_entry_imports(entry, &mut imports);
+        if let Some(methods) = entry.get("methods").and_then(|v| v.as_array()) {
+            for method in methods {
+                collect_entry_imports(method, &mut imports);
+            }
+        }
+    }
+    imports
+}
+
+/// Collect the dotted-annotation modules of one function/method entry.
+fn collect_entry_imports(
+    entry: &serde_json::Value,
+    imports: &mut std::collections::BTreeSet<String>,
+) {
+    let param_annotations = entry
+        .get("params")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|param| param.get("annotation").and_then(|v| v.as_str()));
+    let return_annotation = entry.get("return").and_then(|v| v.as_str());
+    for annotation in param_annotations.chain(return_annotation) {
+        if let Some(module) = dotted_annotation_module(annotation) {
+            let _newly_inserted = imports.insert(module);
+        }
+    }
+}
+
+/// The module portion of a plain dotted-name annotation, if any:
+/// `datetime.datetime` → `datetime`, `a.b.C` → `a.b`. Generic or otherwise
+/// composite annotations return `None` — imports for those stay best-effort.
+fn dotted_annotation_module(annotation: &str) -> Option<String> {
+    let (module, class_name) = annotation.trim().rsplit_once('.')?;
+    let is_identifier = |segment: &str| {
+        let mut chars = segment.chars();
+        chars
+            .next()
+            .is_some_and(|first| first.is_ascii_alphabetic() || first == '_')
+            && chars.all(|rest| rest.is_ascii_alphanumeric() || rest == '_')
+    };
+    (module.split('.').all(&is_identifier) && is_identifier(class_name)).then(|| module.to_owned())
 }
 
 /// Timeout constant exposed for configuration.
@@ -693,6 +779,130 @@ exit 7",
         assert!(
             pyi.contains("config: Any"),
             "a variable with no annotation defaults to Any: {pyi}"
+        );
+    }
+
+    /// GitHub #336 follow-up: `repr()` of a runtime class object
+    /// (`<class 'str'>`) is not a type expression. Whatever the interpreter
+    /// hands back, every annotation must be emitted as parseable source — an
+    /// annotation that isn't a valid expression degrades to `Any`, and the
+    /// assembled stub must always pass Basilisk's own parser.
+    #[test]
+    fn entries_to_pyi_sanitizes_repr_style_annotations_to_a_parseable_stub() {
+        let entries: Vec<serde_json::Value> = serde_json::from_str(
+            r#"[
+                {"name": "get_host", "kind": "function",
+                 "params": [{"name": "when", "annotation": "<class 'datetime.datetime'>"}],
+                 "return": "<class 'str'>"}
+            ]"#,
+        )
+        .unwrap();
+
+        let pyi = entries_to_pyi("m", &entries);
+        assert!(
+            basilisk_parser::parse_source(pyi.clone(), "m.pyi".to_owned()).is_ok(),
+            "the generated stub must parse:\n{pyi}"
+        );
+        assert!(
+            !pyi.contains("<class"),
+            "repr-style annotations must never reach the stub:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("def get_host(when: Any) -> Any: ..."),
+            "unparseable annotations degrade to Any:\n{pyi}"
+        );
+    }
+
+    /// GitHub #336 follow-up: a dotted annotation like `datetime.datetime`
+    /// references a module the stub never imports — the generator must emit
+    /// the matching `import` so the stub is self-consistent.
+    #[test]
+    fn entries_to_pyi_imports_modules_referenced_by_dotted_annotations() {
+        let entries: Vec<serde_json::Value> = serde_json::from_str(
+            r#"[
+                {"name": "stamp", "kind": "function",
+                 "params": [{"name": "when", "annotation": "datetime.datetime"}],
+                 "return": "zoneinfo.ZoneInfo"}
+            ]"#,
+        )
+        .unwrap();
+
+        let pyi = entries_to_pyi("m", &entries);
+        assert!(
+            pyi.contains("import datetime"),
+            "dotted parameter annotations need their module imported:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("import zoneinfo"),
+            "dotted return annotations need their module imported:\n{pyi}"
+        );
+        assert!(
+            pyi.contains("def stamp(when: datetime.datetime) -> zoneinfo.ZoneInfo: ..."),
+            "valid dotted annotations must be preserved verbatim:\n{pyi}"
+        );
+    }
+
+    /// GitHub #336 follow-up: the real introspection script must format
+    /// runtime class-object annotations as type expressions
+    /// (`datetime.datetime`), never `str(cls)` = `<class '...'>`. Exercises
+    /// the REAL script against a real interpreter (like the dotted-submodule
+    /// test above, this depends on `python3` being on PATH).
+    #[cfg(unix)]
+    #[test]
+    fn runtime_introspection_formats_class_annotations_as_type_expressions() {
+        use std::fmt::Write as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("ann_fixture_336.py"),
+            "import datetime\n\n\
+             def stamp(when: datetime.datetime) -> str:\n    return \"\"\n",
+        )
+        .unwrap();
+        // Wrapper so the fixture dir is importable without mutating this
+        // process's environment (parallel tests share it).
+        let mut wrapper = String::from("#!/bin/sh\n");
+        let _ = writeln!(
+            wrapper,
+            "PYTHONPATH={} exec python3 \"$@\"",
+            dir.path().display()
+        );
+        let python = dir.path().join("python");
+        std::fs::write(&python, wrapper).unwrap();
+        let mut permissions = std::fs::metadata(&python).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, 0o700);
+        std::fs::set_permissions(&python, permissions).unwrap();
+
+        let stub = generate_runtime_stubs("ann_fixture_336", &python)
+            .expect("python3 must introspect the fixture module");
+        assert!(
+            !stub.pyi_content.contains("<class"),
+            "class-object annotations must not be repr()'d:\n{}",
+            stub.pyi_content
+        );
+        assert!(
+            stub.pyi_content
+                .contains("def stamp(when: datetime.datetime) -> str: ..."),
+            "class-object annotations must render as type expressions:\n{}",
+            stub.pyi_content
+        );
+    }
+
+    /// GitHub #336 follow-up: reporting `✓ Generated` for a stub Basilisk's
+    /// own parser rejects is a lie. If the assembled content does not parse,
+    /// generation must fail loudly instead of succeeding.
+    #[cfg(unix)]
+    #[test]
+    fn generate_runtime_stubs_fails_when_the_assembled_stub_does_not_parse() {
+        // A symbol name that cannot form a valid `def` line — sanitizing
+        // annotations alone cannot save this stub.
+        let (_dir, python) =
+            fake_python(r#"printf '%s' '[{"name": "not a name", "kind": "function"}]'"#);
+
+        let error = generate_runtime_stubs("mod", &python).unwrap_err();
+        assert!(
+            matches!(error, StubGenError::Subprocess(ref msg) if msg.contains("parse")),
+            "an unparseable assembled stub must be an error, not a success: {error:?}"
         );
     }
 

--- a/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
+++ b/docs/specs/CHECKER-ARCHITECTURE-SPEC.md
@@ -488,6 +488,38 @@ code) — false-positive surface is zero by construction. Third-party typeshed /
 are deferred. Implemented in `crates/basilisk-checker/src/rules/e0154/`; tests in
 `crates/basilisk-checker/src/rules/e0154/tests.rs`.
 
+#### Missing imported name {#CHKARCH-DIAG-IMPORT-MEMBER}
+
+`imports_missing_name` closes the symbol-level half of import checking (GitHub #55):
+`from M import name` where the module path `M` resolves to a **workspace `.py`
+source** but `name` is neither a module-level binding in `M` nor an existing
+submodule of the package is an error — at runtime it raises `ImportError`.
+This complements [CHKARCH-DIAG-TYPESAFETY] (`imports_unresolved`, module-path
+level) and [CHKARCH-DIAG-STUB-MEMBER] (`imports_module_attribute`, stub-backed
+attribute access).
+
+The rule re-reads and parses the target module at check time (read through
+`basilisk_common::fs::read_tracked` so the CLI result cache records the content
+edge; the parse is memoized per `(path, content-hash)` process-wide) and
+collects **every** module-level binding form: `def`/`class`, all assignment
+forms, `import`/`from` bindings (re-exports), `for`/`with`/`match`/`except`
+targets, walrus expressions, and `type` alias statements — recursing through
+control flow but not into function/class bodies.
+
+Conservative by construction — silence over guessing:
+
+- a module-level `__getattr__` (PEP 562) permits any name;
+- a target containing `from x import *` has an unknowable member set and is skipped;
+- an unreadable or unparseable target is skipped (its own check reports the syntax error);
+- `from pkg import mod` is satisfied by an existing `pkg/mod.py`, `pkg/mod.pyi`, or `pkg/mod/`;
+- imports resolving into `site-packages` are out of scope (PEP 561 trust
+  boundary — untyped third-party sources belong to `missing_type_stubs`);
+- in cross-module mode a name found in live-buffer `imported_symbols` is
+  trusted over the on-disk view.
+
+Implemented in `crates/basilisk-checker/src/rules/imports_missing_name.rs`;
+tests in `crates/basilisk-checker/tests/imports_missing_name_tests.rs`.
+
 #### TypedDict `extra_items` / `closed` (PEP 728) {#CHKARCH-DIAG-TYPEDDICT-EXTRA-ITEMS}
 
 `typeddicts_extra_items` implements [PEP 728](https://peps.python.org/pep-0728/) — the

--- a/website/src/_data/rules.json
+++ b/website/src/_data/rules.json
@@ -4567,6 +4567,55 @@
     ]
   },
   {
+    "code": "imports_missing_name",
+    "scope": "check",
+    "provenance": "pep",
+    "tags": [
+      "pep"
+    ],
+    "summary": "Importing a name the resolved module does not define",
+    "summaryHtml": "Importing a name the resolved module does not define",
+    "body": [
+      {
+        "type": "text",
+        "html": "<code>from M import name</code> only proves that the module path <code>M</code> resolves to a file; it says nothing about <code>name</code>. When <code>M</code> is a workspace <code>.py</code> source Basilisk can see every module-level binding, so importing a name that is neither bound in <code>M</code>, nor an existing submodule of the package, is an <code>ImportError</code> waiting for runtime (GitHub #55)."
+      },
+      {
+        "type": "code",
+        "lang": "python",
+        "code": "from demo.late_module import provide_value  # late_module.py defines nothing"
+      },
+      {
+        "type": "text",
+        "html": "The rule is deliberately conservative \u2014 silence over guessing:"
+      },
+      {
+        "type": "text",
+        "html": "- Every module-level binding form counts as defined: <code>def</code>/<code>class</code>,   every assignment form, <code>import</code>/<code>from</code> re-exports, <code>for</code>/<code>with</code>/<code>match</code>/   <code>except</code> targets, walrus expressions, and <code>type</code> alias statements. - A module-level <code>__getattr__</code> (<a href=\"https://peps.python.org/pep-0562/\">PEP 562</a>) permits any name. - A target containing <code>from x import *</code> has an unknowable member set and   suppresses the rule for that module. - <code>from pkg import mod</code> is satisfied by an existing <code>pkg/mod.py</code>,   <code>pkg/mod.pyi</code>, or <code>pkg/mod/</code> submodule."
+      },
+      {
+        "type": "text",
+        "html": "Scope: <code>from</code>-imports resolved to workspace <code>.py</code> sources. Stub-backed imports are covered by <code>imports_module_attribute</code>; site-packages sources stay with <code>missing_type_stubs</code> (<a href=\"https://peps.python.org/pep-0561/\">PEP 561</a> draws the trust boundary there)."
+      }
+    ],
+    "group": "Type System",
+    "docsUrl": "https://www.basilisk-python.dev/errors/imports_missing_name",
+    "references": [
+      {
+        "label": "Typing spec: Distributing type information",
+        "url": "https://typing.python.org/en/latest/spec/distributing.html"
+      },
+      {
+        "label": "PEP 561",
+        "url": "https://peps.python.org/pep-0561/"
+      },
+      {
+        "label": "PEP 562",
+        "url": "https://peps.python.org/pep-0562/"
+      }
+    ]
+  },
+  {
     "code": "imports_module_attribute",
     "scope": "check",
     "provenance": "pep",


### PR DESCRIPTION
## TLDR
Add the `imports_missing_name` rule so `from M import X` is flagged when the resolved workspace module `M` defines no `X` (Refs #55), and make generated/loaded stubs honest: introspected stubs are always emitted as parseable source and empty/unparseable stubs no longer silence the untyped-package rule BSK-0152 (Refs #336).

## What Was Added?
- **New diagnostic `imports_missing_name`** (`crates/basilisk-checker/src/rules/imports_missing_name.rs`, spec `[CHKARCH-DIAG-IMPORT-MEMBER]`). For a `from`-import that resolves to a workspace `.py` source, it reads the target module and collects every module-level binding — `def`/`class`, every assignment form, `import`/`from` re-exports, `for`/`with`/`try`/`match`/`except` targets, walrus, and `type` aliases — then flags any imported name that is neither bound nor an existing submodule. It is deliberately conservative: a module-level `__getattr__` (PEP 562) or a `from x import *` in the target suppresses it, `from pkg import mod` is satisfied by `pkg/mod.py`/`.pyi`/`mod/`, and an unreadable/unparseable target stays silent. Scope is workspace sources only — stub-backed imports remain `imports_module_attribute`'s domain and site-packages remain `missing_type_stubs`', matching the PEP 561 trust boundary.
- **Stub-generation helpers** in `crates/basilisk-stubs/src/generate/runtime.rs`: `sanitized_annotation` degrades any annotation that is not a valid single expression (e.g. the `repr()` of a runtime class object, `<class 'str'>`) to `Any`; `collect_annotation_imports`/`dotted_annotation_module` emit the `import` for each module a dotted annotation references (`datetime.datetime` → `import datetime`) so the stub is self-consistent.
- The generated `/errors/imports_missing_name/` page and the `website/src/_data/rules.json` entry (both produced from the rule source), plus the `[CHKARCH-DIAG-IMPORT-MEMBER]` spec section.

## What Was Changed or Deleted?
- **Import resolution** (`crates/basilisk-checker/src/imports/resolve.rs`): a step-1 user stub only wins resolution when it actually carries type info — `stub_provides_type_info` requires the `.pyi` to parse and, for a module stub, to declare or re-export at least one name (an empty `__init__.pyi` stays valid as a partial-stub package marker). A contentless or unparseable stub is now treated as absent, so resolution falls through and BSK-0152 still reports the package as untyped instead of the stub silencing the very rule it was meant to satisfy (Refs #336).
- **Stub generation** (`runtime.rs`): the real introspection script now formats class-object annotations as type expressions rather than `str(cls)`, and `generate_runtime_stubs` fails loudly when the assembled stub does not pass Basilisk's own parser instead of reporting `✓ Generated` for a stub the checker would reject.

## How Do The Automated Tests Prove It Works?
- `imports_missing_name_tests.rs` (10 tests): `from_import_of_name_missing_from_resolved_module_is_flagged` proves the core case; `aliased_from_import_checks_the_imported_name_not_the_alias` and `from_import_flags_only_the_undefined_name_in_a_nonempty_module` pin the alias/positional behaviour; `pyi_and_directory_submodules_satisfy_a_package_import`, `target_module_with_star_import_suppresses_the_rule`, `module_level_getattr_suppresses_the_rule`, `unparseable_target_module_suppresses_the_rule`, and `names_bound_by_any_module_level_statement_count_as_defined` cover the suppression paths and every binding form.
- `resolve_tests.rs` (3 tests): `stub_path_stub_declaring_nothing_is_treated_as_absent` and `stub_path_stub_that_fails_to_parse_is_treated_as_absent` prove BSK-0152 still fires past a hollow stub, while `stub_path_stub_with_declarations_still_wins_step_one` guards that valid manual stubs are undisturbed.
- `runtime.rs` (4 tests): `entries_to_pyi_sanitizes_repr_style_annotations_to_a_parseable_stub`, `entries_to_pyi_imports_modules_referenced_by_dotted_annotations`, `runtime_introspection_formats_class_annotations_as_type_expressions` (exercises the real script against a real interpreter), and `generate_runtime_stubs_fails_when_the_assembled_stub_does_not_parse`.
- Full local CI is green: workspace tests + per-crate coverage thresholds, **conformance 100% / 0 false positives** on a fresh `python/typing` clone (the new rule adds no false positive), mutation gate at the committed baseline (137 caught / 0 missed / 100%), and the website/Zed/Neovim/VS Code (590 + corpus passing) and shipwright gates.

## Spec / Doc Changes
- `docs/specs/CHECKER-ARCHITECTURE-SPEC.md`: adds the `[CHKARCH-DIAG-IMPORT-MEMBER]` section describing the new rule and its scope.
- `website/src/_data/rules.json`: regenerated from the checker source to include `imports_missing_name` (drives the `/docs/rules/` table and the generated `/errors/` page).

## Breaking Changes
- [x] None — `imports_missing_name` is a PEP-scope diagnostic that fires only on genuinely undefined imported names (previously a silent false negative); the stub changes only make already-invalid/empty stubs behave honestly.
